### PR TITLE
feat: introduce process lock so that solo doesn't allow parallel execution of commands

### DIFF
--- a/src/commands/account.mjs
+++ b/src/commands/account.mjs
@@ -147,7 +147,7 @@ export class AccountCommand extends BaseCommand {
         }
       },
       {
-        title: 'create the new account',
+        title: 'Create the new account',
         task: async (ctx, task) => {
           self.accountInfo = await self.createNewAccount(ctx)
           const accountInfoCopy = { ...self.accountInfo }
@@ -203,7 +203,7 @@ export class AccountCommand extends BaseCommand {
         }
       },
       {
-        title: 'get the account info',
+        title: 'Get the account info',
         task: async (ctx, task) => {
           ctx.treasuryAccountInfo = await self.accountManager.getTreasuryAccountKeys(ctx.config.namespace)
           await self.loadNodeClient(ctx)
@@ -211,7 +211,7 @@ export class AccountCommand extends BaseCommand {
         }
       },
       {
-        title: 'update the account',
+        title: 'Update the account',
         task: async (ctx, task) => {
           if (!(await self.updateAccountInfo(ctx))) {
             throw new FullstackTestingError(`An error occurred updating account ${ctx.accountInfo.accountId}`)
@@ -219,7 +219,7 @@ export class AccountCommand extends BaseCommand {
         }
       },
       {
-        title: 'get the updated account info',
+        title: 'Get the updated account info',
         task: async (ctx, task) => {
           self.accountInfo = await self.buildAccountInfo(await self.getAccountInfo(ctx), ctx.config.namespace, false)
           this.logger.showJSON('account info', self.accountInfo)
@@ -270,7 +270,7 @@ export class AccountCommand extends BaseCommand {
         }
       },
       {
-        title: 'get the account info',
+        title: 'Get the account info',
         task: async (ctx, task) => {
           ctx.treasuryAccountInfo = await self.accountManager.getTreasuryAccountKeys(ctx.config.namespace)
           await self.loadNodeClient(ctx)
@@ -312,18 +312,8 @@ export class AccountCommand extends BaseCommand {
               flags.privateKey,
               flags.amount
             ),
-            handler: argv => {
-              accountCmd.logger.debug("==== Running 'account create' ===")
-              accountCmd.logger.debug(argv)
-
-              accountCmd.create(argv).then(r => {
-                accountCmd.logger.debug("==== Finished running 'account create' ===")
-                if (!r) process.exit(1)
-              }).catch(err => {
-                accountCmd.logger.showUserError(err)
-                process.exit(1)
-              })
-            }
+            handler: argv => accountCmd.handleCommand(
+              argv, async (args) => await accountCmd.create(args))
           })
           .command({
             command: 'update',
@@ -334,18 +324,8 @@ export class AccountCommand extends BaseCommand {
               flags.privateKey,
               flags.amount
             ),
-            handler: argv => {
-              accountCmd.logger.debug("==== Running 'account update' ===")
-              accountCmd.logger.debug(argv)
-
-              accountCmd.update(argv).then(r => {
-                accountCmd.logger.debug("==== Finished running 'account update' ===")
-                if (!r) process.exit(1)
-              }).catch(err => {
-                accountCmd.logger.showUserError(err)
-                process.exit(1)
-              })
-            }
+            handler: argv => accountCmd.handleCommand(
+              argv, async (args) => await accountCmd.update(args))
           })
           .command({
             command: 'get',
@@ -354,18 +334,8 @@ export class AccountCommand extends BaseCommand {
               flags.namespace,
               flags.accountId
             ),
-            handler: argv => {
-              accountCmd.logger.debug("==== Running 'account get' ===")
-              accountCmd.logger.debug(argv)
-
-              accountCmd.get(argv).then(r => {
-                accountCmd.logger.debug("==== Finished running 'account get' ===")
-                if (!r) process.exit(1)
-              }).catch(err => {
-                accountCmd.logger.showUserError(err)
-                process.exit(1)
-              })
-            }
+            handler: argv => accountCmd.handleCommand(
+              argv, async (args) => await accountCmd.get(args))
           })
           .demandCommand(1, 'Select an account command')
       }

--- a/src/commands/cluster.mjs
+++ b/src/commands/cluster.mjs
@@ -223,33 +223,14 @@ export class ClusterCommand extends BaseCommand {
           .command({
             command: 'list',
             desc: 'List all available clusters',
-            handler: argv => {
-              clusterCmd.logger.debug("==== Running 'cluster list' ===", { argv })
-
-              clusterCmd.showClusterList().then(r => {
-                clusterCmd.logger.debug('==== Finished running `cluster list`====')
-
-                if (!r) process.exit(1)
-              }).catch(err => {
-                clusterCmd.logger.showUserError(err)
-                process.exit(1)
-              })
-            }
+            handler: argv => clusterCmd.handleCommand(
+              argv, async (args) => await clusterCmd.showClusterList(args))
           })
           .command({
             command: 'info',
             desc: 'Get cluster info',
-            handler: argv => {
-              clusterCmd.logger.debug("==== Running 'cluster info' ===", { argv })
-              clusterCmd.getClusterInfo(argv).then(r => {
-                clusterCmd.logger.debug('==== Finished running `cluster info`====')
-
-                if (!r) process.exit(1)
-              }).catch(err => {
-                clusterCmd.logger.showUserError(err)
-                process.exit(1)
-              })
-            }
+            handler: argv => clusterCmd.handleCommand(
+              argv, async (args) => await clusterCmd.getClusterInfo(args))
           })
           .command({
             command: 'setup',
@@ -264,18 +245,8 @@ export class ClusterCommand extends BaseCommand {
               flags.deployCertManagerCrds,
               flags.fstChartVersion
             ),
-            handler: argv => {
-              clusterCmd.logger.debug("==== Running 'cluster setup' ===", { argv })
-
-              clusterCmd.setup(argv).then(r => {
-                clusterCmd.logger.debug('==== Finished running `cluster setup`====')
-
-                if (!r) process.exit(1)
-              }).catch(err => {
-                clusterCmd.logger.showUserError(err)
-                process.exit(1)
-              })
-            }
+            handler: argv => clusterCmd.handleCommand(
+              argv, async (args) => await clusterCmd.setup(args))
           })
           .command({
             command: 'reset',
@@ -284,18 +255,8 @@ export class ClusterCommand extends BaseCommand {
               flags.clusterName,
               flags.clusterSetupNamespace
             ),
-            handler: argv => {
-              clusterCmd.logger.debug("==== Running 'cluster reset' ===", { argv })
-
-              clusterCmd.reset(argv).then(r => {
-                clusterCmd.logger.debug('==== Finished running `cluster reset`====')
-
-                if (!r) process.exit(1)
-              }).catch(err => {
-                clusterCmd.logger.showUserError(err)
-                process.exit(1)
-              })
-            }
+            handler: argv => clusterCmd.handleCommand(
+              argv, async (args) => await clusterCmd.reset(args))
           })
           .demandCommand(1, 'Select a cluster command')
       }

--- a/src/commands/index.mjs
+++ b/src/commands/index.mjs
@@ -45,4 +45,13 @@ function Initialize (opts) {
 }
 
 // Expose components from the command module
-export { Initialize, flags }
+export {
+  Initialize,
+  InitCommand,
+  ClusterCommand,
+  NetworkCommand,
+  NodeCommand,
+  RelayCommand,
+  AccountCommand,
+  flags
+}

--- a/src/commands/init.mjs
+++ b/src/commands/init.mjs
@@ -163,14 +163,8 @@ export class InitCommand extends BaseCommand {
           flags.fstChartVersion
         )
       },
-      handler: (argv) => {
-        initCmd.init(argv).then(r => {
-          if (!r) process.exit(1)
-        }).catch(err => {
-          initCmd.logger.showUserError(err)
-          process.exit(1)
-        })
-      }
+      handler: argv => initCmd.handleCommand(
+        argv, async (args) => await initCmd.init(args))
     }
   }
 }

