### PR TITLE
ci: set verbose to true for codecov to see what is being uploaded to diagnose missing coverage

### DIFF
--- a/.github/workflows/zxc-code-analysis.yaml
+++ b/.github/workflows/zxc-code-analysis.yaml
@@ -109,7 +109,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.codecov-token }}
         with:
           verbose: true
-#          directory: ''
+#          directory: 'coverage'
 
       - name: Setup Snyk
         env:

--- a/.github/workflows/zxc-code-analysis.yaml
+++ b/.github/workflows/zxc-code-analysis.yaml
@@ -102,6 +102,8 @@ jobs:
         if: ${{ inputs.enable-codecov-analysis && !cancelled() && !failure() }}
         env:
           CODECOV_TOKEN: ${{ secrets.codecov-token }}
+        with:
+          verbose: true
 
       - name: Setup Snyk
         env:

--- a/.github/workflows/zxc-code-analysis.yaml
+++ b/.github/workflows/zxc-code-analysis.yaml
@@ -98,7 +98,7 @@ jobs:
           name: E2E Coverage Report
 
       - name: TODO remove check dir
-        if: ${{ inputs.enable-snyk-scan && !cancelled() && !failure() }}
+        if: ${{ inputs.enable-codecov-analysis && !cancelled() && !failure() }}
         run: ls -alR .
 
       - name: Publish To Codecov

--- a/.github/workflows/zxc-code-analysis.yaml
+++ b/.github/workflows/zxc-code-analysis.yaml
@@ -97,6 +97,10 @@ jobs:
         with:
           name: E2E Coverage Report
 
+      - name: TODO remove check dir
+        if: ${{ inputs.enable-snyk-scan && !cancelled() && !failure() }}
+        run: ls -alR .
+
       - name: Publish To Codecov
         uses: codecov/codecov-action@e0b68c6749509c5f83f984dd99a76a1c1a231044 # v4.0.1
         if: ${{ inputs.enable-codecov-analysis && !cancelled() && !failure() }}

--- a/.github/workflows/zxc-code-analysis.yaml
+++ b/.github/workflows/zxc-code-analysis.yaml
@@ -85,17 +85,18 @@ jobs:
         with:
           node-version: ${{ inputs.node-version }}
 
-      - name: Download Unit Test Coverage Report
+      - name: Download Coverage Reports
         uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
         if: ${{ inputs.enable-codecov-analysis && !cancelled() && !failure() }}
         with:
-          name: Unit Test Coverage Report
+          path: 'coverage'
+          merge-multiple: true
 
-      - name: Download E2E Coverage Report
-        uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
-        if: ${{ inputs.enable-codecov-analysis && inputs.enable-e2e-coverage-report && !cancelled() && !failure() }}
-        with:
-          name: E2E Coverage Report
+#      - name: Download E2E Coverage Report
+#        uses: actions/download-artifact@eaceaf801fd36c7dee90939fad912460b18a1ffe # v4.1.2
+#        if: ${{ inputs.enable-codecov-analysis && inputs.enable-e2e-coverage-report && !cancelled() && !failure() }}
+#        with:
+#          name: E2E Coverage Report
 
       - name: TODO remove check dir
         if: ${{ inputs.enable-codecov-analysis && !cancelled() && !failure() }}

--- a/.github/workflows/zxc-code-analysis.yaml
+++ b/.github/workflows/zxc-code-analysis.yaml
@@ -109,6 +109,7 @@ jobs:
           CODECOV_TOKEN: ${{ secrets.codecov-token }}
         with:
           verbose: true
+#          directory: ''
 
       - name: Setup Snyk
         env:


### PR DESCRIPTION
## Description

This pull request changes the following:

* set verbose to true for codecov to see what is being uploaded to diagnose missing coverage

### Related Issues

* Closes #
