### PR TITLE
fix: refactor account initialization and mirror node setup from node command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,8 @@
         "inquirer": "^9.2.15",
         "js-base64": "^3.7.7",
         "listr2": "^8.0.2",
+        "stoppable": "^1.1.0",
+        "stream-buffers": "^3.0.2",
         "tar": "^6.2.0",
         "uuid": "^9.0.1",
         "winston": "^3.11.0",
@@ -12474,6 +12476,15 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/stoppable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
+      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+      "engines": {
+        "node": ">=4",
+        "npm": ">=6"
       }
     },
     "node_modules/stream-buffers": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
       ],
       "dependencies": {
         "@hashgraph/proto": "^2.14.0-beta.4",
-        "@hashgraph/sdk": "^2.42.0",
+        "@hashgraph/sdk": "^2.43.0-beta.1",
         "@kubernetes/client-node": "^0.20.0",
         "@listr2/prompt-adapter-enquirer": "^2.0.2",
         "@peculiar/x509": "^1.9.7",
@@ -1275,9 +1275,9 @@
       }
     },
     "node_modules/@hashgraph/proto": {
-      "version": "2.14.0-beta.4",
-      "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.14.0-beta.4.tgz",
-      "integrity": "sha512-DCmK9CivuVpdDuay1VcYt++Zhms55uu8JZgJI6fBtJuv/WkMuYLNtmnihKcQ39Ykmm8SV6iL6trTziTINHV44g==",
+      "version": "2.14.0-beta.5",
+      "resolved": "https://registry.npmjs.org/@hashgraph/proto/-/proto-2.14.0-beta.5.tgz",
+      "integrity": "sha512-UrIbLdctpD//Ua99Z4PnknbR8220nc1Pzv0nkDJ1emZE9EAi7YOOry2Dw660azQHWfVw/HhqECPdiKrTIZ2b+Q==",
       "dependencies": {
         "long": "^4.0.0",
         "protobufjs": "^7.2.5"
@@ -1287,9 +1287,9 @@
       }
     },
     "node_modules/@hashgraph/sdk": {
-      "version": "2.42.0",
-      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.42.0.tgz",
-      "integrity": "sha512-47E08ZHGRKoZCmJJhbcaFWcAWNPpJfs5F0SvqocDNFHs616+zrAwFDPXqWLtGx3JhyeCZClgpDYvJX7CVBFCtA==",
+      "version": "2.43.0-beta.1",
+      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.43.0-beta.1.tgz",
+      "integrity": "sha512-CS8Z21OS7/apQFBAuwfXcSpSQFZ3AFzgHL6a8jRfYFY5MWJ9Pdo5Ox9fqJJgl+iF1KZHc48hvQmv9iWMYk6sYA==",
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
@@ -1297,7 +1297,7 @@
         "@ethersproject/rlp": "^5.7.0",
         "@grpc/grpc-js": "1.8.2",
         "@hashgraph/cryptography": "1.4.8-beta.5",
-        "@hashgraph/proto": "2.14.0-beta.4",
+        "@hashgraph/proto": "2.14.0-beta.5",
         "axios": "^1.6.4",
         "bignumber.js": "^9.1.1",
         "bn.js": "^5.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,6 @@
         "inquirer": "^9.2.15",
         "js-base64": "^3.7.7",
         "listr2": "^8.0.2",
-        "stoppable": "^1.1.0",
         "stream-buffers": "^3.0.2",
         "tar": "^6.2.0",
         "uuid": "^9.0.1",
@@ -12476,15 +12475,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/stoppable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
-      "engines": {
-        "node": ">=4",
-        "npm": ">=6"
       }
     },
     "node_modules/stream-buffers": {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "license": "Apache2.0",
   "dependencies": {
     "@hashgraph/proto": "^2.14.0-beta.4",
-    "@hashgraph/sdk": "^2.42.0",
+    "@hashgraph/sdk": "^2.43.0-beta.1",
     "@kubernetes/client-node": "^0.20.0",
     "@listr2/prompt-adapter-enquirer": "^2.0.2",
     "@peculiar/x509": "^1.9.7",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,8 @@
     "inquirer": "^9.2.15",
     "js-base64": "^3.7.7",
     "listr2": "^8.0.2",
+    "stoppable": "^1.1.0",
+    "stream-buffers": "^3.0.2",
     "tar": "^6.2.0",
     "uuid": "^9.0.1",
     "winston": "^3.11.0",

--- a/package.json
+++ b/package.json
@@ -40,7 +40,6 @@
     "inquirer": "^9.2.15",
     "js-base64": "^3.7.7",
     "listr2": "^8.0.2",
-    "stoppable": "^1.1.0",
     "stream-buffers": "^3.0.2",
     "tar": "^6.2.0",
     "uuid": "^9.0.1",

--- a/src/commands/account.mjs
+++ b/src/commands/account.mjs
@@ -24,13 +24,14 @@ import { constants } from '../core/index.mjs'
 import { HbarUnit, PrivateKey } from '@hashgraph/sdk'
 
 export class AccountCommand extends BaseCommand {
-  constructor (opts) {
+  constructor (opts, systemAccounts = constants.SYSTEM_ACCOUNTS) {
     super(opts)
 
     if (!opts || !opts.accountManager) throw new IllegalArgumentError('An instance of core/AccountManager is required', opts.accountManager)
 
     this.accountManager = opts.accountManager
     this.accountInfo = null
+    this.systemAccounts = systemAccounts
   }
 
   async closeConnections () {
@@ -135,7 +136,7 @@ export class AccountCommand extends BaseCommand {
                 const secrets = await self.k8.getSecretsByLabel(['fullstack.hedera.com/account-id'])
                 ctx.updateSecrets = secrets.length > 0
 
-                ctx.accountsBatchedSet = self.accountManager.batchAccounts()
+                ctx.accountsBatchedSet = self.accountManager.batchAccounts(this.systemAccounts)
 
                 ctx.resultTracker = {
                   rejectedCount: 0,

--- a/src/commands/account.mjs
+++ b/src/commands/account.mjs
@@ -180,10 +180,11 @@ export class AccountCommand extends BaseCommand {
                 if (ctx.resultTracker.skippedCount > 0) self.logger.showUser(chalk.cyan(`Account keys updates SKIPPED: ${ctx.resultTracker.skippedCount}`))
                 if (ctx.resultTracker.rejectedCount > 0) {
                   self.logger.showUser(chalk.yellowBright(`Account keys updates with ERROR: ${ctx.resultTracker.rejectedCount}`))
+                }
+                self.logger.showUser(chalk.gray('Waiting for sockets to be closed....'))
+                if (ctx.resultTracker.rejectedCount > 0) {
                   throw new FullstackTestingError(`Account keys updates failed for ${ctx.resultTracker.rejectedCount} accounts.`)
                 }
-
-                self.logger.showUser(chalk.gray('Waiting for sockets to be closed....'))
               }
             }
           ], {

--- a/src/commands/account.mjs
+++ b/src/commands/account.mjs
@@ -14,6 +14,7 @@
  * limitations under the License.
  *
  */
+import chalk from 'chalk'
 import { BaseCommand } from './base.mjs'
 import { FullstackTestingError, IllegalArgumentError } from '../core/errors.mjs'
 import { flags } from './index.mjs'
@@ -94,6 +95,119 @@ export class AccountCommand extends BaseCommand {
 
   async transferAmountFromOperator (toAccountId, amount) {
     return await this.accountManager.transferAmount(constants.TREASURY_ACCOUNT_ID, toAccountId, amount)
+  }
+
+  async init (argv) {
+    const self = this
+
+    const tasks = new Listr([
+      {
+        title: 'Initialize',
+        task: async (ctx, task) => {
+          self.configManager.update(argv)
+          await prompts.execute(task, self.configManager, [
+            flags.namespace
+          ])
+
+          const config = {
+            namespace: self.configManager.getFlag(flags.namespace)
+          }
+
+          if (!await this.k8.hasNamespace(config.namespace)) {
+            throw new FullstackTestingError(`namespace ${config.namespace} does not exist`)
+          }
+
+          // set config in the context for later tasks to use
+          ctx.config = config
+
+          self.logger.debug('Initialized config', { config })
+
+          await self.accountManager.loadNodeClient(ctx.config.namespace)
+        }
+      },
+      {
+        title: 'Update special account keys',
+        task: async (ctx, task) => {
+          return new Listr([
+            {
+              title: 'Prepare for account key updates',
+              task: async (ctx) => {
+                const secrets = await self.k8.getSecretsByLabel(['fullstack.hedera.com/account-id'])
+                ctx.updateSecrets = secrets.length > 0
+
+                ctx.accountsBatchedSet = self.accountManager.batchAccounts()
+
+                ctx.resultTracker = {
+                  rejectedCount: 0,
+                  fulfilledCount: 0,
+                  skippedCount: 0
+                }
+              }
+            },
+            {
+              title: 'Update special account key sets',
+              task: async (ctx) => {
+                const subTasks = []
+                const realm = constants.HEDERA_NODE_ACCOUNT_ID_START.realm
+                const shard = constants.HEDERA_NODE_ACCOUNT_ID_START.shard
+                for (const currentSet of ctx.accountsBatchedSet) {
+                  const accStart = `${realm}.${shard}.${currentSet[0]}`
+                  const accEnd = `${realm}.${shard}.${currentSet[currentSet.length - 1]}`
+                  const rangeStr = accStart !== accEnd ? `${chalk.yellow(accStart)} to ${chalk.yellow(accEnd)}` : `${chalk.yellow(accStart)}`
+                  subTasks.push({
+                    title: `Updating accounts [${rangeStr}]`,
+                    task: async (ctx) => {
+                      ctx.resultTracker = await self.accountManager.updateSpecialAccountsKeys(
+                        ctx.config.namespace, currentSet,
+                        ctx.updateSecrets, ctx.resultTracker)
+                    }
+                  })
+                }
+
+                // set up the sub-tasks
+                return task.newListr(subTasks, {
+                  concurrent: false,
+                  rendererOptions: {
+                    collapseSubtasks: false
+                  }
+                })
+              }
+            },
+            {
+              title: 'Display results',
+              task: async (ctx) => {
+                self.logger.showUser(chalk.green(`Account keys updated SUCCESSFULLY: ${ctx.resultTracker.fulfilledCount}`))
+                if (ctx.resultTracker.skippedCount > 0) self.logger.showUser(chalk.cyan(`Account keys updates SKIPPED: ${ctx.resultTracker.skippedCount}`))
+                if (ctx.resultTracker.rejectedCount > 0) {
+                  self.logger.showUser(chalk.yellowBright(`Account keys updates with ERROR: ${ctx.resultTracker.rejectedCount}`))
+                  throw new FullstackTestingError(`Account keys updates failed for ${ctx.resultTracker.rejectedCount} accounts.`)
+                }
+
+                self.logger.showUser(chalk.gray('Waiting for sockets to be closed....'))
+              }
+            }
+          ], {
+            concurrent: false,
+            rendererOptions: {
+              collapseSubtasks: false
+            }
+          })
+        }
+      }
+    ], {
+      concurrent: false,
+      rendererOptions: constants.LISTR_DEFAULT_RENDERER_OPTION
+    })
+
+    try {
+      await tasks.run()
+    } catch (e) {
+      throw new FullstackTestingError(`Error in creating account: ${e.message}`, e)
+    } finally {
+      await this.closeConnections()
+    }
+
+    return true
   }
 
   async create (argv) {
@@ -288,6 +402,25 @@ export class AccountCommand extends BaseCommand {
       desc: 'Manage Hedera accounts in fullstack testing network',
       builder: yargs => {
         return yargs
+          .command({
+            command: 'init',
+            desc: 'Initialize system accounts with new keys',
+            builder: y => flags.setCommandFlags(y,
+              flags.namespace
+            ),
+            handler: argv => {
+              accountCmd.logger.debug('==== Running \'account init\' ===')
+              accountCmd.logger.debug(argv)
+
+              accountCmd.init(argv).then(r => {
+                accountCmd.logger.debug('==== Finished running \'account init\' ===')
+                if (!r) process.exit(1)
+              }).catch(err => {
+                accountCmd.logger.showUserError(err)
+                process.exit(1)
+              })
+            }
+          })
           .command({
             command: 'create',
             desc: 'Creates a new account with a new key and stores the key in the Kubernetes secrets',

--- a/src/commands/cluster.mjs
+++ b/src/commands/cluster.mjs
@@ -164,14 +164,16 @@ export class ClusterCommand extends BaseCommand {
       {
         title: 'Initialize',
         task: async (ctx, task) => {
-          const confirm = await task.prompt(ListrEnquirerPromptAdapter).run({
-            type: 'toggle',
-            default: false,
-            message: 'Are you sure you would like to uninstall fullstack-cluster-setup chart?'
-          })
+          if (!argv[flags.force.name]) {
+            const confirm = await task.prompt(ListrEnquirerPromptAdapter).run({
+              type: 'toggle',
+              default: false,
+              message: 'Are you sure you would like to uninstall fullstack-cluster-setup chart?'
+            })
 
-          if (!confirm) {
-            process.exit(0)
+            if (!confirm) {
+              process.exit(0)
+            }
           }
 
           self.configManager.update(argv)
@@ -282,7 +284,8 @@ export class ClusterCommand extends BaseCommand {
             desc: 'Uninstall shared components from cluster',
             builder: y => flags.setCommandFlags(y,
               flags.clusterName,
-              flags.clusterSetupNamespace
+              flags.clusterSetupNamespace,
+              flags.force
             ),
             handler: argv => {
               clusterCmd.logger.debug("==== Running 'cluster reset' ===", { argv })

--- a/src/commands/flags.mjs
+++ b/src/commands/flags.mjs
@@ -53,6 +53,7 @@ export const clusterSetupNamespace = {
   name: 'cluster-setup-namespace',
   definition: {
     describe: 'Cluster Setup Namespace',
+    defaultValue: constants.FULLSTACK_SETUP_NAMESPACE,
     alias: 's',
     type: 'string'
   }

--- a/src/commands/index.mjs
+++ b/src/commands/index.mjs
@@ -16,6 +16,7 @@
  */
 import { ClusterCommand } from './cluster.mjs'
 import { InitCommand } from './init.mjs'
+import { MirrorNodeCommand } from './mirror_node.mjs'
 import { NetworkCommand } from './network.mjs'
 import { NodeCommand } from './node.mjs'
 import { RelayCommand } from './relay.mjs'
@@ -33,6 +34,7 @@ function Initialize (opts) {
   const nodeCmd = new NodeCommand(opts)
   const relayCmd = new RelayCommand(opts)
   const accountCmd = new AccountCommand(opts)
+  const mirrorNodeCmd = new MirrorNodeCommand(opts)
 
   return [
     InitCommand.getCommandDefinition(initCmd),
@@ -40,7 +42,8 @@ function Initialize (opts) {
     NetworkCommand.getCommandDefinition(networkCommand),
     NodeCommand.getCommandDefinition(nodeCmd),
     RelayCommand.getCommandDefinition(relayCmd),
-    AccountCommand.getCommandDefinition(accountCmd)
+    AccountCommand.getCommandDefinition(accountCmd),
+    MirrorNodeCommand.getCommandDefinition(mirrorNodeCmd)
   ]
 }
 

--- a/src/commands/mirror_node.mjs
+++ b/src/commands/mirror_node.mjs
@@ -1,0 +1,307 @@
+/**
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the ""License"");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an ""AS IS"" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import { ListrEnquirerPromptAdapter } from '@listr2/prompt-adapter-enquirer'
+import { Listr } from 'listr2'
+import { FullstackTestingError, IllegalArgumentError } from '../core/errors.mjs'
+import { Templates, constants } from '../core/index.mjs'
+import { BaseCommand } from './base.mjs'
+import * as flags from './flags.mjs'
+import * as prompts from './prompts.mjs'
+
+export class MirrorNodeCommand extends BaseCommand {
+  constructor (opts) {
+    super(opts)
+    if (!opts || !opts.accountManager) throw new IllegalArgumentError('An instance of core/AccountManager is required', opts.accountManager)
+    this.accountManager = opts.accountManager
+  }
+
+  async deploy (argv) {
+    const self = this
+
+    const tasks = new Listr([
+      {
+        title: 'Initialize',
+        task: async (ctx, task) => {
+          self.configManager.update(argv)
+          await prompts.execute(task, self.configManager, [
+            flags.namespace,
+            flags.deployHederaExplorer
+          ])
+
+          ctx.config = {
+            namespace: self.configManager.getFlag(flags.namespace),
+            chartDir: self.configManager.getFlag(flags.chartDirectory),
+            deployHederaExplorer: self.configManager.getFlag(flags.deployHederaExplorer)
+          }
+
+          ctx.config.chartPath = await self.prepareChartPath(ctx.config.chartDir,
+            constants.FULLSTACK_TESTING_CHART, constants.FULLSTACK_DEPLOYMENT_CHART)
+
+          ctx.config.stagingDir = Templates.renderStagingDir(self.configManager, flags)
+
+          ctx.config.valuesArg = ` --set hedera-mirror-node.enabled=true --set hedera-explorer.enabled=${ctx.config.deployHederaExplorer}`
+
+          if (!await self.k8.hasNamespace(ctx.config.namespace)) {
+            throw new FullstackTestingError(`namespace ${ctx.config.namespace} does not exist`)
+          }
+
+          await self.accountManager.loadNodeClient(ctx.config.namespace)
+        }
+      },
+      {
+        title: 'Enable mirror-node',
+        task: async (ctx, parentTask) => {
+          const subTasks = [
+            {
+              title: 'Prepare address book',
+              task: async (ctx, _) => {
+                ctx.addressBook = await self.accountManager.prepareAddressBookBase64()
+                ctx.config.valuesArg += ` --set "hedera-mirror-node.importer.addressBook=${ctx.addressBook}"`
+              }
+            },
+            {
+              title: 'Deploy mirror-node',
+              task: async (ctx, _) => {
+                await self.chartManager.upgrade(
+                  ctx.config.namespace,
+                  constants.FULLSTACK_DEPLOYMENT_CHART,
+                  ctx.config.chartPath,
+                  ctx.config.valuesArg
+                )
+              }
+            }
+          ]
+
+          return parentTask.newListr(subTasks, {
+            concurrent: false,
+            rendererOptions: constants.LISTR_DEFAULT_RENDERER_OPTION
+          })
+        }
+      },
+      {
+        title: 'Check Mirror node components are ACTIVE',
+        task: async (ctx, parentTask) => {
+          const subTasks = [
+            {
+              title: 'Check Postgres DB',
+              task: async (ctx, _) => self.k8.waitForPod(constants.POD_STATUS_RUNNING, [
+                'app.kubernetes.io/component=postgresql',
+                'app.kubernetes.io/name=postgres'
+              ], 1, 900)
+            },
+            {
+              title: 'Check Importer',
+              task: async (ctx, _) => self.k8.waitForPod(constants.POD_STATUS_RUNNING, [
+                'app.kubernetes.io/component=importer',
+                'app.kubernetes.io/name=importer'
+              ], 1, 900)
+            },
+            {
+              title: 'Check REST API',
+              task: async (ctx, _) => self.k8.waitForPod(constants.POD_STATUS_RUNNING, [
+                'app.kubernetes.io/component=rest',
+                'app.kubernetes.io/name=rest'
+              ], 1, 900)
+            },
+            {
+              title: 'Check Web3',
+              task: async (ctx, _) => self.k8.waitForPod(constants.POD_STATUS_RUNNING, [
+                'app.kubernetes.io/component=web3',
+                'app.kubernetes.io/name=web3'
+              ], 1, 900)
+            },
+            {
+              title: 'Check GRPC',
+              task: async (ctx, _) => self.k8.waitForPod(constants.POD_STATUS_RUNNING, [
+                'app.kubernetes.io/component=grpc',
+                'app.kubernetes.io/name=grpc'
+              ], 1, 900)
+            },
+            {
+              title: 'Check Hedera Explorer',
+              skip: (ctx, _) => !ctx.config.deployHederaExplorer,
+              task: async (ctx, _) => self.k8.waitForPod(constants.POD_STATUS_RUNNING, [
+                'app.kubernetes.io/component=hedera-explorer',
+                'app.kubernetes.io/name=hedera-explorer'
+              ], 1, 900)
+            }
+          ]
+
+          return parentTask.newListr(subTasks, {
+            concurrent: false,
+            rendererOptions: constants.LISTR_DEFAULT_RENDERER_OPTION
+          })
+        }
+      }
+    ], {
+      concurrent: false,
+      rendererOptions: constants.LISTR_DEFAULT_RENDERER_OPTION
+    })
+
+    try {
+      await tasks.run()
+      self.logger.debug('node start has completed')
+    } catch (e) {
+      throw new FullstackTestingError(`Error starting node: ${e.message}`, e)
+    } finally {
+      await self.accountManager.close()
+    }
+
+    return true
+  }
+
+  async destroy (argv) {
+    const self = this
+
+    const tasks = new Listr([
+      {
+        title: 'Initialize',
+        task: async (ctx, task) => {
+          if (!argv.force) {
+            const confirm = await task.prompt(ListrEnquirerPromptAdapter).run({
+              type: 'toggle',
+              default: false,
+              message: 'Are you sure you would like to destroy the mirror-node components?'
+            })
+
+            if (!confirm) {
+              process.exit(0)
+            }
+          }
+
+          self.configManager.update(argv)
+          await prompts.execute(task, self.configManager, [
+            flags.namespace
+          ])
+
+          ctx.config = {
+            namespace: self.configManager.getFlag(flags.namespace),
+            chartDir: self.configManager.getFlag(flags.chartDirectory)
+          }
+
+          ctx.config.chartPath = await self.prepareChartPath(ctx.config.chartDir,
+            constants.FULLSTACK_TESTING_CHART, constants.FULLSTACK_DEPLOYMENT_CHART)
+
+          ctx.config.stagingDir = Templates.renderStagingDir(self.configManager, flags)
+
+          ctx.config.valuesArg = ' --set hedera-mirror-node.enabled=false --set hedera-explorer.enabled=false'
+
+          if (!await self.k8.hasNamespace(ctx.config.namespace)) {
+            throw new FullstackTestingError(`namespace ${ctx.config.namespace} does not exist`)
+          }
+
+          await self.accountManager.loadNodeClient(ctx.config.namespace)
+        }
+      },
+      {
+        title: 'Destroy mirror-node',
+        task: async (ctx, _) => {
+          await self.chartManager.upgrade(
+            ctx.config.namespace,
+            constants.FULLSTACK_DEPLOYMENT_CHART,
+            ctx.config.chartPath,
+            ctx.config.valuesArg
+          )
+        }
+      },
+      {
+        title: 'Delete PVCs for namespace',
+        task: async (ctx, _) => {
+          const pvcs = await self.k8.listPvcsByNamespace(ctx.config.namespace, [
+            'app.kubernetes.io/component=postgresql',
+            'app.kubernetes.io/instance=fullstack-deployment',
+            'app.kubernetes.io/name=postgres'
+          ])
+
+          if (pvcs) {
+            for (const pvc of pvcs) {
+              await self.k8.deletePvc(pvc, ctx.config.namespace)
+            }
+          }
+        }
+      }
+    ], {
+      concurrent: false,
+      rendererOptions: constants.LISTR_DEFAULT_RENDERER_OPTION
+    })
+
+    try {
+      await tasks.run()
+      self.logger.debug('node start has completed')
+    } catch (e) {
+      throw new FullstackTestingError(`Error starting node: ${e.message}`, e)
+    } finally {
+      await self.accountManager.close()
+    }
+
+    return true
+  }
+
+  /**
+   * Return Yargs command definition for 'mirror-mirror-node' command
+   * @param mirrorNodeCmd an instance of NodeCommand
+   */
+  static getCommandDefinition (mirrorNodeCmd) {
+    return {
+      command: 'mirror-node',
+      desc: 'Manage Hedera Mirror Node in fullstack testing network',
+      builder: yargs => {
+        return yargs
+          .command({
+            command: 'deploy',
+            desc: 'Deploy mirror-node and its components',
+            builder: y => flags.setCommandFlags(y,
+              flags.namespace,
+              flags.deployHederaExplorer
+            ),
+            handler: argv => {
+              mirrorNodeCmd.logger.debug('==== Running \'mirror-node deploy\' ===')
+              mirrorNodeCmd.logger.debug(argv)
+
+              mirrorNodeCmd.deploy(argv).then(r => {
+                mirrorNodeCmd.logger.debug('==== Finished running `mirror-node deploy`====')
+                if (!r) process.exit(1)
+              }).catch(err => {
+                mirrorNodeCmd.logger.showUserError(err)
+                process.exit(1)
+              })
+            }
+          })
+          .command({
+            command: 'destroy',
+            desc: 'Destroy mirror-node components and database',
+            builder: y => flags.setCommandFlags(y,
+              flags.namespace
+            ),
+            handler: argv => {
+              mirrorNodeCmd.logger.debug('==== Running \'mirror-node destroy\' ===')
+              mirrorNodeCmd.logger.debug(argv)
+
+              mirrorNodeCmd.destroy(argv).then(r => {
+                mirrorNodeCmd.logger.debug('==== Finished running `mirror-node destroy`====')
+                if (!r) process.exit(1)
+              }).catch(err => {
+                mirrorNodeCmd.logger.showUserError(err)
+                process.exit(1)
+              })
+            }
+          })
+          .demandCommand(1, 'Select a mirror-node command')
+      }
+    }
+  }
+}

--- a/src/commands/network.mjs
+++ b/src/commands/network.mjs
@@ -78,7 +78,6 @@ export class NetworkCommand extends BaseCommand {
 
     // do not deploy mirror node until after we have the updated address book
     valuesArg += ' --set hedera-mirror-node.enabled=false --set hedera-explorer.enabled=false'
-
     valuesArg += ` --set telemetry.prometheus.svcMonitor.enabled=${config.enablePrometheusSvcMonitor}`
 
     if (config.enableHederaExplorerTls) {
@@ -111,8 +110,6 @@ export class NetworkCommand extends BaseCommand {
       flags.nodeIDs,
       flags.chartDirectory,
       flags.valuesFile,
-      flags.deployMirrorNode,
-      flags.deployHederaExplorer,
       flags.tlsClusterIssuerType,
       flags.enableHederaExplorerTls,
       flags.hederaExplorerTlsHostName,
@@ -131,8 +128,6 @@ export class NetworkCommand extends BaseCommand {
       chartDir: this.configManager.getFlag(flags.chartDirectory),
       fstChartVersion: this.configManager.getFlag(flags.fstChartVersion),
       valuesFile: this.configManager.getFlag(flags.valuesFile),
-      deployMirrorNode: this.configManager.getFlag(flags.deployMirrorNode),
-      deployHederaExplorer: this.configManager.getFlag(flags.deployHederaExplorer),
       tlsClusterIssuerType: this.configManager.getFlag(flags.tlsClusterIssuerType),
       enableHederaExplorerTls: this.configManager.getFlag(flags.enableHederaExplorerTls),
       hederaExplorerTlsHostName: this.configManager.getFlag(flags.hederaExplorerTlsHostName),
@@ -358,8 +353,6 @@ export class NetworkCommand extends BaseCommand {
               flags.nodeIDs,
               flags.chartDirectory,
               flags.valuesFile,
-              flags.deployMirrorNode,
-              flags.deployHederaExplorer,
               flags.tlsClusterIssuerType,
               flags.enableHederaExplorerTls,
               flags.hederaExplorerTlsLoadBalancerIp,

--- a/src/commands/node.mjs
+++ b/src/commands/node.mjs
@@ -528,7 +528,7 @@ export class NodeCommand extends BaseCommand {
     return true
   }
 
-  async checkNetworkNodeProxyUp (namespace, nodeId, maxAttempts = 5, delay = 5000) {
+  async checkNetworkNodeProxyUp (namespace, nodeId, maxAttempts = 10, delay = 5000) {
     const podArray = await this.k8.getPodsByLabel([`app=haproxy-${nodeId}`, 'fullstack.hedera.com/type=haproxy'])
 
     let attempts = 0

--- a/src/commands/node.mjs
+++ b/src/commands/node.mjs
@@ -543,12 +543,14 @@ export class NodeCommand extends BaseCommand {
           throw new FullstackTestingError(`Expected pod ${podName} log query to execute successful, but instead got a status of ${logResponse.response.statusCode}`)
         }
 
+        this.logger.debug(`Received HAProxy log from ${podName}`, { output: logResponse.body })
         if (logResponse.body.includes('Server be_servers/server1 is UP')) {
+          this.logger.debug(`HAProxy ${podName} is UP`)
           return true
         }
 
         attempts++
-        this.logger.debug(`Checking for pod ${podName} to realize network node is UP [attempt: ${attempts}/${maxAttempts}]`)
+        this.logger.debug(`Checking if proxy ${podName} is UP [attempt: ${attempts}/${maxAttempts}]`)
         await sleep(1000)
       }
     } else {

--- a/src/commands/node.mjs
+++ b/src/commands/node.mjs
@@ -409,10 +409,7 @@ export class NodeCommand extends BaseCommand {
           await prompts.execute(task, self.configManager, [
             flags.namespace,
             flags.chartDirectory,
-            flags.nodeIDs,
-            flags.deployHederaExplorer,
-            flags.deployMirrorNode,
-            flags.updateAccountKeys
+            flags.nodeIDs
           ])
 
           ctx.config = {
@@ -420,9 +417,6 @@ export class NodeCommand extends BaseCommand {
             chartDir: self.configManager.getFlag(flags.chartDirectory),
             fstChartVersion: self.configManager.getFlag(flags.fstChartVersion),
             nodeIds: helpers.parseNodeIDs(self.configManager.getFlag(flags.nodeIDs)),
-            deployMirrorNode: self.configManager.getFlag(flags.deployMirrorNode),
-            deployHederaExplorer: self.configManager.getFlag(flags.deployHederaExplorer),
-            updateAccountKeys: self.configManager.getFlag(flags.updateAccountKeys),
             applicationEnv: self.configManager.getFlag(flags.applicationEnv),
             cacheDir: self.configManager.getFlag(flags.cacheDir)
           }
@@ -431,8 +425,6 @@ export class NodeCommand extends BaseCommand {
             constants.FULLSTACK_TESTING_CHART, constants.FULLSTACK_DEPLOYMENT_CHART)
 
           ctx.config.stagingDir = Templates.renderStagingDir(self.configManager, flags)
-
-          ctx.config.valuesArg = ` --set hedera-mirror-node.enabled=${ctx.config.deployMirrorNode} --set hedera-explorer.enabled=${ctx.config.deployHederaExplorer}`
 
           if (!await self.k8.hasNamespace(ctx.config.namespace)) {
             throw new FullstackTestingError(`namespace ${ctx.config.namespace} does not exist`)
@@ -500,140 +492,23 @@ export class NodeCommand extends BaseCommand {
         }
       },
       {
-        title: 'Enable mirror node',
+        title: 'Check node proxies are ACTIVE',
         task: async (ctx, parentTask) => {
-          if (ctx.config.deployMirrorNode) {
-            const subTasks = [
-              {
-                title: 'Check node proxies are ACTIVE',
-                task: async (ctx, _) => {
-                  const subTasks = []
-                  for (const nodeId of ctx.config.nodeIds) {
-                    subTasks.push({
-                      title: `Check proxy for node: ${chalk.yellow(nodeId)}`,
-                      task: async () => await self.checkNetworkNodeProxyUp(ctx.config.namespace, nodeId)
-                    })
-                  }
-
-                  // set up the sub-tasks
-                  return parentTask.newListr(subTasks, {
-                    concurrent: false,
-                    rendererOptions: {
-                      collapseSubtasks: false
-                    }
-                  })
-                }
-              },
-              {
-                title: 'Prepare address book',
-                task: async (ctx, _) => {
-                  ctx.addressBook = await self.getAddressBook(ctx.nodeClient)
-                  ctx.config.valuesArg += ` --set "hedera-mirror-node.importer.addressBook=${ctx.addressBook}"`
-                }
-              },
-              {
-                title: 'Deploy mirror node',
-                task: async (ctx, _) => {
-                  await self.chartManager.upgrade(
-                    ctx.config.namespace,
-                    constants.FULLSTACK_DEPLOYMENT_CHART,
-                    ctx.config.chartPath,
-                    ctx.config.valuesArg
-                  )
-                }
-              },
-              {
-                title: 'Waiting for Hedera Explorer to be ready',
-                task: async (ctx, _) => {
-                  if (ctx.config.deployHederaExplorer) {
-                    await self.k8.waitForPod(constants.POD_STATUS_RUNNING, [
-                      'app.kubernetes.io/component=hedera-explorer', 'app.kubernetes.io/name=hedera-explorer'
-                    ], 1, 900)
-                  }
-                }
-              }
-            ]
-
-            return parentTask.newListr(subTasks, {
-              concurrent: false,
-              rendererOptions: constants.LISTR_DEFAULT_RENDERER_OPTION
+          const subTasks = []
+          for (const nodeId of ctx.config.nodeIds) {
+            subTasks.push({
+              title: `Check proxy for node: ${chalk.yellow(nodeId)}`,
+              task: async () => await self.checkNetworkNodeProxyUp(ctx.config.namespace, nodeId)
             })
           }
-        }
-      },
-      {
-        title: 'Update special account keys',
-        skip: (ctx, _) => !ctx.config.updateAccountKeys,
-        task: async (ctx, task) => {
-          if (ctx.config.updateAccountKeys) {
-            return new Listr([
-              {
-                title: 'Prepare for account key updates',
-                task: async (ctx) => {
-                  const secrets = await self.k8.getSecretsByLabel(['fullstack.hedera.com/account-id'])
-                  ctx.updateSecrets = secrets.length > 0
 
-                  ctx.accountsBatchedSet = self.accountManager.batchAccounts()
-
-                  ctx.resultTracker = {
-                    rejectedCount: 0,
-                    fulfilledCount: 0,
-                    skippedCount: 0
-                  }
-                }
-              },
-              {
-                title: 'Update special account key sets',
-                task: async (ctx) => {
-                  const subTasks = []
-                  const realm = constants.HEDERA_NODE_ACCOUNT_ID_START.realm
-                  const shard = constants.HEDERA_NODE_ACCOUNT_ID_START.shard
-                  for (const currentSet of ctx.accountsBatchedSet) {
-                    const accStart = `${realm}.${shard}.${currentSet[0]}`
-                    const accEnd = `${realm}.${shard}.${currentSet[currentSet.length - 1]}`
-                    const rangeStr = accStart !== accEnd ? `${chalk.yellow(accStart)} to ${chalk.yellow(accEnd)}` : `${chalk.yellow(accStart)}`
-                    subTasks.push({
-                      title: `Updating accounts [${rangeStr}]`,
-                      task: async (ctx) => {
-                        ctx.resultTracker = await self.accountManager.updateSpecialAccountsKeys(
-                          ctx.config.namespace, currentSet,
-                          ctx.updateSecrets, ctx.resultTracker)
-                      }
-                    })
-                  }
-
-                  // set up the sub-tasks
-                  return task.newListr(subTasks, {
-                    concurrent: false,
-                    rendererOptions: {
-                      collapseSubtasks: false
-                    }
-                  })
-                }
-              },
-              {
-                title: 'Display results',
-                task: async (ctx) => {
-                  self.logger.showUser(chalk.green(`Account keys updated SUCCESSFULLY: ${ctx.resultTracker.fulfilledCount}`))
-                  if (ctx.resultTracker.skippedCount > 0) self.logger.showUser(chalk.cyan(`Account keys updates SKIPPED: ${ctx.resultTracker.skippedCount}`))
-                  if (ctx.resultTracker.rejectedCount > 0) {
-                    self.logger.showUser(chalk.yellowBright(`Account keys updates with ERROR: ${ctx.resultTracker.rejectedCount}`))
-                    throw new FullstackTestingError(`Account keys updates failed for ${ctx.resultTracker.rejectedCount} accounts.`)
-                  }
-
-                  self.logger.showUser(chalk.gray('Waiting for sockets to be closed....'))
-                }
-              }
-            ], {
-              concurrent: false,
-              rendererOptions: {
-                collapseSubtasks: false
-              }
-            })
-          } else {
-            self.logger.showUser(chalk.yellowBright('> WARNING:'), chalk.yellow(
-              'skipping special account keys update, special accounts will retain genesis private keys'))
-          }
+          // set up the sub-tasks
+          return parentTask.newListr(subTasks, {
+            concurrent: false,
+            rendererOptions: {
+              collapseSubtasks: false
+            }
+          })
         }
       }
     ], {
@@ -681,20 +556,6 @@ export class NodeCommand extends BaseCommand {
     }
 
     return false
-  }
-
-  /**
-   * Will get the address book from the network (base64 encoded)
-   * @param nodeClient the configured and active NodeClient to use to retrieve the address book
-   * @returns {Promise<string>} the base64 encoded address book for the network
-   */
-  async getAddressBook (nodeClient) {
-    try {
-      // Retrieve the AddressBook as base64
-      return await this.accountManager.prepareAddressBookBase64(nodeClient)
-    } catch (e) {
-      throw new FullstackTestingError(`an error was encountered while trying to prepare the address book: ${e.message}`, e)
-    }
   }
 
   async stop (argv) {
@@ -929,7 +790,6 @@ export class NodeCommand extends BaseCommand {
             builder: y => flags.setCommandFlags(y,
               flags.namespace,
               flags.nodeIDs,
-              flags.updateAccountKeys,
               flags.applicationEnv
             ),
             handler: argv => {

--- a/src/core/account_manager.mjs
+++ b/src/core/account_manager.mjs
@@ -469,18 +469,15 @@ export class AccountManager {
     const self = this
 
     return new Promise((resolve, reject) => {
-      const socket = net.createConnection({
-        host,
-        port
-      })
-      socket.on('error', (e) => {
-        socket.destroy()
+      const s = new net.Socket()
+      s.on('error', (e) => {
+        s.destroy()
         reject(new FullstackTestingError(`failed to connect to '${host}:${port}': ${e.message}`, e))
       })
 
-      socket.on('connect', () => {
-        self.logger.debug(`Connected to port '${port}' of pod ${podName} at IP address ${host}`)
-        socket.destroy()
+      s.connect(port, host, () => {
+        self.logger.debug(`Connection test successful: ${host}:${port}`)
+        s.destroy()
         resolve(true)
       })
     })

--- a/src/core/account_manager.mjs
+++ b/src/core/account_manager.mjs
@@ -122,12 +122,12 @@ export class AccountManager {
    * batch up the accounts into sets to be processed
    * @returns {*[]} an array of arrays of numbers representing the accounts to update
    */
-  batchAccounts () {
+  batchAccounts (accountRange = constants.SYSTEM_ACCOUNTS) {
     const batchSize = constants.ACCOUNT_CREATE_BATCH_SIZE
     const batchSets = []
 
     let currentBatch = []
-    for (const [start, end] of constants.SYSTEM_ACCOUNTS) {
+    for (const [start, end] of accountRange) {
       let batchCounter = start
       for (let i = start; i <= end; i++) {
         currentBatch.push(i)

--- a/src/core/account_manager.mjs
+++ b/src/core/account_manager.mjs
@@ -30,7 +30,7 @@ import {
   Status,
   TransferTransaction
 } from '@hashgraph/sdk'
-import { FullstackTestingError } from './errors.mjs'
+import { FullstackTestingError, MissingArgumentError } from './errors.mjs'
 import net from 'net'
 import { Templates } from './templates.mjs'
 
@@ -395,6 +395,10 @@ export class AccountManager {
    * @returns {AccountInfo} the private key of the account
    */
   async accountInfoQuery (accountId) {
+    if (!this._nodeClient) {
+      throw new MissingArgumentError('node client is not initialized')
+    }
+
     return await new AccountInfoQuery()
       .setAccountId(accountId)
       .execute(this._nodeClient)

--- a/src/core/account_manager.mjs
+++ b/src/core/account_manager.mjs
@@ -215,7 +215,6 @@ export class AccountManager {
       this.logger.debug(`creating client from network configuration: ${JSON.stringify(nodes)}`)
       this._nodeClient = Client.fromConfig({ network: nodes })
       this._nodeClient.setOperator(operatorId, operatorKey)
-
       return this._nodeClient
     } catch (e) {
       throw new FullstackTestingError(`failed to setup node client: ${e.message}`, e)
@@ -401,6 +400,8 @@ export class AccountManager {
 
     return await new AccountInfoQuery()
       .setAccountId(accountId)
+      .setMaxAttempts(3)
+      .setMaxBackoff(1000)
       .execute(this._nodeClient)
   }
 

--- a/src/core/account_manager.mjs
+++ b/src/core/account_manager.mjs
@@ -178,7 +178,6 @@ export class AccountManager {
 
       this._nodeClient = await this._getNodeClient(namespace,
         serviceMap, treasuryAccountInfo.accountId, treasuryAccountInfo.privateKey)
-      this._nodeClient.setMaxBackoff(2000)
     }
   }
 

--- a/src/core/chart_manager.mjs
+++ b/src/core/chart_manager.mjs
@@ -128,9 +128,9 @@ export class ChartManager {
 
   async upgrade (namespaceName, chartName, chartPath, valuesArg = '') {
     try {
-      this.logger.showUser(chalk.cyan('> upgrading chart:'), chalk.yellow(`${chartName}`))
+      this.logger.debug(chalk.cyan('> upgrading chart:'), chalk.yellow(`${chartName}`))
       await this.helm.upgrade(`-n ${namespaceName} ${chartName} ${chartPath} --reuse-values ${valuesArg}`)
-      this.logger.showUser(chalk.green('OK'), `chart '${chartName}' is upgraded`)
+      this.logger.debug(chalk.green('OK'), `chart '${chartName}' is upgraded`)
     } catch (e) {
       throw new FullstackTestingError(`failed to upgrade chart ${chartName}: ${e.message}`, e)
     }

--- a/src/core/config_manager.mjs
+++ b/src/core/config_manager.mjs
@@ -165,7 +165,7 @@ export class ConfigManager {
   persist () {
     try {
       this.config.updatedAt = new Date().toISOString()
-      let configJSON = JSON.stringify(this.config)
+      let configJSON = JSON.stringify(this.config, null, 2)
       fs.writeFileSync(`${this.cachedConfigFile}`, configJSON)
 
       // refresh config with the file contents

--- a/src/core/constants.mjs
+++ b/src/core/constants.mjs
@@ -81,7 +81,7 @@ export const GENESIS_KEY = process.env.GENESIS_KEY || '302e020100300506032b65700
 export const SYSTEM_ACCOUNTS = [[3, 100], [200, 349], [400, 750], [900, 1000]] // do account 0.0.2 last and outside the loop
 export const TREASURY_ACCOUNT = 2
 export const LOCAL_NODE_START_PORT = process.env.LOCAL_NODE_START_PORT || 30212
-export const ACCOUNT_CREATE_BATCH_SIZE = process.env.ACCOUNT_CREATE_BATCH_SIZE || 25
+export const ACCOUNT_CREATE_BATCH_SIZE = process.env.ACCOUNT_CREATE_BATCH_SIZE || 50
 
 export const POD_STATUS_RUNNING = 'Running'
 export const POD_STATUS_READY = 'Ready'
@@ -91,7 +91,7 @@ export const LISTR_DEFAULT_RENDERER_TIMER_OPTION = {
   ...PRESET_TIMER,
   condition: (duration) => duration > 100,
   format: (duration) => {
-    if (duration > 10000) {
+    if (duration > 30000) {
       return color.red
     }
 
@@ -117,3 +117,5 @@ export const AGREEMENT_KEY_PREFIX = 'a'
 export const OS_WINDOWS = 'windows'
 export const OS_DARWIN = 'darwin'
 export const OS_LINUX = 'linux'
+
+export const LOCAL_HOST = '127.0.0.1'

--- a/src/core/constants.mjs
+++ b/src/core/constants.mjs
@@ -111,6 +111,8 @@ export const KEY_FORMAT_PFX = 'pfx'
 
 export const KEY_TYPE_GOSSIP = 'gossip'
 
+export const PUBLIC_PFX = 'public.pfx'
+
 export const KEY_TYPE_TLS = 'tls'
 export const SIGNING_KEY_PREFIX = 's'
 export const AGREEMENT_KEY_PREFIX = 'a'

--- a/src/core/constants.mjs
+++ b/src/core/constants.mjs
@@ -59,6 +59,7 @@ export const LOG_STATUS_DONE = chalk.green('OK')
 export const LOG_GROUP_DIVIDER = chalk.yellow('----------------------------------------------------------------------------')
 
 // --------------- Charts related constants ----------------------------------------------------------------------------
+export const FULLSTACK_SETUP_NAMESPACE = 'fullstack-setup'
 export const FULLSTACK_TESTING_CHART_URL = 'https://hashgraph.github.io/full-stack-testing/charts'
 export const FULLSTACK_TESTING_CHART = 'full-stack-testing'
 export const FULLSTACK_CLUSTER_SETUP_CHART = 'fullstack-cluster-setup'

--- a/src/core/helm.mjs
+++ b/src/core/helm.mjs
@@ -18,9 +18,12 @@ import { constants } from './index.mjs'
 import { ShellRunner } from './shell_runner.mjs'
 import { Templates } from './templates.mjs'
 
-const helmPath = Templates.installationPath(constants.HELM)
-
 export class Helm extends ShellRunner {
+  constructor (logger) {
+    super(logger)
+    this.helmPath = Templates.installationPath(constants.HELM)
+  }
+
   /**
      * Prepare a `helm` shell command string
      * @param action represents a helm command (e.g. create | install | get )
@@ -28,7 +31,7 @@ export class Helm extends ShellRunner {
      * @returns {string}
      */
   prepareCommand (action, ...args) {
-    let cmd = `${helmPath} ${action}`
+    let cmd = `${this.helmPath} ${action}`
     args.forEach(arg => { cmd += ` ${arg}` })
     return cmd
   }

--- a/src/core/k8.mjs
+++ b/src/core/k8.mjs
@@ -119,7 +119,6 @@ export class K8 {
   filterItem (items, filters = {}) {
     const filtered = this.applyMetadataFilter(items, filters)
     if (filtered.length > 1) throw new FullstackTestingError('multiple items found with filters', { filters })
-    if (filtered.length !== 1) throw new FullstackTestingError('item not found with filters', { filters })
     return filtered[0]
   }
 

--- a/src/core/k8.mjs
+++ b/src/core/k8.mjs
@@ -710,13 +710,13 @@ export class K8 {
     const fieldSelector = `status.phase=${status}`
     const labelSelector = labels.join(',')
 
-    this.logger.debug(`WaitForPod [${fieldSelector}, ${labelSelector}], maxAttempts: ${maxAttempts}`)
+    this.logger.debug(`WaitForPod [namespace:${ns}, fieldSector(${fieldSelector}, labelSelector: ${labelSelector}], maxAttempts: ${maxAttempts}`)
 
     return new Promise((resolve, reject) => {
       let attempts = 0
 
       const check = async () => {
-        this.logger.debug(`Checking for pod ${fieldSelector}, ${labelSelector} [attempt: ${attempts}/${maxAttempts}]`)
+        this.logger.debug(`Checking for pod [namespace:${ns}, fieldSector(${fieldSelector}, labelSelector: ${labelSelector}] [attempt: ${attempts}/${maxAttempts}]`)
 
         // wait for the pod to be available with the given status and labels
         const resp = await this.kubeClient.listNamespacedPod(
@@ -729,8 +729,8 @@ export class K8 {
           podCount
         )
 
+        this.logger.debug(`${resp.body.items.length}/${podCount} pod found [namespace:${ns}, fieldSector(${fieldSelector}, labelSelector: ${labelSelector}] [attempt: ${attempts}/${maxAttempts}]`)
         if (resp.body && resp.body.items && resp.body.items.length === podCount) {
-          this.logger.debug(`Found ${resp.body.items.length}/${podCount} pod with ${fieldSelector}, ${labelSelector} [attempt: ${attempts}/${maxAttempts}]`)
           return resolve(true)
         }
 
@@ -748,12 +748,19 @@ export class K8 {
   /**
    * Get a list of persistent volume claim names for the given namespace
    * @param namespace the namespace of the persistent volume claims to return
+   * @param labels labels
    * @returns {Promise<*[]>} list of persistent volume claims
    */
-  async listPvcsByNamespace (namespace) {
+  async listPvcsByNamespace (namespace, labels = []) {
     const pvcs = []
+    const labelSelector = labels.join(',')
     const resp = await this.kubeClient.listNamespacedPersistentVolumeClaim(
-      namespace
+      namespace,
+      null,
+      null,
+      null,
+      null,
+      labelSelector
     )
 
     for (const item of resp.body.items) {

--- a/src/core/k8.mjs
+++ b/src/core/k8.mjs
@@ -666,8 +666,8 @@ export class K8 {
   async portForward (podName, localPort, podPort) {
     const ns = this._getNamespace()
     const forwarder = new k8s.PortForward(this.kubeConfig, false)
-    const server = await net.createServer(async (socket) => {
-      await forwarder.portForward(ns, podName, [podPort], socket, null, socket, 3)
+    const server = await net.createServer((socket) => {
+      forwarder.portForward(ns, podName, [podPort], socket, null, socket, 3)
     })
 
     // add info for logging

--- a/src/core/k8.mjs
+++ b/src/core/k8.mjs
@@ -680,9 +680,19 @@ export class K8 {
    * @param server an instance of server returned by portForward method
    * @return {Promise<void>}
    */
-  async stopPortForward (server) {
+  stopPortForward (server) {
     this.logger.debug(`Stopping port-forwarder [${server.info}]`)
-    server.close()
+    return new Promise((resolve, reject) => {
+      server.close((e) => {
+        if (e) {
+          this.logger.debug(`Failed to stop port-forwarder [${server.info}]: ${e.message}`)
+          reject(e)
+        } else {
+          this.logger.debug(`Stopped port-forwarder [${server.info}]`)
+          resolve()
+        }
+      })
+    })
   }
 
   /**

--- a/test/e2e/commands/01_node.test.mjs
+++ b/test/e2e/commands/01_node.test.mjs
@@ -46,6 +46,7 @@ import {
   testLogger
 } from '../../test_util.js'
 import { AccountManager } from '../../../src/core/account_manager.mjs'
+import * as version from 'version.mjs'
 
 describe.each([
   ['v0.42.5', constants.KEY_FORMAT_PFX]
@@ -69,7 +70,7 @@ describe.each([
   argv[flags.generateTlsKeys.name] = true
   argv[flags.clusterName.name] = TEST_CLUSTER
   argv[flags.namespace.name] = namespace
-  argv[flags.fstChartVersion.name] = 'v0.22.0'
+  argv[flags.fstChartVersion.name] = version.FST_CHART_VERSION
 
   // prepare dependency manger registry
   const downloader = new PackageDownloader(testLogger)

--- a/test/e2e/commands/01_node.test.mjs
+++ b/test/e2e/commands/01_node.test.mjs
@@ -14,26 +14,22 @@
  * limitations under the License.
  *
  */
-import {
-  AccountBalanceQuery,
-  AccountCreateTransaction,
-  Hbar,
-  PrivateKey
-} from '@hashgraph/sdk'
+import { AccountBalanceQuery, AccountCreateTransaction, Hbar, PrivateKey } from '@hashgraph/sdk'
 import {
   afterAll,
-  afterEach, beforeAll,
+  beforeAll,
   describe,
   expect,
   it
 } from '@jest/globals'
-import path from 'path'
+import { ClusterCommand } from '../../../src/commands/cluster.mjs'
 import { flags } from '../../../src/commands/index.mjs'
+import { InitCommand } from '../../../src/commands/init.mjs'
+import { NetworkCommand } from '../../../src/commands/network.mjs'
 import { NodeCommand } from '../../../src/commands/node.mjs'
 import { DependencyManager, HelmDependencyManager } from '../../../src/core/dependency_managers/index.mjs'
 import {
   ChartManager,
-  ConfigManager,
   Helm,
   K8,
   PackageDownloader,
@@ -41,19 +37,39 @@ import {
   constants,
   KeyManager, Zippy
 } from '../../../src/core/index.mjs'
-import { ShellRunner } from '../../../src/core/shell_runner.mjs'
-import { getTestCacheDir, testLogger } from '../../test_util.js'
+import {
+  bootstrapNetwork,
+  getDefaultArgv,
+  getTestCacheDir,
+  getTestConfigManager,
+  TEST_CLUSTER,
+  testLogger
+} from '../../test_util.js'
 import { AccountManager } from '../../../src/core/account_manager.mjs'
-import { sleep } from '../../../src/core/helpers.mjs'
 
 describe.each([
   ['v0.42.5', constants.KEY_FORMAT_PFX]
   // ['v0.47.0-alpha.0', constants.KEY_FORMAT_PFX],
   // ['v0.47.0-alpha.0', constants.KEY_FORMAT_PEM]
 ])('NodeCommand', (testRelease, testKeyFormat) => {
+  const testName = 'node-cmd-e2e'
+  const namespace = testName
   const helm = new Helm(testLogger)
   const chartManager = new ChartManager(helm, testLogger)
-  const configManager = new ConfigManager(testLogger, path.join(getTestCacheDir(), 'solo.config'))
+  const configManager = getTestConfigManager(`${testName}-solo.config`)
+  const cacheDir = getTestCacheDir(testName)
+
+  // set argv with defaults
+  const argv = getDefaultArgv()
+  argv[flags.releaseTag.name] = testRelease
+  argv[flags.keyFormat.name] = testKeyFormat
+  argv[flags.nodeIDs.name] = 'node0,node1,node2'
+  argv[flags.cacheDir.name] = cacheDir
+  argv[flags.generateGossipKeys.name] = false
+  argv[flags.generateTlsKeys.name] = true
+  argv[flags.clusterName.name] = TEST_CLUSTER
+  argv[flags.namespace.name] = namespace
+  argv[flags.fstChartVersion.name] = 'v0.22.0'
 
   // prepare dependency manger registry
   const downloader = new PackageDownloader(testLogger)
@@ -67,7 +83,7 @@ describe.each([
   const keyManager = new KeyManager(testLogger)
   const accountManager = new AccountManager(testLogger, k8, constants)
 
-  const nodeCmd = new NodeCommand({
+  const opts = {
     logger: testLogger,
     helm,
     k8,
@@ -78,151 +94,60 @@ describe.each([
     depManager,
     keyManager,
     accountManager
+  }
+  const nodeCmd = new NodeCommand(opts)
+  const initCmd = new InitCommand(opts)
+  const clusterCmd = new ClusterCommand(opts)
+  const networkCmd = new NetworkCommand(opts)
+
+  beforeAll(async () => {
+    configManager.update(argv)
   })
 
-  const cacheDir = getTestCacheDir()
+  afterAll(async () => {
+    await k8.deleteNamespace(namespace)
+    await accountManager.close()
+  })
 
-  describe(`node start should succeed [release ${testRelease}, keyFormat: ${testKeyFormat}]`, () => {
-    const argv = {}
-    argv[flags.releaseTag.name] = testRelease
-    argv[flags.keyFormat.name] = testKeyFormat
-    argv[flags.nodeIDs.name] = 'node0,node1,node2'
-    argv[flags.cacheDir.name] = cacheDir
-    argv[flags.force.name] = false
-    argv[flags.chainId.name] = constants.HEDERA_CHAIN_ID
-    argv[flags.generateGossipKeys.name] = false
-    argv[flags.generateTlsKeys.name] = true
-    argv[flags.applicationProperties.name] = flags.applicationProperties.definition.defaultValue
-    argv[flags.apiPermissionProperties.name] = flags.apiPermissionProperties.definition.defaultValue
-    argv[flags.bootstrapProperties.name] = flags.bootstrapProperties.definition.defaultValue
-    argv[flags.settingTxt.name] = flags.settingTxt.definition.defaultValue
-    argv[flags.log4j2Xml.name] = flags.log4j2Xml.definition.defaultValue
-    argv[flags.namespace.name] = 'solo-e2e'
-    argv[flags.clusterName.name] = 'kind-solo-e2e'
-    argv[flags.clusterSetupNamespace.name] = 'solo-e2e-cluster'
-    argv[flags.updateAccountKeys.name] = true
-    argv[flags.fstChartVersion.name] = flags.fstChartVersion.definition.defaultValue
-    argv[flags.deployHederaExplorer.name] = true
-    argv[flags.deployMirrorNode.name] = true
-    configManager.update(argv)
-    const nodeIds = argv[flags.nodeIDs.name].split(',')
+  describe(`Node should start successfully [release ${testRelease}, keyFormat: ${testKeyFormat}]`, () => {
+    bootstrapNetwork(argv, namespace, k8, initCmd, clusterCmd, networkCmd, nodeCmd)
 
-    afterEach(async () => {
-      await sleep(5) // give a few ticks so that connections can close
-    })
+    it('Balance query should succeed', async () => {
+      expect.assertions(2)
 
-    it('should pre-generate keys', async () => {
-      if (argv[flags.keyFormat.name] === constants.KEY_FORMAT_PFX) {
-        const shellRunner = new ShellRunner(testLogger)
-        await shellRunner.run(`test/scripts/gen-legacy-keys.sh ${nodeIds.join(',')} ${path.join(cacheDir, 'keys')}`)
-      }
-    }, 60000)
-
-    it('node setup should succeed', async () => {
-      expect.assertions(1)
       try {
-        await expect(nodeCmd.setup(argv)).resolves.toBeTruthy()
+        await accountManager.loadNodeClient(namespace)
+        expect(accountManager._nodeClient).not.toBeNull()
+
+        const balance = await new AccountBalanceQuery()
+          .setAccountId(accountManager._nodeClient.getOperator().accountId)
+          .execute(accountManager._nodeClient)
+
+        expect(balance.hbars).not.toBeNull()
       } catch (e) {
         nodeCmd.logger.showUserError(e)
         expect(e).toBeNull()
       }
-    }, 60000)
+    }, 120000)
 
-    it('node start should succeed', async () => {
-      expect.assertions(1)
+    it('Account creation should succeed', async () => {
+      expect.assertions(2)
+
       try {
-        await expect(nodeCmd.start(argv)).resolves.toBeTruthy()
-      } catch (e) {
-        nodeCmd.logger.showUserError(e)
-        expect(e).toBeNull()
-      }
-    }, 600000)
+        expect(accountManager._nodeClient).not.toBeNull()
+        const accountKey = PrivateKey.generate()
 
-    describe('only genesis account should have genesis key for all special accounts', () => {
-      const genesisKey = PrivateKey.fromStringED25519(constants.GENESIS_KEY)
-      const realm = constants.HEDERA_NODE_ACCOUNT_ID_START.realm
-      const shard = constants.HEDERA_NODE_ACCOUNT_ID_START.shard
+        let transaction = await new AccountCreateTransaction()
+          .setNodeAccountIds([constants.HEDERA_NODE_ACCOUNT_ID_START])
+          .setInitialBalance(new Hbar(0))
+          .setKey(accountKey.publicKey)
+          .freezeWith(accountManager._nodeClient)
 
-      beforeAll(async () => {
-        await accountManager.loadNodeClient(argv[flags.namespace.name])
-      })
+        transaction = await transaction.sign(accountKey)
+        const response = await transaction.execute(accountManager._nodeClient)
+        const receipt = await response.getReceipt(accountManager._nodeClient)
 
-      afterAll(async () => {
-        await accountManager.close()
-        await sleep(5000) // sometimes takes a while to close all sockets
-      }, 10000)
-
-      for (const [start, end] of constants.SYSTEM_ACCOUNTS) {
-        for (let i = start; i <= end; i++) {
-          it(`special account ${i} should not have genesis key`, async () => {
-            expect(accountManager._nodeClient).not.toBeNull()
-
-            const accountId = `${realm}.${shard}.${i}`
-            nodeCmd.logger.info(`getAccountKeys: accountId ${accountId}`)
-            const keys = await accountManager.getAccountKeys(accountId)
-
-            expect(keys[0].toString()).not.toEqual(genesisKey.toString())
-          }, 60000)
-        }
-      }
-    })
-
-    describe('use the node client to interact with the Hedera network', () => {
-      beforeAll(async () => {
-        await accountManager.loadNodeClient(argv[flags.namespace.name])
-      })
-
-      afterAll(async () => {
-        await accountManager.close()
-        await sleep(5000) // sometimes takes a while to close all sockets
-      }, 10000)
-
-      it('balance query should succeed', async () => {
-        expect.assertions(2)
-
-        try {
-          expect(accountManager._nodeClient).not.toBeNull()
-
-          const balance = await new AccountBalanceQuery()
-            .setAccountId(accountManager._nodeClient.getOperator().accountId)
-            .execute(accountManager._nodeClient)
-
-          expect(balance.hbars).not.toBeNull()
-        } catch (e) {
-          nodeCmd.logger.showUserError(e)
-          expect(e).toBeNull()
-        }
-      }, 20000)
-
-      it('account creation should succeed', async () => {
-        expect.assertions(2)
-
-        try {
-          expect(accountManager._nodeClient).not.toBeNull()
-          const accountKey = PrivateKey.generate()
-
-          let transaction = await new AccountCreateTransaction()
-            .setNodeAccountIds([constants.HEDERA_NODE_ACCOUNT_ID_START])
-            .setInitialBalance(new Hbar(0))
-            .setKey(accountKey.publicKey)
-            .freezeWith(accountManager._nodeClient)
-
-          transaction = await transaction.sign(accountKey)
-          const response = await transaction.execute(accountManager._nodeClient)
-          const receipt = await response.getReceipt(accountManager._nodeClient)
-
-          expect(receipt.accountId).not.toBeNull()
-        } catch (e) {
-          nodeCmd.logger.showUserError(e)
-          expect(e).toBeNull()
-        }
-      }, 20000)
-    })
-
-    it('checkNetworkNodeProxyUp should succeed', async () => {
-      expect.assertions(1)
-      try {
-        await expect(nodeCmd.checkNetworkNodeProxyUp('solo-e2e', 'node0')).resolves.toBeTruthy()
+        expect(receipt.accountId).not.toBeNull()
       } catch (e) {
         nodeCmd.logger.showUserError(e)
         expect(e).toBeNull()

--- a/test/e2e/commands/02_account.test.mjs
+++ b/test/e2e/commands/02_account.test.mjs
@@ -16,7 +16,7 @@
  */
 import { PrivateKey } from '@hashgraph/sdk'
 import {
-  afterAll,
+  afterAll, beforeAll,
   describe,
   expect,
   it
@@ -63,6 +63,7 @@ argv[flags.generateTlsKeys.name] = true
 argv[flags.clusterName.name] = TEST_CLUSTER
 argv[flags.namespace.name] = namespace
 argv[flags.fstChartVersion.name] = version.FST_CHART_VERSION
+// argv[flags.chartDirectory.name] = '../full-stack-testing/charts'
 configManager.update(argv)
 
 // prepare dependency manger registry
@@ -110,9 +111,9 @@ describe('AccountCommand', () => {
 
   describe('node proxies should be UP', () => {
     for (const nodeId of argv[flags.nodeIDs.name].split(',')) {
-      it(`proxy for node ${nodeId} should be UP`, async () => {
-        await nodeCmd.checkNetworkNodeProxyUp(namespace, nodeId, 10)
-      })
+      it(`proxy should be UP: ${nodeId} `, async () => {
+        await nodeCmd.checkNetworkNodeProxyUp(namespace, nodeId)
+      }, 30000)
     }
   })
 
@@ -126,6 +127,14 @@ describe('AccountCommand', () => {
       const genesisKey = PrivateKey.fromStringED25519(constants.GENESIS_KEY)
       const realm = constants.HEDERA_NODE_ACCOUNT_ID_START.realm
       const shard = constants.HEDERA_NODE_ACCOUNT_ID_START.shard
+
+      beforeAll(async () => {
+        await accountManager.loadNodeClient(namespace)
+      })
+
+      afterAll(async () => {
+        await accountManager.close()
+      })
 
       for (const [start, end] of testSystemAccounts) {
         for (let i = start; i <= end; i++) {

--- a/test/e2e/commands/02_account.test.mjs
+++ b/test/e2e/commands/02_account.test.mjs
@@ -32,6 +32,7 @@ import {
   Helm,
   K8, KeyManager, PackageDownloader, PlatformInstaller, Zippy
 } from '../../../src/core/index.mjs'
+import * as version from '../../../version.mjs'
 import {
   bootstrapNetwork,
   getDefaultArgv,
@@ -61,7 +62,7 @@ argv[flags.generateGossipKeys.name] = true
 argv[flags.generateTlsKeys.name] = true
 argv[flags.clusterName.name] = TEST_CLUSTER
 argv[flags.namespace.name] = namespace
-argv[flags.fstChartVersion.name] = 'v0.22.0'
+argv[flags.fstChartVersion.name] = version.FST_CHART_VERSION
 configManager.update(argv)
 
 // prepare dependency manger registry

--- a/test/e2e/core/account_manager.test.mjs
+++ b/test/e2e/core/account_manager.test.mjs
@@ -1,0 +1,75 @@
+/**
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the ""License"");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an ""AS IS"" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import { describe, expect, it } from '@jest/globals'
+import path from 'path'
+import { flags } from '../../../src/commands/index.mjs'
+import { AccountManager } from '../../../src/core/account_manager.mjs'
+import { ConfigManager, constants, K8 } from '../../../src/core/index.mjs'
+import { getTestCacheDir, testLogger } from '../../test_util.js'
+
+describe('AccountManager', () => {
+  const configManager = new ConfigManager(testLogger, path.join(getTestCacheDir('accountCmd'), 'solo.config'))
+  configManager.setFlag(flags.namespace, 'solo-e2e')
+
+  const k8 = new K8(configManager, testLogger)
+  const accountManager = new AccountManager(testLogger, k8, constants)
+
+  it('should be able to stop port forwards', async () => {
+    const podNames = new Map()
+      .set('network-node0-svc', 20111)
+      .set('network-node1-svc', 30111)
+    const podPort = 50111
+    const localHost = '127.0.0.1'
+
+    expect(accountManager._portForwards.length).toStrictEqual(0)
+
+    // ports should be opened
+    for (const entry of podNames) {
+      const podName = entry[0]
+      const localPort = entry[1]
+      accountManager._portForwards.push(await k8.portForward(podName, localPort, podPort))
+      await expect(accountManager.testConnection(podName, localHost, localPort)).resolves.toBeTruthy()
+    }
+
+    await accountManager._stopPortForwards()
+
+    // ports should be closed
+    for (const entry of podNames) {
+      const podName = entry[0]
+      const localPort = entry[1]
+      await expect(accountManager.testConnection(podName, localHost, localPort)).rejects
+    }
+
+    expect(accountManager._portForwards.length).toStrictEqual(0)
+  })
+
+  it('should be able to update special account keys', async () => {
+    const resultTracker = {
+      rejectedCount: 0,
+      fulfilledCount: 0,
+      skippedCount: 0
+    }
+    const accountsBatchedSet = accountManager.batchAccounts()
+    const namespace = configManager.getFlag(flags.namespace)
+    await accountManager.loadNodeClient(namespace)
+    for (let i = 0; i < 3; i++) {
+      const currentSet = accountsBatchedSet[i]
+      await accountManager.updateSpecialAccountsKeys(namespace, currentSet, true, resultTracker)
+    }
+    await accountManager.close()
+  }, 120000)
+})

--- a/test/e2e/core/account_manager.test.mjs
+++ b/test/e2e/core/account_manager.test.mjs
@@ -29,9 +29,9 @@ describe('AccountManager', () => {
   const accountManager = new AccountManager(testLogger, k8, constants)
 
   it('should be able to stop port forwards', async () => {
+    expect.assertions(4)
     const localHost = '127.0.0.1'
 
-    // map of svc -> local port
     const podName = 'minio-console' // use a svc that is less likely to be used by other tests
     const podPort = 9090
     const localPort = 19090
@@ -40,11 +40,17 @@ describe('AccountManager', () => {
 
     // ports should be opened
     accountManager._portForwards.push(await k8.portForward(podName, localPort, podPort))
-    await expect(accountManager.testConnection(podName, localHost, localPort)).resolves.toBeTruthy()
+    const status = await accountManager.testConnection(podName, localHost, localPort)
+    expect(status).toBeTruthy()
 
     // ports should be closed
     await accountManager.close()
-    await expect(accountManager.testConnection(podName, localHost, localPort)).rejects
+    try {
+      await accountManager.testConnection(podName, localHost, localPort)
+    } catch (e) {
+      expect(e.message.includes(`failed to connect to '${localHost}:${localPort}'`)).toBeTruthy()
+    }
+
     expect(accountManager._portForwards.length).toStrictEqual(0)
   })
 })

--- a/test/e2e/core/k8_e2e.test.mjs
+++ b/test/e2e/core/k8_e2e.test.mjs
@@ -111,13 +111,13 @@ describe('K8', () => {
       const client = new net.Socket()
       client.on('ready', () => {
         client.destroy()
-        server.close()
+        k8.stopPortForward(server)
         done()
       })
 
       client.on('error', (e) => {
         client.destroy()
-        server.close()
+        k8.stopPortForward(server)
         done(new FullstackTestingError(`could not connect to local port '${localPort}': ${e.message}`, e))
       })
 

--- a/test/e2e/core/k8_e2e.test.mjs
+++ b/test/e2e/core/k8_e2e.test.mjs
@@ -109,15 +109,15 @@ describe('K8', () => {
 
       // client
       const s = new net.Socket()
-      s.on('ready', () => {
+      s.on('ready', async () => {
         s.destroy()
-        k8.stopPortForward(server)
+        await k8.stopPortForward(server)
         done()
       })
 
-      s.on('error', (e) => {
+      s.on('error', async (e) => {
         s.destroy()
-        k8.stopPortForward(server)
+        await k8.stopPortForward(server)
         done(new FullstackTestingError(`could not connect to local port '${localPort}': ${e.message}`, e))
       })
 

--- a/test/e2e/core/k8_e2e.test.mjs
+++ b/test/e2e/core/k8_e2e.test.mjs
@@ -108,20 +108,20 @@ describe('K8', () => {
       expect(server).not.toBeNull()
 
       // client
-      const client = new net.Socket()
-      client.on('ready', () => {
-        client.destroy()
+      const s = new net.Socket()
+      s.on('ready', () => {
+        s.destroy()
         k8.stopPortForward(server)
         done()
       })
 
-      client.on('error', (e) => {
-        client.destroy()
+      s.on('error', (e) => {
+        s.destroy()
         k8.stopPortForward(server)
         done(new FullstackTestingError(`could not connect to local port '${localPort}': ${e.message}`, e))
       })
 
-      client.connect(localPort)
+      s.connect(localPort)
     })
   })
 

--- a/test/e2e/setup-e2e.sh
+++ b/test/e2e/setup-e2e.sh
@@ -6,6 +6,7 @@ SOLO_NAMESPACE=solo-e2e
 SOLO_CLUSTER_SETUP_NAMESPACE=solo-e2e-cluster
 kind delete cluster -n "${SOLO_CLUSTER_NAME}" || true
 kind create cluster -n "${SOLO_CLUSTER_NAME}" --image "${KIND_IMAGE}" || exit 1
-solo init --namespace "${SOLO_NAMESPACE}" -i node0,node1,node2 -t v0.42.5 -s "${SOLO_CLUSTER_SETUP_NAMESPACE}" || exit 1 # cache args for subsequent commands
+solo init --namespace "${SOLO_NAMESPACE}" -i node0,node1,node2 -t v0.42.5 -s "${SOLO_CLUSTER_SETUP_NAMESPACE}" --fst-chart-version v0.22.0 --dev || exit 1 # cache args for subsequent commands
 solo cluster setup  || exit 1
 solo network deploy || exit 1
+helm list --all-namespaces

--- a/test/e2e/setup-e2e.sh
+++ b/test/e2e/setup-e2e.sh
@@ -7,11 +7,19 @@ SOLO_CLUSTER_SETUP_NAMESPACE=fullstack-setup
 kind delete cluster -n "${SOLO_CLUSTER_NAME}" || true
 kind create cluster -n "${SOLO_CLUSTER_NAME}" --image "${KIND_IMAGE}" || exit 1
 
-# Warm up the cluster
-# We deploy network once to have the cluster loaded with the images so that during test network deployment is faster
+# **********************************************************************************************************************
+# Warm up the cluster by deploying the network
+# This also helps to have the cluster loaded with the images.
+# Most of the e2e test should bootstrap its own network in its own namespace. However, some tests can use this as a
+# shared resource if required.
+# **********************************************************************************************************************
 solo init --namespace "${SOLO_NAMESPACE}" -i node0,node1,node2 -t v0.42.5 -s "${SOLO_CLUSTER_SETUP_NAMESPACE}" --fst-chart-version v0.22.0 --dev || exit 1 # cache args for subsequent commands
 solo cluster setup  || exit 1
 helm list --all-namespaces
 solo network deploy || exit 1
-kubectl delete ns "${SOLO_NAMESPACE}"
-kubectl delete ns "${SOLO_CLUSTER_SETUP_NAMESPACE}"
+
+# **********************************************************************************************************************
+# Don't delete the namespaces as some e2e tests (i.e. test/e2e/core/*.test.mjs) still uses it as shared resources.
+# **********************************************************************************************************************
+# kubectl delete ns "${SOLO_NAMESPACE}"v
+# kubectl delete ns "${SOLO_CLUSTER_SETUP_NAMESPACE}"

--- a/test/e2e/setup-e2e.sh
+++ b/test/e2e/setup-e2e.sh
@@ -3,10 +3,15 @@ readonly KIND_IMAGE="kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23
 
 SOLO_CLUSTER_NAME=solo-e2e
 SOLO_NAMESPACE=solo-e2e
-SOLO_CLUSTER_SETUP_NAMESPACE=solo-e2e-cluster
+SOLO_CLUSTER_SETUP_NAMESPACE=fullstack-setup
 kind delete cluster -n "${SOLO_CLUSTER_NAME}" || true
 kind create cluster -n "${SOLO_CLUSTER_NAME}" --image "${KIND_IMAGE}" || exit 1
+
+# Warm up the cluster
+# We deploy network once to have the cluster loaded with the images so that during test network deployment is faster
 solo init --namespace "${SOLO_NAMESPACE}" -i node0,node1,node2 -t v0.42.5 -s "${SOLO_CLUSTER_SETUP_NAMESPACE}" --fst-chart-version v0.22.0 --dev || exit 1 # cache args for subsequent commands
 solo cluster setup  || exit 1
-solo network deploy || exit 1
 helm list --all-namespaces
+solo network deploy || exit 1
+kubectl delete ns "${SOLO_NAMESPACE}"
+kubectl delete ns "${SOLO_CLUSTER_SETUP_NAMESPACE}"

--- a/test/test_util.js
+++ b/test/test_util.js
@@ -14,16 +14,20 @@
  * limitations under the License.
  *
  */
+import { describe, expect, it } from '@jest/globals'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
-import { logging } from '../src/core/index.mjs'
+import { flags } from '../src/commands/index.mjs'
+import { sleep } from '../src/core/helpers.mjs'
+import { ConfigManager, constants, logging } from '../src/core/index.mjs'
 
 export const testLogger = logging.NewLogger('debug')
+export const TEST_CLUSTER = 'solo-e2e'
 
-export function getTestCacheDir (appendDir) {
+export function getTestCacheDir (testName) {
   const baseDir = 'test/data/tmp'
-  const d = appendDir ? path.join(baseDir, appendDir) : baseDir
+  const d = testName ? path.join(baseDir, testName) : baseDir
 
   if (!fs.existsSync(d)) {
     fs.mkdirSync(d)
@@ -33,4 +37,80 @@ export function getTestCacheDir (appendDir) {
 
 export function getTmpDir () {
   return fs.mkdtempSync(path.join(os.tmpdir(), 'solo-'))
+}
+
+/**
+ * Return a config manager with the specified config file name
+ * @param fileName solo config file name
+ * @return {ConfigManager}
+ */
+export function getTestConfigManager (fileName = 'solo-test.config') {
+  return new ConfigManager(testLogger, path.join(getTestCacheDir(), fileName))
+}
+
+/**
+ * Get argv with defaults
+ */
+export function getDefaultArgv () {
+  const argv = {}
+  for (const f of flags.allFlags) {
+    argv[f.name] = f.definition.defaultValue
+  }
+  return argv
+}
+
+/**
+ * Bootstrap network in a given namespace
+ *
+ * @param argv argv for commands
+ * @param namespace namespace name
+ * @param k8 instance of K8
+ * @param initCmd instance of InitCommand
+ * @param clusterCmd instance of ClusterCommand
+ * @param networkCmd instance of NetworkCommand
+ * @param nodeCmd instance of NodeCommand
+ */
+export function bootstrapNetwork (argv, namespace, k8, initCmd, clusterCmd, networkCmd, nodeCmd) {
+  describe('Preconfigure network for test', () => {
+    it('should cleanup previous deployment', async () => {
+      await initCmd.init(argv)
+
+      if (await k8.hasNamespace(namespace)) {
+        await k8.deleteNamespace(namespace)
+
+        while (await k8.hasNamespace(namespace)) {
+          testLogger.debug(`Namespace ${namespace} still exist. Waiting...`)
+          await sleep(1500)
+        }
+      }
+
+      if (!await k8.hasNamespace(constants.FULLSTACK_SETUP_NAMESPACE)) {
+        await clusterCmd.setup(argv)
+      }
+    }, 60000)
+
+    it('should succeed with network deploy', async () => {
+      await networkCmd.deploy(argv)
+    }, 60000)
+
+    it('should succeed with node setup command', async () => {
+      expect.assertions(1)
+      try {
+        await expect(nodeCmd.setup(argv)).resolves.toBeTruthy()
+      } catch (e) {
+        nodeCmd.logger.showUserError(e)
+        expect(e).toBeNull()
+      }
+    }, 120000)
+
+    it('should succeed with node start command', async () => {
+      expect.assertions(1)
+      try {
+        await expect(nodeCmd.start(argv)).resolves.toBeTruthy()
+      } catch (e) {
+        nodeCmd.logger.showUserError(e)
+        expect(e).toBeNull()
+      }
+    }, 600000)
+  })
 }

--- a/test/test_util.js
+++ b/test/test_util.js
@@ -71,7 +71,7 @@ export function getDefaultArgv () {
  * @param nodeCmd instance of NodeCommand
  */
 export function bootstrapNetwork (argv, namespace, k8, initCmd, clusterCmd, networkCmd, nodeCmd) {
-  describe('Preconfigure network for test', () => {
+  describe('Bootstrap network for test', () => {
     it('should cleanup previous deployment', async () => {
       await initCmd.init(argv)
 


### PR DESCRIPTION
## Description

This pull request changes the following:

* Isolate account initialization and mirror node setup from node command
* Remove unnecessary socket cleanup code (`_stopPortForwards`) as the actual issue was with hedera-sdk-js:
     * See: https://github.com/hashgraph/hedera-sdk-js/issues/2194
* Make node-command and account-command e2e tests independent from each other (i.e. use separate namespaces)
* Remove unused function `resetHapiDirectories` to avoid test errors: https://github.com/hashgraph/solo/issues/151

### Related Issues
* Closes #143 
* Closes #116 
* Closes #153 
* Closes #165 
* Closes #151 

### Todo:
* https://github.com/hashgraph/solo/issues/168
* https://github.com/hashgraph/solo/issues/169