### PR TITLE
fix: update HAProxy UP check to use HAProxy Data Plane API

### DIFF
--- a/src/commands/node.mjs
+++ b/src/commands/node.mjs
@@ -656,7 +656,7 @@ export class NodeCommand extends BaseCommand {
           for (const nodeId of ctx.config.nodeIds) {
             subTasks.push({
               title: `Check proxy for node: ${chalk.yellow(nodeId)}`,
-              task: async () => await self.checkNetworkNodeProxyUp(ctx.config.namespace, nodeId, localPort++)
+              task: async () => await self.checkNetworkNodeProxyUp(nodeId, localPort++)
             })
           }
 
@@ -688,14 +688,13 @@ export class NodeCommand extends BaseCommand {
 
   /**
    * Check if the network node proxy is up, requires close() to be called after
-   * @param namespace the namespace
    * @param nodeId the node id
    * @param localPort the local port to forward to
    * @param maxAttempts the maximum number of attempts
    * @param delay the delay between attempts
    * @returns {Promise<boolean>} true if the proxy is up
    */
-  async checkNetworkNodeProxyUp (namespace, nodeId, localPort, maxAttempts = 10, delay = 5000) {
+  async checkNetworkNodeProxyUp (nodeId, localPort, maxAttempts = 10, delay = 5000) {
     const podArray = await this.k8.getPodsByLabel([`app=haproxy-${nodeId}`, 'fullstack.hedera.com/type=haproxy'])
 
     let attempts = 0

--- a/src/commands/node.mjs
+++ b/src/commands/node.mjs
@@ -696,12 +696,12 @@ export class NodeCommand extends BaseCommand {
    * @returns {Promise<boolean>} true if the proxy is up
    */
   async checkNetworkNodeProxyUp (namespace, nodeId, localPort, maxAttempts = 10, delay = 5000) {
-    const podArray = await this.k8.getPodsByLabel(namespace, [`app=haproxy-${nodeId}`, 'fullstack.hedera.com/type=haproxy'])
+    const podArray = await this.k8.getPodsByLabel([`app=haproxy-${nodeId}`, 'fullstack.hedera.com/type=haproxy'])
 
     let attempts = 0
     if (podArray.length > 0) {
       const podName = podArray[0].metadata.name
-      this._portForwards.push(await this.k8.portForward(podName, localPort, 5555, namespace))
+      this._portForwards.push(await this.k8.portForward(podName, localPort, 5555))
       try {
         await this.k8.testConnection('localhost', localPort)
       } catch (e) {

--- a/src/commands/node.mjs
+++ b/src/commands/node.mjs
@@ -44,6 +44,21 @@ export class NodeCommand extends BaseCommand {
     this.keyManager = opts.keyManager
     this.accountManager = opts.accountManager
     this.keytoolDepManager = opts.keytoolDepManager
+    this._portForwards = []
+  }
+
+  /**
+   * stops and closes the port forwards
+   * @returns {Promise<void>}
+   */
+  async close () {
+    if (this._portForwards) {
+      for (const srv of this._portForwards) {
+        await this.k8.stopPortForward(srv)
+      }
+    }
+
+    this._portForwards = []
   }
 
   async checkNetworkNodePod (namespace, nodeId) {
@@ -637,10 +652,11 @@ export class NodeCommand extends BaseCommand {
         title: 'Check node proxies are ACTIVE',
         task: async (ctx, parentTask) => {
           const subTasks = []
+          let localPort = constants.LOCAL_NODE_PROXY_START_PORT
           for (const nodeId of ctx.config.nodeIds) {
             subTasks.push({
               title: `Check proxy for node: ${chalk.yellow(nodeId)}`,
-              task: async () => await self.checkNetworkNodeProxyUp(ctx.config.namespace, nodeId)
+              task: async () => await self.checkNetworkNodeProxyUp(ctx.config.namespace, nodeId, localPort++)
             })
           }
 
@@ -664,45 +680,48 @@ export class NodeCommand extends BaseCommand {
       throw new FullstackTestingError(`Error starting node: ${e.message}`, e)
     } finally {
       await self.accountManager.close()
+      await self.close()
     }
 
     return true
   }
 
-  async checkNetworkNodeProxyUp (namespace, nodeId, maxAttempts = 10, delay = 5000) {
-    const podArray = await this.k8.getPodsByLabel([`app=haproxy-${nodeId}`, 'fullstack.hedera.com/type=haproxy'])
+  /**
+   * Check if the network node proxy is up, requires close() to be called after
+   * @param namespace the namespace
+   * @param nodeId the node id
+   * @param localPort the local port to forward to
+   * @param maxAttempts the maximum number of attempts
+   * @param delay the delay between attempts
+   * @returns {Promise<boolean>} true if the proxy is up
+   */
+  async checkNetworkNodeProxyUp (namespace, nodeId, localPort, maxAttempts = 10, delay = 5000) {
+    const podArray = await this.k8.getPodsByLabel(namespace, [`app=haproxy-${nodeId}`, 'fullstack.hedera.com/type=haproxy'])
 
     let attempts = 0
     if (podArray.length > 0) {
       const podName = podArray[0].metadata.name
+      this._portForwards.push(await this.k8.portForward(podName, localPort, 5555, namespace))
+      try {
+        await this.k8.testConnection('localhost', localPort)
+      } catch (e) {
+        throw new FullstackTestingError(`failed to create port forward for '${nodeId}' proxy on port ${localPort}`, e)
+      }
 
       while (attempts < maxAttempts) {
-        const logResponse = await this.k8.kubeClient.readNamespacedPodLog(
-          podName,
-          namespace,
-          'haproxy',
-          undefined,
-          undefined,
-          1024,
-          undefined,
-          undefined,
-          undefined,
-          4
-        )
+        try {
+          const status = await this.getNodeProxyStatus(`http://localhost:${localPort}/v2/services/haproxy/stats/native?type=backend`)
+          if (status === 'UP') {
+            this.logger.debug(`Proxy ${podName} is UP. [attempt: ${attempts}/${maxAttempts}]`)
+            return true
+          }
 
-        if (logResponse.response.statusCode !== 200) {
-          throw new FullstackTestingError(`Expected pod ${podName} log query to execute successful, but instead got a status of ${logResponse.response.statusCode}`)
+          attempts++
+          this.logger.debug(`Proxy ${podName} is not UP. Checking again in ${delay}ms ... [attempt: ${attempts}/${maxAttempts}]`)
+          await sleep(delay)
+        } catch (e) {
+          throw new FullstackTestingError(`failed to create port forward for '${nodeId}' proxy on port ${localPort}`, e)
         }
-
-        this.logger.debug(`Received HAProxy log from ${podName}`, { output: logResponse.body })
-        if (logResponse.body.includes('Server be_servers/server1 is UP')) {
-          this.logger.debug(`Proxy ${podName} is UP [attempt: ${attempts}/${maxAttempts}]`)
-          return true
-        }
-
-        attempts++
-        this.logger.debug(`Proxy ${podName} is not UP. Checking again in ${delay}ms ... [attempt: ${attempts}/${maxAttempts}]`)
-        await sleep(delay)
       }
     }
 
@@ -965,6 +984,34 @@ export class NodeCommand extends BaseCommand {
           })
           .demandCommand(1, 'Select a node command')
       }
+    }
+  }
+
+  async getNodeProxyStatus (url) {
+    try {
+      this.logger.debug(`Fetching proxy status from: ${url}`)
+      const res = await fetch(url, {
+        method: 'GET',
+        signal: AbortSignal.timeout(5000),
+        headers: {
+          Authorization: `Basic ${Buffer.from(
+              `${constants.NODE_PROXY_USER_ID}:${constants.NODE_PROXY_PASSWORD}`).toString(
+              'base64')}`
+        }
+      })
+      const response = await res.json()
+
+      if (res.status === 200) {
+        const status = response[0]?.stats?.filter(
+          (stat) => stat.name === 'http_backend')[0]?.stats?.status
+        this.logger.debug(`Proxy status: ${status}`)
+        return status
+      } else {
+        this.logger.debug(`Proxy request status code: ${res.status}`)
+        return null
+      }
+    } catch (e) {
+      this.logger.error(`Error in fetching proxy status: ${e.message}`, e)
     }
   }
 }

--- a/src/core/constants.mjs
+++ b/src/core/constants.mjs
@@ -83,7 +83,10 @@ export const GENESIS_KEY = process.env.GENESIS_KEY || '302e020100300506032b65700
 export const SYSTEM_ACCOUNTS = [[3, 100], [200, 349], [400, 750], [900, 1000]] // do account 0.0.2 last and outside the loop
 export const TREASURY_ACCOUNT = 2
 export const LOCAL_NODE_START_PORT = process.env.LOCAL_NODE_START_PORT || 30212
+export const LOCAL_NODE_PROXY_START_PORT = process.env.LOCAL_NODE_PROXY_START_PORT || 30313
 export const ACCOUNT_CREATE_BATCH_SIZE = process.env.ACCOUNT_CREATE_BATCH_SIZE || 50
+export const NODE_PROXY_USER_ID = process.env.NODE_PROXY_USER_ID || 'admin'
+export const NODE_PROXY_PASSWORD = process.env.NODE_PROXY_PASSWORD || 'adminpwd'
 
 export const POD_STATUS_RUNNING = 'Running'
 export const POD_STATUS_READY = 'Ready'

--- a/src/core/k8.mjs
+++ b/src/core/k8.mjs
@@ -197,14 +197,14 @@ export class K8 {
 
   /**
    * Get pods by labels
-   * @param namespace the namespace of the pods
    * @param labels list of labels
    * @return {Promise<Array<V1Pod>>}
    */
-  async getPodsByLabel (namespace, labels = []) {
+  async getPodsByLabel (labels = []) {
+    const ns = this._getNamespace()
     const labelSelector = labels.join(',')
     const result = await this.kubeClient.listNamespacedPod(
-      namespace,
+      ns,
       undefined,
       undefined,
       undefined,
@@ -661,10 +661,9 @@ export class K8 {
    * @param podName pod name
    * @param localPort local port
    * @param podPort port of the pod
-   * @param namespace namespace of the pod (optional)
    */
-  async portForward (podName, localPort, podPort, namespace = null) {
-    const ns = namespace || this._getNamespace()
+  async portForward (podName, localPort, podPort) {
+    const ns = this._getNamespace()
     const forwarder = new k8s.PortForward(this.kubeConfig, false)
     const server = await net.createServer((socket) => {
       forwarder.portForward(ns, podName, [podPort], socket, null, socket, 3)

--- a/test/e2e/commands/01_node.test.mjs
+++ b/test/e2e/commands/01_node.test.mjs
@@ -97,5 +97,18 @@ describe.each([
         expect(e).toBeNull()
       }
     }, 20000)
+
+    it('Node Proxy should be UP', async () => {
+      expect.assertions(1)
+
+      try {
+        await expect(nodeCmd.checkNetworkNodeProxyUp(namespace, 'node0', 30313)).resolves.toBeTruthy()
+      } catch (e) {
+        nodeCmd.logger.showUserError(e)
+        expect(e).toBeNull()
+      } finally {
+        await nodeCmd.close()
+      }
+    }, 20000)
   })
 })

--- a/test/e2e/commands/01_node.test.mjs
+++ b/test/e2e/commands/01_node.test.mjs
@@ -102,7 +102,7 @@ describe.each([
       expect.assertions(1)
 
       try {
-        await expect(nodeCmd.checkNetworkNodeProxyUp(namespace, 'node0', 30313)).resolves.toBeTruthy()
+        await expect(nodeCmd.checkNetworkNodeProxyUp('node0', 30313)).resolves.toBeTruthy()
       } catch (e) {
         nodeCmd.logger.showUserError(e)
         expect(e).toBeNull()

--- a/test/e2e/commands/02_account.test.mjs
+++ b/test/e2e/commands/02_account.test.mjs
@@ -63,7 +63,7 @@ describe('AccountCommand', () => {
   describe('node proxies should be UP', () => {
     for (const nodeId of argv[flags.nodeIDs.name].split(',')) {
       it(`proxy should be UP: ${nodeId} `, async () => {
-        await nodeCmd.checkNetworkNodeProxyUp(namespace, nodeId)
+        await nodeCmd.checkNetworkNodeProxyUp(namespace, nodeId, 30399)
       }, 30000)
     }
   })

--- a/test/e2e/commands/02_account.test.mjs
+++ b/test/e2e/commands/02_account.test.mjs
@@ -64,7 +64,7 @@ describe('AccountCommand', () => {
     let localPort = 30399
     for (const nodeId of argv[flags.nodeIDs.name].split(',')) {
       it(`proxy should be UP: ${nodeId} `, async () => {
-        await nodeCmd.checkNetworkNodeProxyUp(namespace, nodeId, localPort++)
+        await nodeCmd.checkNetworkNodeProxyUp(nodeId, localPort++)
       }, 30000)
     }
   })

--- a/test/e2e/commands/02_account.test.mjs
+++ b/test/e2e/commands/02_account.test.mjs
@@ -61,9 +61,10 @@ describe('AccountCommand', () => {
   })
 
   describe('node proxies should be UP', () => {
+    let localPort = 30399
     for (const nodeId of argv[flags.nodeIDs.name].split(',')) {
       it(`proxy should be UP: ${nodeId} `, async () => {
-        await nodeCmd.checkNetworkNodeProxyUp(namespace, nodeId, 30399)
+        await nodeCmd.checkNetworkNodeProxyUp(namespace, nodeId, localPort++)
       }, 30000)
     }
   })

--- a/test/e2e/core/account_manager.test.mjs
+++ b/test/e2e/core/account_manager.test.mjs
@@ -40,13 +40,13 @@ describe('AccountManager', () => {
 
     // ports should be opened
     accountManager._portForwards.push(await k8.portForward(podName, localPort, podPort))
-    const status = await accountManager.testConnection(podName, localHost, localPort)
+    const status = await k8.testConnection(localHost, localPort)
     expect(status).toBeTruthy()
 
     // ports should be closed
     await accountManager.close()
     try {
-      await accountManager.testConnection(podName, localHost, localPort)
+      await k8.testConnection(localHost, localPort)
     } catch (e) {
       expect(e.message.includes(`failed to connect to '${localHost}:${localPort}'`)).toBeTruthy()
     }

--- a/version.mjs
+++ b/version.mjs
@@ -21,4 +21,4 @@
 
 export const JAVA_VERSION = '21.0.1+12'
 export const HELM_VERSION = 'v3.14.2'
-export const FST_CHART_VERSION = 'v0.23.0'
+export const FST_CHART_VERSION = 'v0.24.0'


### PR DESCRIPTION
## Description

This pull request changes the following:

* update HAProxy UP check to use HAProxy Data Plane API

### Related Issues

* Closes #169
* Relates to https://github.com/hashgraph/full-stack-testing/pull/809
