### PR TITLE
feat: add node refresh subcommand

### DIFF
--- a/.github/workflows/flow-update-readme.yaml
+++ b/.github/workflows/flow-update-readme.yaml
@@ -93,7 +93,7 @@ jobs:
           export SOLO_NAMESPACE=solo
           export SOLO_CLUSTER_SETUP_NAMESPACE=solo-cluster
            
-          echo "Perform the followng kind and solo commands and save output to environment variables"
+          echo "Perform the following kind and solo commands and save output to environment variables"
           
           export KIND_CREATE_CLUSTER_OUTPUT=$( kind create cluster -n "${SOLO_CLUSTER_NAME}" 2>&1 | tee test.log )
           

--- a/src/core/helpers.mjs
+++ b/src/core/helpers.mjs
@@ -170,3 +170,10 @@ export function isNumeric (str) {
   return !isNaN(str) && // use type coercion to parse the _entirety_ of the string (`parseFloat` alone does not do this)...
     !isNaN(parseFloat(str)) // ...and ensure strings of whitespace fail
 }
+
+export function validatePath (input) {
+  if (input.indexOf('\0') !== -1) {
+    throw new FullstackTestingError(`access denied for path: ${input}`)
+  }
+  return input
+}

--- a/src/core/templates.mjs
+++ b/src/core/templates.mjs
@@ -159,4 +159,12 @@ export class Templates {
         throw new FullstackTestingError(`unknown dep: ${dep}`)
     }
   }
