### PR TITLE
fix: use FST chart version v0.23.0

### DIFF
--- a/version.mjs
+++ b/version.mjs
@@ -20,4 +20,4 @@
  */
 
 export const HELM_VERSION = 'v3.14.2'
-export const FST_CHART_VERSION = 'v0.22.0'
+export const FST_CHART_VERSION = 'v0.23.0'


### PR DESCRIPTION
## Description

This pull request changes the following:

* use FST chart version v0.23.0

### Related Issues

* Closes #