--- a/src/commands/network.mjs
+++ b/src/commands/network.mjs
@@ -367,19 +367,8 @@ export class NetworkCommand extends BaseCommand {
               flags.enablePrometheusSvcMonitor,
               flags.fstChartVersion
             ),
-            handler: argv => {
-              networkCmd.logger.debug("==== Running 'network deploy' ===")
-              networkCmd.logger.debug(argv)
-
-              networkCmd.deploy(argv).then(r => {
-                networkCmd.logger.debug('==== Finished running `network deploy`====')
-
-                if (!r) process.exit(1)
-              }).catch(err => {
-                networkCmd.logger.showUserError(err)
-                process.exit(1)
-              })
-            }
+            handler: argv => networkCmd.handleCommand(
+              argv, async (args) => await networkCmd.deploy(args))
           })
           .command({
             command: 'destroy',
@@ -389,19 +378,8 @@ export class NetworkCommand extends BaseCommand {
               flags.force,
               flags.deletePvcs
             ),
-            handler: argv => {
-              networkCmd.logger.debug("==== Running 'network destroy' ===")
-              networkCmd.logger.debug(argv)
-
-              networkCmd.destroy(argv).then(r => {
-                networkCmd.logger.debug('==== Finished running `network destroy`====')
-
-                if (!r) process.exit(1)
-              }).catch(err => {
-                networkCmd.logger.showUserError(err)
-                process.exit(1)
-              })
-            }
+            handler: argv => networkCmd.handleCommand(
+              argv, async (args) => await networkCmd.destroy(args))
           })
           .command({
             command: 'refresh',
@@ -418,19 +396,8 @@ export class NetworkCommand extends BaseCommand {
               flags.hederaExplorerTlsHostName,
               flags.enablePrometheusSvcMonitor
             ),
-            handler: argv => {
-              networkCmd.logger.debug("==== Running 'chart upgrade' ===")
-              networkCmd.logger.debug(argv)
-
-              networkCmd.refresh(argv).then(r => {
-                networkCmd.logger.debug('==== Finished running `chart upgrade`====')
-
-                if (!r) process.exit(1)
-              }).catch(err => {
-                networkCmd.logger.showUserError(err)
-                process.exit(1)
-              })
-            }
+            handler: argv => networkCmd.handleCommand(
+              argv, async (args) => await networkCmd.refresh(args))
           })
           .demandCommand(1, 'Select a chart command')
       }