+
+  static renderFullyQualifiedNetworkPodName (namespace, nodeId) {
+    return `${Templates.renderNetworkPodName(nodeId)}.${Templates.renderNetworkSvcName(nodeId)}.${namespace}.svc.cluster.local`
+  }
+
+  static renderFullyQualifiedNetworkSvcName (namespace, nodeId) {
+    return `${Templates.renderNetworkSvcName(nodeId)}.${namespace}.svc.cluster.local`
+  }
 }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -51,7 +51,7 @@ export function main (argv) {
     const chartManager = new ChartManager(helm, logger)
     const configManager = new ConfigManager(logger)
     const k8 = new K8(configManager, logger)
-    const platformInstaller = new PlatformInstaller(logger, k8)
+    const platformInstaller = new PlatformInstaller(logger, k8, configManager)
     const keyManager = new KeyManager(logger)
     const accountManager = new AccountManager(logger, k8)
     const profileManager = new ProfileManager(logger, configManager)

--- a/test/e2e/commands/node.test.mjs
+++ b/test/e2e/commands/node.test.mjs
@@ -14,9 +14,16 @@
  * limitations under the License.
  *
  */
-import { AccountBalanceQuery, AccountCreateTransaction, Hbar, PrivateKey } from '@hashgraph/sdk'
+import {
+  AccountBalanceQuery,
+  AccountCreateTransaction,
+  Hbar,
+  HbarUnit,
+  PrivateKey
+} from '@hashgraph/sdk'
 import {
   afterAll,
+  beforeAll,
   describe,
   expect,
   it
@@ -28,12 +35,14 @@ import {
 import {
   bootstrapNetwork,
   getDefaultArgv,
+  getTestConfigManager,
   TEST_CLUSTER
 } from '../../test_util.js'
+import { sleep } from '../../../src/core/helpers.mjs'
 
 describe.each([
-  { releaseTag: 'v0.47.0-alpha.0', keyFormat: constants.KEY_FORMAT_PFX, testName: 'node-cmd-e2e-pfx' },
-  { releaseTag: 'v0.47.0-alpha.0', keyFormat: constants.KEY_FORMAT_PEM, testName: 'node-cmd-e2e-pem' }
+  { releaseTag: 'v0.49.0-alpha.2', keyFormat: constants.KEY_FORMAT_PFX, testName: 'node-cmd-e2e-pfx', mode: 'kill' },
+  { releaseTag: 'v0.49.0-alpha.2', keyFormat: constants.KEY_FORMAT_PEM, testName: 'node-cmd-e2e-pem', mode: 'stop' }
 ])('NodeCommand', (input) => {
   const testName = input.testName
   const namespace = testName
@@ -41,7 +50,7 @@ describe.each([
   argv[flags.namespace.name] = namespace
   argv[flags.releaseTag.name] = input.releaseTag
   argv[flags.keyFormat.name] = input.keyFormat
-  argv[flags.nodeIDs.name] = 'node0,node1,node2'
+  argv[flags.nodeIDs.name] = 'node0,node1,node2,node3'
   argv[flags.generateGossipKeys.name] = true
   argv[flags.generateTlsKeys.name] = true
   argv[flags.clusterName.name] = TEST_CLUSTER
@@ -55,54 +64,16 @@ describe.each([
     await accountManager.close()
   })
 
-  describe(`Node should start successfully [release ${input.keyFormat}, keyFormat: ${input.releaseTag}]`, () => {
-    it('Balance query should succeed', async () => {
-      expect.assertions(2)
+  describe(`Node should start successfully [release ${input.releaseTag}, keyFormat: ${input.keyFormat}]`, () => {
+    balanceQueryShouldSucceed(accountManager, nodeCmd, namespace)
 
-      try {
-        await accountManager.loadNodeClient(namespace)
-        expect(accountManager._nodeClient).not.toBeNull()
-
-        const balance = await new AccountBalanceQuery()
-          .setAccountId(accountManager._nodeClient.getOperator().accountId)
-          .execute(accountManager._nodeClient)
-
-        expect(balance.hbars).not.toBeNull()
-      } catch (e) {
-        nodeCmd.logger.showUserError(e)
-        expect(e).toBeNull()
-      }
-    }, 120000)
-
-    it('Account creation should succeed', async () => {
-      expect.assertions(2)
-
-      try {
-        expect(accountManager._nodeClient).not.toBeNull()
-        const accountKey = PrivateKey.generate()
-
-        let transaction = await new AccountCreateTransaction()
-          .setNodeAccountIds([constants.HEDERA_NODE_ACCOUNT_ID_START])
-          .setInitialBalance(new Hbar(0))
-          .setKey(accountKey.publicKey)
-          .freezeWith(accountManager._nodeClient)
-
-        transaction = await transaction.sign(accountKey)
-        const response = await transaction.execute(accountManager._nodeClient)
-        const receipt = await response.getReceipt(accountManager._nodeClient)
-
-        expect(receipt.accountId).not.toBeNull()
-      } catch (e) {
-        nodeCmd.logger.showUserError(e)
-        expect(e).toBeNull()
-      }
-    }, 20000)
+    accountCreationShouldSucceed(accountManager, nodeCmd, namespace)
 
     it('Node Proxy should be UP', async () => {
       expect.assertions(1)
 
       try {
-        await expect(nodeCmd.checkNetworkNodeProxyUp('node0', 30313)).resolves.toBeTruthy()
+        await expect(nodeCmd.checkNetworkNodeProxyUp('node0', 30399)).resolves.toBeTruthy()
       } catch (e) {
         nodeCmd.logger.showUserError(e)
         expect(e).toBeNull()
@@ -111,4 +82,142 @@ describe.each([
       }
     }, 20000)
   })
+
+  describe(`Node should refresh successfully [mode ${input.mode}, release ${input.releaseTag}, keyFormat: ${input.keyFormat}]`, () => {
+    const nodeId = 'node0'
+
+    beforeAll(async () => {
+      const podName = await nodeRefreshTestSetup(argv, testName, k8, nodeId)
+      if (input.mode === 'kill') {
+        const resp = await k8.kubeClient.deleteNamespacedPod(podName, namespace)
+        expect(resp.response.statusCode).toEqual(200)
+        await sleep(20000) // sleep to wait for pod to finish terminating
+      } else if (input.mode === 'stop') {
+        await expect(nodeCmd.stop(argv)).resolves.toBeTruthy()
+      } else {
+        throw new Error(`invalid mode: ${input.mode}`)
+      }
+    }, 120000)
+
+    nodeShouldBeRunning(nodeCmd, namespace, nodeId)
+
+    nodeShouldNotBeActive(nodeCmd, nodeId)
+
+    nodeRefreshShouldSucceed(nodeId, nodeCmd, argv)
+
+    balanceQueryShouldSucceed(accountManager, nodeCmd, namespace)
+
+    accountCreationShouldSucceed(accountManager, nodeCmd, namespace)
+  })
 })
+
+function accountCreationShouldSucceed (accountManager, nodeCmd, namespace) {
+  it('Account creation should succeed', async () => {
+    expect.assertions(3)
+
+    try {
+      await accountManager.loadNodeClient(namespace)
+      expect(accountManager._nodeClient).not.toBeNull()
+      const privateKey = PrivateKey.generate()
+      const amount = 100
+
+      const newAccount = await new AccountCreateTransaction()
+        .setKey(privateKey)
+        .setInitialBalance(Hbar.from(amount, HbarUnit.Hbar))
+        .execute(accountManager._nodeClient)
+
+      // Get the new account ID
+      const getReceipt = await newAccount.getReceipt(accountManager._nodeClient)
+      const accountInfo = {
+        accountId: getReceipt.accountId.toString(),
+        privateKey: privateKey.toString(),
+        publicKey: privateKey.publicKey.toString(),
+        balance: amount
+      }
+
+      expect(accountInfo.accountId).not.toBeNull()
+      expect(accountInfo.balance).toEqual(amount)
+    } catch (e) {
+      nodeCmd.logger.showUserError(e)
+      expect(e).toBeNull()
+    }
+  }, 60000)
+}
+
+function balanceQueryShouldSucceed (accountManager, nodeCmd, namespace) {
+  it('Balance query should succeed', async () => {
+    expect.assertions(2)
+
+    try {
+      await accountManager.loadNodeClient(namespace)
+      expect(accountManager._nodeClient).not.toBeNull()
+
+      const balance = await new AccountBalanceQuery()
+        .setAccountId(accountManager._nodeClient.getOperator().accountId)
+        .execute(accountManager._nodeClient)
+
+      expect(balance.hbars).not.toBeNull()
+    } catch (e) {
+      nodeCmd.logger.showUserError(e)
+      expect(e).toBeNull()
+    }
+    await sleep(1000)
+  }, 20000)
+}
+
+function nodeShouldBeRunning (nodeCmd, namespace, nodeId) {
+  it(`${nodeId} should be running`, async () => {
+    try {
+      await expect(nodeCmd.checkNetworkNodePod(namespace, nodeId)).resolves.toBeTruthy()
+    } catch (e) {
+      nodeCmd.logger.showUserError(e)
+      expect(e).toBeNull()
+    } finally {
+      await nodeCmd.close()
+    }
+  }, 20000)
+}
+
+function nodeRefreshShouldSucceed (nodeId, nodeCmd, argv) {
+  it(`${nodeId} refresh should succeed`, async () => {
+    try {
+      await expect(nodeCmd.refresh(argv)).resolves.toBeTruthy()
+    } catch (e) {
+      nodeCmd.logger.showUserError(e)
+      expect(e).toBeNull()
+    } finally {
+      await nodeCmd.close()
+    }
+  }, 1200000)
+}
+
+function nodeShouldNotBeActive (nodeCmd, nodeId) {
+  it(`${nodeId} should not be ACTIVE`, async () => {
+    expect(2)
+    try {
+      await expect(nodeCmd.checkNetworkNodeStarted(nodeId, 5)).rejects.toThrowError()
+    } catch (e) {
+      nodeCmd.logger.showUserError(e)
+      expect(e).not.toBeNull()
+    } finally {
+      await nodeCmd.close()
+    }
+  }, 20000)
+}
+
+async function nodeRefreshTestSetup (argv, testName, k8, nodeId) {
+  argv[flags.nodeIDs.name] = nodeId
+  const configManager = getTestConfigManager(`${testName}-solo.config`)
+  configManager.update(argv, true)
+
+  const podArray = await k8.getPodsByLabel(
+    [`app=network-${nodeId}`, 'fullstack.hedera.com/type=network-node'])
+
+  if (podArray.length > 0) {
+    const podName = podArray[0].metadata.name
+    k8.logger.info(`nodeRefreshTestSetup: podName: ${podName}`)
+    return podName
+  } else {
+    throw new Error(`pod for ${nodeId} not found`)
+  }
+}

--- a/test/e2e/core/platform_installer_e2e.test.mjs
+++ b/test/e2e/core/platform_installer_e2e.test.mjs
@@ -29,7 +29,7 @@ import { getTestCacheDir, getTmpDir, testLogger } from '../../test_util.js'
 describe('PackageInstallerE2E', () => {
   const configManager = new ConfigManager(testLogger)
   const k8 = new K8(configManager, testLogger)
-  const installer = new PlatformInstaller(testLogger, k8)
+  const installer = new PlatformInstaller(testLogger, k8, configManager)
   const testCacheDir = getTestCacheDir()
   const podName = 'network-node0-0'
   const packageVersion = 'v0.42.5'

--- a/test/test_util.js
+++ b/test/test_util.js
@@ -113,7 +113,7 @@ export function bootstrapTestVariables (testName, argv,
   const helm = new Helm(testLogger)
   const chartManager = new ChartManager(helm, testLogger)
   const k8 = k8Arg || new K8(configManager, testLogger)
-  const platformInstaller = new PlatformInstaller(testLogger, k8)
+  const platformInstaller = new PlatformInstaller(testLogger, k8, configManager)
   const accountManager = new AccountManager(testLogger, k8, constants)
   const profileManager = new ProfileManager(testLogger, configManager)
   const opts = {

--- a/test/unit/core/platform_installer.test.mjs
+++ b/test/unit/core/platform_installer.test.mjs
@@ -28,7 +28,7 @@ describe('PackageInstaller', () => {
   const testLogger = core.logging.NewLogger('debug')
   const configManager = new ConfigManager(testLogger)
   const k8 = new core.K8(configManager, testLogger)
-  const installer = new PlatformInstaller(testLogger, k8)
+  const installer = new PlatformInstaller(testLogger, k8, configManager)
 
   describe('validatePlatformReleaseDir', () => {
     it('should fail for missing path', async () => {


### PR DESCRIPTION
## Description

This pull request changes the following:

* adds the `solo node refresh` subcommand

### Related Issues

* Closes #96 
* Depends on https://github.com/hashgraph/full-stack-testing/pull/815