--- a/src/commands/relay.mjs
+++ b/src/commands/relay.mjs
@@ -16,6 +16,7 @@
  */
 import { Listr } from 'listr2'
 import { FullstackTestingError, MissingArgumentError } from '../core/errors.mjs'
+import * as helpers from '../core/helpers.mjs'
 import { BaseCommand } from './base.mjs'
 import * as flags from './flags.mjs'
 import * as paths from 'path'
@@ -67,7 +68,7 @@ export class RelayCommand extends BaseCommand {
     return valuesArg
   }
 
-  prepareReleaseName (nodeIDs = []) {
+  prepareReleaseName (nodeIDs) {
     if (!nodeIDs) {
       throw new MissingArgumentError('Node IDs must be specified')
     }
@@ -87,34 +88,29 @@ export class RelayCommand extends BaseCommand {
         title: 'Initialize',
         task: async (ctx, task) => {
           self.configManager.update(argv)
+          await prompts.execute(task, self.configManager, [
+            flags.namespace,
+            flags.chartDirectory,
+            flags.valuesFile,
+            flags.nodeIDs,
+            flags.chainId,
+            flags.relayReleaseTag,
+            flags.replicaCount,
+            flags.operatorId,
+            flags.operatorKey
+          ])
 
-          // extract config values
-          const valuesFile = self.configManager.getFlag(flags.valuesFile)
-          const nodeIds = self.configManager.getFlag(flags.nodeIDs)
-          const chainId = self.configManager.getFlag(flags.chainId)
-          const relayRelease = self.configManager.getFlag(flags.relayReleaseTag)
-          const replicaCount = self.configManager.getFlag(flags.replicaCount)
-          const operatorId = self.configManager.getFlag(flags.operatorId)
-          const operatorKey = self.configManager.getFlag(flags.operatorKey)
-
-          const namespace = self.configManager.getFlag(flags.namespace)
-          const chartDir = self.configManager.getFlag(flags.chartDirectory)
-
-          // prompt if inputs are empty and set it in the context
-          const namespaces = await self.k8.getNamespaces()
           ctx.config = {
-            chartDir: await prompts.promptChartDir(task, chartDir),
-            namespace: await prompts.promptSelectNamespaceArg(task, namespace, namespaces),
-            valuesFile: await prompts.promptValuesFile(task, valuesFile),
-            nodeIds: await prompts.promptNodeIds(task, nodeIds),
-            chainId: await prompts.promptChainId(task, chainId),
-            relayRelease: await prompts.promptRelayReleaseTag(task, relayRelease),
-            replicaCount: await prompts.promptReplicaCount(task, replicaCount),
-            operatorId: await prompts.promptOperatorId(task, operatorId),
-            operatorKey: await prompts.promptOperatorId(task, operatorKey)
+            chartDir: self.configManager.getFlag(flags.chartDirectory),
+            namespace: self.configManager.getFlag(flags.namespace),
+            valuesFile: self.configManager.getFlag(flags.valuesFile),
+            nodeIds: helpers.parseNodeIDs(self.configManager.getFlag(flags.nodeIDs)),
+            chainId: self.configManager.getFlag(flags.chainId),
+            relayRelease: self.configManager.getFlag(flags.relayReleaseTag),
+            replicaCount: self.configManager.getFlag(flags.replicaCount),
+            operatorId: self.configManager.getFlag(flags.operatorId),
+            operatorKey: self.configManager.getFlag(flags.operatorKey)
           }
-
-          self.logger.debug('Finished prompts', { ctx })
 
           ctx.releaseName = this.prepareReleaseName(ctx.config.nodeIds)
           ctx.isChartInstalled = await this.chartManager.isChartInstalled(ctx.config.namespace, ctx.releaseName)
@@ -125,7 +121,7 @@ export class RelayCommand extends BaseCommand {
       {
         title: 'Prepare chart values',
         task: async (ctx, _) => {
-          ctx.chartPath = await this.prepareChartPath(ctx.config.chartDir, constants.JSON_RPC_RELAY_CHART, constants.CHART_JSON_RPC_RELAY_NAME)
+          ctx.chartPath = await this.prepareChartPath(ctx.config.chartDir, constants.JSON_RPC_RELAY_CHART, constants.JSON_RPC_RELAY_CHART)
           ctx.valuesArg = this.prepareValuesArg(
             ctx.config.valuesFile,
             ctx.config.nodeIds,
@@ -178,19 +174,19 @@ export class RelayCommand extends BaseCommand {
         task: async (ctx, task) => {
           self.configManager.update(argv)
 
-          // extract config values
-          const nodeIds = self.configManager.getFlag(flags.nodeIDs)
-          const namespace = self.configManager.getFlag(flags.namespace)
+          await prompts.execute(task, self.configManager, [
+            flags.namespace,
+            flags.nodeIDs
+          ])
 
-          // prompt if inputs are empty and set it in the context
-          const namespaces = await self.k8.getNamespaces()
           ctx.config = {
-            namespace: await prompts.promptSelectNamespaceArg(task, namespace, namespaces),
-            nodeIds: await prompts.promptNodeIds(task, nodeIds)
+            namespace: self.configManager.getFlag(flags.namespace),
+            nodeIds: helpers.parseNodeIDs(self.configManager.getFlag(flags.nodeIDs))
           }
 
-          ctx.config.releaseName = this.prepareReleaseName(ctx.config.nodeIds)
           self.logger.debug('Finished ctx initialization', { ctx })
+
+          ctx.config.releaseName = this.prepareReleaseName(ctx.config.nodeIds)
         }
       },
       {
@@ -240,18 +236,8 @@ export class RelayCommand extends BaseCommand {
                 flags.operatorKey
               )
             },
-            handler: argv => {
-              relayCmd.logger.debug("==== Running 'relay install' ===", { argv })
-
-              relayCmd.install(argv).then(r => {
-                relayCmd.logger.debug('==== Finished running `relay install`====')
-
-                if (!r) process.exit(1)
-              }).catch(err => {
-                relayCmd.logger.showUserError(err)
-                process.exit(1)
-              })
-            }
+            handler: argv => relayCmd.handleCommand(
+              argv, async (args) => await relayCmd.install(args))
           })
           .command({
             command: 'uninstall',
@@ -260,16 +246,8 @@ export class RelayCommand extends BaseCommand {
               flags.namespace,
               flags.nodeIDs
             ),
-            handler: argv => {
-              relayCmd.logger.debug("==== Running 'relay uninstall' ===", { argv })
-              relayCmd.logger.debug(argv)
-
-              relayCmd.uninstall(argv).then(r => {
-                relayCmd.logger.debug('==== Finished running `relay uninstall`====')
-
-                if (!r) process.exit(1)
-              })
-            }
+            handler: argv => relayCmd.handleCommand(
+              argv, async (args) => await relayCmd.uninstall(args))
           })
           .demandCommand(1, 'Select a relay command')
       }

--- a/src/core/constants.mjs
+++ b/src/core/constants.mjs
@@ -16,22 +16,26 @@
  */
 import { AccountId } from '@hashgraph/sdk'
 import { color, PRESET_TIMER } from 'listr2'
-import { dirname, normalize } from 'path'
+import os from 'os'
+import * as path from 'path'
 import { fileURLToPath } from 'url'
 import chalk from 'chalk'
 
 // -------------------- solo related constants ---------------------------------------------------------------------
-export const CUR_FILE_DIR = dirname(fileURLToPath(import.meta.url))
-export const USER = `${process.env.USER}`
-export const USER_SANITIZED = USER.replace(/[\W_]+/g, '-')
-export const SOLO_HOME_DIR = process.env.SOLO_HOME || `${process.env.HOME}/.solo`
-export const SOLO_LOGS_DIR = `${SOLO_HOME_DIR}/logs`
-export const SOLO_CACHE_DIR = `${SOLO_HOME_DIR}/cache`
+export const SOLO_HOME_DIR = process.env.SOLO_HOME_DIR || path.resolve(path.join(process.env.HOME, '.solo'))
+export const CUR_FILE_DIR = path.dirname(fileURLToPath(import.meta.url))
+export const SOLO_INSTALLATION_DIR = path.resolve(path.join(CUR_FILE_DIR, '/../..'))
+// resources directory of solo where various templates exists
+export const RESOURCES_DIR = path.resolve(path.join(SOLO_INSTALLATION_DIR, 'resources'))
+export const SOLO_TMP_DIR = process.env.SOLO_TMP_DIR || os.tmpdir()
+
+export const SOLO_LOGS_DIR = path.join(SOLO_HOME_DIR, 'logs')
+export const SOLO_PID_FILE = path.join(SOLO_HOME_DIR, 'solo.pid')
+export const SOLO_CACHE_DIR = path.join(SOLO_HOME_DIR, 'cache')
+export const SOLO_CONFIG_FILE = path.join(SOLO_HOME_DIR, 'solo.config')
+
 export const DEFAULT_NAMESPACE = 'default'
 export const HELM = 'helm'
-export const CWD = process.cwd()
-export const SOLO_CONFIG_FILE = `${SOLO_HOME_DIR}/solo.config`
-export const RESOURCES_DIR = normalize(CUR_FILE_DIR + '/../../resources')
 
 export const ROOT_CONTAINER = 'root-container'
 

--- a/src/core/helpers.mjs
+++ b/src/core/helpers.mjs
@@ -15,9 +15,11 @@
  *
  */
 import fs from 'fs'
+import path from 'path'
 import { FullstackTestingError } from './errors.mjs'
 import * as paths from 'path'
 import { fileURLToPath } from 'url'
+import { constants } from './index.mjs'
 
 // cache current directory
 const CUR_FILE_DIR = paths.dirname(fileURLToPath(import.meta.url))
@@ -131,4 +133,18 @@ export function getRootImageRepository (releaseTag) {
   }
 
   return 'hashgraph/full-stack-testing/ubi8-init-java21'
+}
+
+export function getTmpDir () {
+  return fs.mkdtempSync(path.join(constants.SOLO_TMP_DIR, 'solo-'))
+}
+
+/**
+ * This is a default command error handler used by handleCommand
+ * @param err error
+ * @param logger logger
+ */
+export function defaultErrorHandler (err, logger) {
+  // TODO add user friendly message for the error
+  logger.showUserError(err)
 }

--- a/src/core/logging.mjs
+++ b/src/core/logging.mjs
@@ -124,7 +124,8 @@ export const Logger = class {
       }
     }
 
-    console.log(chalk.red('*********************************** ERROR *****************************************'))
+    console.log(chalk.red('*********************************** ERROR ****************************************'))
+    console.log(chalk.yellow(`Error Reference: ${this.traceId}`))
     if (this.devMode) {
       let prefix = ''
       let indent = ''

--- a/test/test_util.js
+++ b/test/test_util.js
@@ -15,9 +15,8 @@
  *
  */
 import fs from 'fs'
-import os from 'os'
 import path from 'path'
-import { logging } from '../src/core/index.mjs'
+import { logging, constants } from '../src/core/index.mjs'
 
 export const testLogger = logging.NewLogger('debug')
 
@@ -32,5 +31,5 @@ export function getTestCacheDir (appendDir) {
 }
 
 export function getTmpDir () {
-  return fs.mkdtempSync(path.join(os.tmpdir(), 'solo-'))
+  return fs.mkdtempSync(path.join(constants.SOLO_TMP_DIR, 'solo-test-'))
 }

--- a/test/unit/commands/init.test.mjs
+++ b/test/unit/commands/init.test.mjs
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-import { InitCommand } from '../../../src/commands/init.mjs'
+import { InitCommand } from '../../../src/commands/index.mjs'
 import { expect, describe, it } from '@jest/globals'
 import {
   ChartManager,

--- a/test/unit/core/helpers.test.mjs
+++ b/test/unit/core/helpers.test.mjs
@@ -14,9 +14,11 @@
  * limitations under the License.
  *
  */
-import { describe, expect, it } from '@jest/globals'
+import { describe, expect, it, jest } from '@jest/globals'
 import { FullstackTestingError } from '../../../src/core/errors.mjs'
+import { Logger } from '../../../src/core/logging.mjs'
 import * as helpers from '../../../src/core/helpers.mjs'
+import { testLogger } from '../../test_util.js'
 
 describe('Helpers', () => {
   it.each([
@@ -68,6 +70,16 @@ describe('Helpers', () => {
 
     it('should succeed with a later version', () => {
       expect(helpers.compareVersion('v3.12.3', 'v3.14.0')).toBe(1)
+    })
+  })
+
+  describe('default error handler', () => {
+    it('should exit with error code on error', () => {
+      expect.assertions(1)
+      const spy = jest.spyOn(Logger.prototype, 'showUserError').mockImplementation()
+      const err = new FullstackTestingError('test')
+      helpers.defaultErrorHandler(err, testLogger)
+      expect(spy).toHaveBeenCalledWith(err)
     })
   })
 })


### PR DESCRIPTION
## Description

This pull request changes the following:

* Introduce process lock for solo commands
* Add a command handler in BaseCommand to allow centralized process lock/unlock 
* Fix `relay` command argument parsing and chart name
* Improve test coverage

Example:
<img width="603" alt="Screenshot 2024-02-28 at 5 02 53 PM" src="https://github.com/hashgraph/solo/assets/811437/4fb94d74-c263-46e5-910e-a2c11d4b01f6">


### Related Issues

* Closes #43 
