### PR TITLE
feat: add node refresh subcommand

### DIFF
--- a/.github/workflows/flow-update-readme.yaml
+++ b/.github/workflows/flow-update-readme.yaml
@@ -93,7 +93,7 @@ jobs:
           export SOLO_NAMESPACE=solo
           export SOLO_CLUSTER_SETUP_NAMESPACE=solo-cluster
            
-          echo "Perform the followng kind and solo commands and save output to environment variables"
+          echo "Perform the following kind and solo commands and save output to environment variables"
           
           export KIND_CREATE_CLUSTER_OUTPUT=$( kind create cluster -n "${SOLO_CLUSTER_NAME}" 2>&1 | tee test.log )
           

--- a/README.md
+++ b/README.md
@@ -579,6 +579,6 @@ Contributions are welcome. Please see the [contributing guide](https://github.co
 This project is governed by the [Contributor Covenant Code of Conduct](https://github.com/hashgraph/.github/blob/main/CODE_OF_CONDUCT.md). By participating, you are
 expected to uphold this code of conduct.
 
-## License
+## License 
 
 [Apache License 2.0](LICENSE)

--- a/jest.config.mjs
+++ b/jest.config.mjs
@@ -21,7 +21,7 @@ const config = {
   testRegex: '(/__tests__/.*|(\\.|/)(test|spec))\\.(mjs?)$',
   moduleFileExtensions: ['js', 'mjs'],
   verbose: true,
-  reporters: ['default', 'jest-junit'],
+  reporters: [['default', { summaryThreshold: 1 }], 'jest-junit'],
   testSequencer: './test/testSequencer.mjs'
 }
 

--- a/src/core/helpers.mjs
+++ b/src/core/helpers.mjs
@@ -170,3 +170,10 @@ export function isNumeric (str) {
   return !isNaN(str) && // use type coercion to parse the _entirety_ of the string (`parseFloat` alone does not do this)...
     !isNaN(parseFloat(str)) // ...and ensure strings of whitespace fail
 }
+
+export function validatePath (input) {
+  if (input.indexOf('\0') !== -1) {
+    throw new FullstackTestingError(`access denied for path: ${input}`)
+  }
+  return input
+}

--- a/src/core/templates.mjs
+++ b/src/core/templates.mjs
@@ -159,4 +159,12 @@ export class Templates {
         throw new FullstackTestingError(`unknown dep: ${dep}`)
     }
   }
+
+  static renderFullyQualifiedNetworkPodName (namespace, nodeId) {
+    return `${Templates.renderNetworkPodName(nodeId)}.${Templates.renderNetworkSvcName(nodeId)}.${namespace}.svc.cluster.local`
+  }
+
+  static renderFullyQualifiedNetworkSvcName (namespace, nodeId) {
+    return `${Templates.renderNetworkSvcName(nodeId)}.${namespace}.svc.cluster.local`
+  }
 }

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -51,7 +51,7 @@ export function main (argv) {
     const chartManager = new ChartManager(helm, logger)
     const configManager = new ConfigManager(logger)
     const k8 = new K8(configManager, logger)
-    const platformInstaller = new PlatformInstaller(logger, k8)
+    const platformInstaller = new PlatformInstaller(logger, k8, configManager)
     const keyManager = new KeyManager(logger)
     const accountManager = new AccountManager(logger, k8)
     const profileManager = new ProfileManager(logger, configManager)

--- a/test/e2e/commands/account.test.mjs
+++ b/test/e2e/commands/account.test.mjs
@@ -58,6 +58,7 @@ describe('AccountCommand', () => {
   afterAll(async () => {
     await k8.deleteNamespace(namespace)
     await accountManager.close()
+    await nodeCmd.close()
   })
 
   describe('node proxies should be UP', () => {

--- a/test/e2e/commands/account.test.mjs
+++ b/test/e2e/commands/account.test.mjs
@@ -73,7 +73,7 @@ describe('AccountCommand', () => {
     it('should succeed with init command', async () => {
       const status = await accountCmd.init(argv)
       expect(status).toBeTruthy()
-    }, 120000)
+    }, 180000)
 
     describe('special accounts should have new keys', () => {
       const genesisKey = PrivateKey.fromStringED25519(constants.GENESIS_KEY)
@@ -121,7 +121,7 @@ describe('AccountCommand', () => {
         testLogger.showUserError(e)
         expect(e).toBeNull()
       }
-    }, defaultTimeout)
+    }, 40000)
 
     it('should create account with private key and hbar amount options', async () => {
       try {

--- a/test/e2e/commands/network.test.mjs
+++ b/test/e2e/commands/network.test.mjs
@@ -81,7 +81,7 @@ describe('NetworkCommand', () => {
       networkCmd.logger.showUserError(e)
       expect(e).toBeNull()
     }
-  }, 60000)
+  }, 120000)
 
   it('network destroy should success', async () => {
     argv[flags.deletePvcs.name] = true

--- a/test/e2e/commands/node.test.mjs
+++ b/test/e2e/commands/node.test.mjs
@@ -62,7 +62,7 @@ describe.each([
   afterAll(async () => {
     await k8.deleteNamespace(namespace)
     await accountManager.close()
-  })
+  }, 20000)
 
   describe(`Node should start successfully [release ${input.releaseTag}, keyFormat: ${input.keyFormat}]`, () => {
     balanceQueryShouldSucceed(accountManager, nodeCmd, namespace)
@@ -162,7 +162,7 @@ function balanceQueryShouldSucceed (accountManager, nodeCmd, namespace) {
       expect(e).toBeNull()
     }
     await sleep(1000)
-  }, 20000)
+  }, 40000)
 }
 
 function nodeShouldBeRunning (nodeCmd, namespace, nodeId) {

--- a/test/e2e/commands/node.test.mjs
+++ b/test/e2e/commands/node.test.mjs
@@ -147,9 +147,10 @@ function accountCreationShouldSucceed (accountManager, nodeCmd, namespace) {
 
 function balanceQueryShouldSucceed (accountManager, nodeCmd, namespace) {
   it('Balance query should succeed', async () => {
-    expect.assertions(2)
+    expect.assertions(3)
 
     try {
+      expect(accountManager._nodeClient).toBeNull()
       await accountManager.loadNodeClient(namespace)
       expect(accountManager._nodeClient).not.toBeNull()
 
@@ -188,6 +189,7 @@ function nodeRefreshShouldSucceed (nodeId, nodeCmd, argv) {
       expect(e).toBeNull()
     } finally {
       await nodeCmd.close()
+      await sleep(10000) // sleep to wait for node to finish starting
     }
   }, 1200000)
 }

--- a/test/e2e/commands/node.test.mjs
+++ b/test/e2e/commands/node.test.mjs
@@ -64,16 +64,16 @@ describe.each([
     await accountManager.close()
   }, 20000)
 
-  describe(`Node should start successfully [release ${input.releaseTag}, keyFormat: ${input.keyFormat}]`, () => {
+  describe(`Node should start successfully [mode ${input.mode}, release ${input.releaseTag}, keyFormat: ${input.keyFormat}]`, () => {
     balanceQueryShouldSucceed(accountManager, nodeCmd, namespace)
 
     accountCreationShouldSucceed(accountManager, nodeCmd, namespace)
 
-    it('Node Proxy should be UP', async () => {
+    it(`Node Proxy should be UP [mode ${input.mode}, release ${input.releaseTag}, keyFormat: ${input.keyFormat}`, async () => {
       expect.assertions(1)
 
       try {
-        await expect(nodeCmd.checkNetworkNodeProxyUp('node0', 30399)).resolves.toBeTruthy()
+        await expect(nodeCmd.checkNetworkNodeProxyUp('node0', 30499)).resolves.toBeTruthy()
       } catch (e) {
         nodeCmd.logger.showUserError(e)
         expect(e).toBeNull()
@@ -94,12 +94,13 @@ describe.each([
         await sleep(20000) // sleep to wait for pod to finish terminating
       } else if (input.mode === 'stop') {
         await expect(nodeCmd.stop(argv)).resolves.toBeTruthy()
+        await sleep(10000) // give time for node to stop and update its logs
       } else {
         throw new Error(`invalid mode: ${input.mode}`)
       }
     }, 120000)
 
-    nodeShouldBeRunning(nodeCmd, namespace, nodeId)
+    nodePodShouldBeRunning(nodeCmd, namespace, nodeId)
 
     nodeShouldNotBeActive(nodeCmd, nodeId)
 
@@ -165,7 +166,7 @@ function balanceQueryShouldSucceed (accountManager, nodeCmd, namespace) {
   }, 40000)
 }
 
-function nodeShouldBeRunning (nodeCmd, namespace, nodeId) {
+function nodePodShouldBeRunning (nodeCmd, namespace, nodeId) {
   it(`${nodeId} should be running`, async () => {
     try {
       await expect(nodeCmd.checkNetworkNodePod(namespace, nodeId)).resolves.toBeTruthy()

--- a/test/e2e/commands/node.test.mjs
+++ b/test/e2e/commands/node.test.mjs
@@ -62,7 +62,7 @@ describe.each([
   afterAll(async () => {
     await k8.deleteNamespace(namespace)
     await accountManager.close()
-  }, 20000)
+  }, 120000)
 
   describe(`Node should start successfully [mode ${input.mode}, release ${input.releaseTag}, keyFormat: ${input.keyFormat}]`, () => {
     balanceQueryShouldSucceed(accountManager, nodeCmd, namespace)

--- a/test/e2e/commands/node.test.mjs
+++ b/test/e2e/commands/node.test.mjs
@@ -94,7 +94,7 @@ describe.each([
         await sleep(20000) // sleep to wait for pod to finish terminating
       } else if (input.mode === 'stop') {
         await expect(nodeCmd.stop(argv)).resolves.toBeTruthy()
-        await sleep(10000) // give time for node to stop and update its logs
+        await sleep(20000) // give time for node to stop and update its logs
       } else {
         throw new Error(`invalid mode: ${input.mode}`)
       }
@@ -163,7 +163,7 @@ function balanceQueryShouldSucceed (accountManager, nodeCmd, namespace) {
       expect(e).toBeNull()
     }
     await sleep(1000)
-  }, 40000)
+  }, 120000)
 }
 
 function nodePodShouldBeRunning (nodeCmd, namespace, nodeId) {

--- a/test/e2e/commands/node.test.mjs
+++ b/test/e2e/commands/node.test.mjs
@@ -14,9 +14,16 @@
  * limitations under the License.
  *
  */
-import { AccountBalanceQuery, AccountCreateTransaction, Hbar, PrivateKey } from '@hashgraph/sdk'
+import {
+  AccountBalanceQuery,
+  AccountCreateTransaction,
+  Hbar,
+  HbarUnit,
+  PrivateKey
+} from '@hashgraph/sdk'
 import {
   afterAll,
+  beforeAll,
   describe,
   expect,
   it
@@ -28,12 +35,14 @@ import {
 import {
   bootstrapNetwork,
   getDefaultArgv,
+  getTestConfigManager,
   TEST_CLUSTER
 } from '../../test_util.js'
+import { sleep } from '../../../src/core/helpers.mjs'
 
 describe.each([
-  { releaseTag: 'v0.47.0-alpha.0', keyFormat: constants.KEY_FORMAT_PFX, testName: 'node-cmd-e2e-pfx' },
-  { releaseTag: 'v0.47.0-alpha.0', keyFormat: constants.KEY_FORMAT_PEM, testName: 'node-cmd-e2e-pem' }
+  { releaseTag: 'v0.49.0-alpha.2', keyFormat: constants.KEY_FORMAT_PFX, testName: 'node-cmd-e2e-pfx', mode: 'kill' },
+  { releaseTag: 'v0.49.0-alpha.2', keyFormat: constants.KEY_FORMAT_PEM, testName: 'node-cmd-e2e-pem', mode: 'stop' }
 ])('NodeCommand', (input) => {
   const testName = input.testName
   const namespace = testName
@@ -41,7 +50,7 @@ describe.each([
   argv[flags.namespace.name] = namespace
   argv[flags.releaseTag.name] = input.releaseTag
   argv[flags.keyFormat.name] = input.keyFormat
-  argv[flags.nodeIDs.name] = 'node0,node1,node2'
+  argv[flags.nodeIDs.name] = 'node0,node1,node2,node3'
   argv[flags.generateGossipKeys.name] = true
   argv[flags.generateTlsKeys.name] = true
   argv[flags.clusterName.name] = TEST_CLUSTER
@@ -55,54 +64,16 @@ describe.each([
     await accountManager.close()
   })
 
-  describe(`Node should start successfully [release ${input.keyFormat}, keyFormat: ${input.releaseTag}]`, () => {
-    it('Balance query should succeed', async () => {
-      expect.assertions(2)
+  describe(`Node should start successfully [release ${input.releaseTag}, keyFormat: ${input.keyFormat}]`, () => {
+    balanceQueryShouldSucceed(accountManager, nodeCmd, namespace)
 
-      try {
-        await accountManager.loadNodeClient(namespace)
-        expect(accountManager._nodeClient).not.toBeNull()
-
-        const balance = await new AccountBalanceQuery()
-          .setAccountId(accountManager._nodeClient.getOperator().accountId)
-          .execute(accountManager._nodeClient)
-
-        expect(balance.hbars).not.toBeNull()
-      } catch (e) {
-        nodeCmd.logger.showUserError(e)
-        expect(e).toBeNull()
-      }
-    }, 120000)
-
-    it('Account creation should succeed', async () => {
-      expect.assertions(2)
-
-      try {
-        expect(accountManager._nodeClient).not.toBeNull()
-        const accountKey = PrivateKey.generate()
-
-        let transaction = await new AccountCreateTransaction()
-          .setNodeAccountIds([constants.HEDERA_NODE_ACCOUNT_ID_START])
-          .setInitialBalance(new Hbar(0))
-          .setKey(accountKey.publicKey)
-          .freezeWith(accountManager._nodeClient)
-
-        transaction = await transaction.sign(accountKey)
-        const response = await transaction.execute(accountManager._nodeClient)
-        const receipt = await response.getReceipt(accountManager._nodeClient)
-
-        expect(receipt.accountId).not.toBeNull()
-      } catch (e) {
-        nodeCmd.logger.showUserError(e)
-        expect(e).toBeNull()
-      }
-    }, 20000)
+    accountCreationShouldSucceed(accountManager, nodeCmd, namespace)
 
     it('Node Proxy should be UP', async () => {
       expect.assertions(1)
 
       try {
-        await expect(nodeCmd.checkNetworkNodeProxyUp('node0', 30313)).resolves.toBeTruthy()
+        await expect(nodeCmd.checkNetworkNodeProxyUp('node0', 30399)).resolves.toBeTruthy()
       } catch (e) {
         nodeCmd.logger.showUserError(e)
         expect(e).toBeNull()
@@ -111,4 +82,142 @@ describe.each([
       }
     }, 20000)
   })
+
+  describe(`Node should refresh successfully [mode ${input.mode}, release ${input.releaseTag}, keyFormat: ${input.keyFormat}]`, () => {
+    const nodeId = 'node0'
+
+    beforeAll(async () => {
+      const podName = await nodeRefreshTestSetup(argv, testName, k8, nodeId)
+      if (input.mode === 'kill') {
+        const resp = await k8.kubeClient.deleteNamespacedPod(podName, namespace)
+        expect(resp.response.statusCode).toEqual(200)
+        await sleep(20000) // sleep to wait for pod to finish terminating
+      } else if (input.mode === 'stop') {
+        await expect(nodeCmd.stop(argv)).resolves.toBeTruthy()
+      } else {
+        throw new Error(`invalid mode: ${input.mode}`)
+      }
+    }, 120000)
+
+    nodeShouldBeRunning(nodeCmd, namespace, nodeId)
+
+    nodeShouldNotBeActive(nodeCmd, nodeId)
+
+    nodeRefreshShouldSucceed(nodeId, nodeCmd, argv)
+
+    balanceQueryShouldSucceed(accountManager, nodeCmd, namespace)
+
+    accountCreationShouldSucceed(accountManager, nodeCmd, namespace)
+  })
 })
+
+function accountCreationShouldSucceed (accountManager, nodeCmd, namespace) {
+  it('Account creation should succeed', async () => {
+    expect.assertions(3)
+
+    try {
+      await accountManager.loadNodeClient(namespace)
+      expect(accountManager._nodeClient).not.toBeNull()
+      const privateKey = PrivateKey.generate()
+      const amount = 100
+
+      const newAccount = await new AccountCreateTransaction()
+        .setKey(privateKey)
+        .setInitialBalance(Hbar.from(amount, HbarUnit.Hbar))
+        .execute(accountManager._nodeClient)
+
+      // Get the new account ID
+      const getReceipt = await newAccount.getReceipt(accountManager._nodeClient)
+      const accountInfo = {
+        accountId: getReceipt.accountId.toString(),
+        privateKey: privateKey.toString(),
+        publicKey: privateKey.publicKey.toString(),
+        balance: amount
+      }
+
+      expect(accountInfo.accountId).not.toBeNull()
+      expect(accountInfo.balance).toEqual(amount)
+    } catch (e) {
+      nodeCmd.logger.showUserError(e)
+      expect(e).toBeNull()
+    }
+  }, 60000)
+}
+
+function balanceQueryShouldSucceed (accountManager, nodeCmd, namespace) {
+  it('Balance query should succeed', async () => {
+    expect.assertions(2)
+
+    try {
+      await accountManager.loadNodeClient(namespace)
+      expect(accountManager._nodeClient).not.toBeNull()
+
+      const balance = await new AccountBalanceQuery()
+        .setAccountId(accountManager._nodeClient.getOperator().accountId)
+        .execute(accountManager._nodeClient)
+
+      expect(balance.hbars).not.toBeNull()
+    } catch (e) {
+      nodeCmd.logger.showUserError(e)
+      expect(e).toBeNull()
+    }
+    await sleep(1000)
+  }, 20000)
+}
+
+function nodeShouldBeRunning (nodeCmd, namespace, nodeId) {
+  it(`${nodeId} should be running`, async () => {
+    try {
+      await expect(nodeCmd.checkNetworkNodePod(namespace, nodeId)).resolves.toBeTruthy()
+    } catch (e) {
+      nodeCmd.logger.showUserError(e)
+      expect(e).toBeNull()
+    } finally {
+      await nodeCmd.close()
+    }
+  }, 20000)
+}
+
+function nodeRefreshShouldSucceed (nodeId, nodeCmd, argv) {
+  it(`${nodeId} refresh should succeed`, async () => {
+    try {
+      await expect(nodeCmd.refresh(argv)).resolves.toBeTruthy()
+    } catch (e) {
+      nodeCmd.logger.showUserError(e)
+      expect(e).toBeNull()
+    } finally {
+      await nodeCmd.close()
+    }
+  }, 1200000)
+}
+
+function nodeShouldNotBeActive (nodeCmd, nodeId) {
+  it(`${nodeId} should not be ACTIVE`, async () => {
+    expect(2)
+    try {
+      await expect(nodeCmd.checkNetworkNodeStarted(nodeId, 5)).rejects.toThrowError()
+    } catch (e) {
+      nodeCmd.logger.showUserError(e)
+      expect(e).not.toBeNull()
+    } finally {
+      await nodeCmd.close()
+    }
+  }, 20000)
+}
+
+async function nodeRefreshTestSetup (argv, testName, k8, nodeId) {
+  argv[flags.nodeIDs.name] = nodeId
+  const configManager = getTestConfigManager(`${testName}-solo.config`)
+  configManager.update(argv, true)
+
+  const podArray = await k8.getPodsByLabel(
+    [`app=network-${nodeId}`, 'fullstack.hedera.com/type=network-node'])
+
+  if (podArray.length > 0) {
+    const podName = podArray[0].metadata.name
+    k8.logger.info(`nodeRefreshTestSetup: podName: ${podName}`)
+    return podName
+  } else {
+    throw new Error(`pod for ${nodeId} not found`)
+  }
+}

--- a/test/e2e/commands/node.test.mjs
+++ b/test/e2e/commands/node.test.mjs
@@ -22,7 +22,7 @@ import {
   PrivateKey
 } from '@hashgraph/sdk'
 import {
-  afterAll,
+  afterAll, afterEach,
   beforeAll,
   describe,
   expect,
@@ -59,9 +59,13 @@ describe.each([
   const k8 = bootstrapResp.opts.k8
   const nodeCmd = bootstrapResp.cmd.nodeCmd
 
+  afterEach(async () => {
+    await nodeCmd.close()
+    await accountManager.close()
+  }, 120000)
+
   afterAll(async () => {
     await k8.deleteNamespace(namespace)
-    await accountManager.close()
   }, 120000)
 
   describe(`Node should start successfully [mode ${input.mode}, release ${input.releaseTag}, keyFormat: ${input.keyFormat}]`, () => {

--- a/test/e2e/core/package_downloader_e2e.test.mjs
+++ b/test/e2e/core/package_downloader_e2e.test.mjs
@@ -19,7 +19,7 @@ import * as fs from 'fs'
 import { logging, PackageDownloader, Templates } from '../../../src/core/index.mjs'
 
 describe('PackageDownloaderE2E', () => {
-  const testLogger = logging.NewLogger('debug')
+  const testLogger = logging.NewLogger('debug', true)
   const downloader = new PackageDownloader(testLogger)
 
   it('should succeed with a valid Hedera release tag', async () => {

--- a/test/e2e/core/platform_installer_e2e.test.mjs
+++ b/test/e2e/core/platform_installer_e2e.test.mjs
@@ -29,7 +29,7 @@ import { getTestCacheDir, getTmpDir, testLogger } from '../../test_util.js'
 describe('PackageInstallerE2E', () => {
   const configManager = new ConfigManager(testLogger)
   const k8 = new K8(configManager, testLogger)
-  const installer = new PlatformInstaller(testLogger, k8)
+  const installer = new PlatformInstaller(testLogger, k8, configManager)
   const testCacheDir = getTestCacheDir()
   const podName = 'network-node0-0'
   const packageVersion = 'v0.42.5'

--- a/test/test_util.js
+++ b/test/test_util.js
@@ -43,7 +43,7 @@ import {
   Zippy
 } from '../src/core/index.mjs'
 
-export const testLogger = logging.NewLogger('debug')
+export const testLogger = logging.NewLogger('debug', true)
 export const TEST_CLUSTER = 'solo-e2e'
 
 export function getTestCacheDir (testName) {

--- a/test/test_util.js
+++ b/test/test_util.js
@@ -113,7 +113,7 @@ export function bootstrapTestVariables (testName, argv,
   const helm = new Helm(testLogger)
   const chartManager = new ChartManager(helm, testLogger)
   const k8 = k8Arg || new K8(configManager, testLogger)
-  const platformInstaller = new PlatformInstaller(testLogger, k8)
+  const platformInstaller = new PlatformInstaller(testLogger, k8, configManager)
   const accountManager = new AccountManager(testLogger, k8, constants)
   const profileManager = new ProfileManager(testLogger, configManager)
   const opts = {

--- a/test/unit/commands/base.test.mjs
+++ b/test/unit/commands/base.test.mjs
@@ -26,7 +26,7 @@ import {
 import { BaseCommand } from '../../../src/commands/base.mjs'
 import { K8 } from '../../../src/core/k8.mjs'
 
-const testLogger = logging.NewLogger('debug')
+const testLogger = logging.NewLogger('debug', true)
 
 describe('BaseCommand', () => {
   const helm = new Helm(testLogger)

--- a/test/unit/commands/init.test.mjs
+++ b/test/unit/commands/init.test.mjs
@@ -30,7 +30,7 @@ import {
 } from '../../../src/core/index.mjs'
 import { K8 } from '../../../src/core/k8.mjs'
 
-const testLogger = logging.NewLogger('debug')
+const testLogger = logging.NewLogger('debug', true)
 describe('InitCommand', () => {
   // prepare dependency manger registry
   const downloader = new PackageDownloader(testLogger)

--- a/test/unit/core/dependency_managers/dependency_manager.test.mjs
+++ b/test/unit/core/dependency_managers/dependency_manager.test.mjs
@@ -19,7 +19,7 @@ import { DependencyManager, HelmDependencyManager } from '../../../../src/core/d
 import { logging, constants, PackageDownloader, Zippy } from '../../../../src/core/index.mjs'
 import { FullstackTestingError } from '../../../../src/core/errors.mjs'
 
-const testLogger = logging.NewLogger('debug')
+const testLogger = logging.NewLogger('debug', true)
 describe('DependencyManager', () => {
   // prepare dependency manger registry
   const downloader = new PackageDownloader(testLogger)

--- a/test/unit/core/helm.test.mjs
+++ b/test/unit/core/helm.test.mjs
@@ -23,7 +23,7 @@ describe.each([
   { osPlatform: 'windows' },
   { osPlatform: 'darwin' }
 ])('Helm', (input) => {
-  const logger = logging.NewLogger('debug')
+  const logger = logging.NewLogger('debug', true)
   const helm = new Helm(logger, input.osPlatform)
   const shellSpy = jest.spyOn(ShellRunner.prototype, 'run').mockImplementation()
   const helmPath = Templates.installationPath(constants.HELM, input.osPlatform)

--- a/test/unit/core/key_manager.test.mjs
+++ b/test/unit/core/key_manager.test.mjs
@@ -23,7 +23,7 @@ import { constants, Keytool, logging, PackageDownloader, Zippy, KeyManager } fro
 import { getTmpDir, testLogger } from '../../test_util.js'
 
 describe('KeyManager', () => {
-  const logger = logging.NewLogger('debug')
+  const logger = logging.NewLogger('debug', true)
   const keyManager = new KeyManager(logger)
 
   it('should generate signing key', async () => {

--- a/test/unit/core/keytool.test.mjs
+++ b/test/unit/core/keytool.test.mjs
@@ -23,7 +23,7 @@ describe.each([
   { osPlatform: 'windows' },
   { osPlatform: 'darwin' }
 ])('Keytool', (input) => {
-  const logger = logging.NewLogger('debug')
+  const logger = logging.NewLogger('debug', true)
   const keytool = new Keytool(logger, input.osPlatform)
   const shellSpy = jest.spyOn(ShellRunner.prototype, 'run').mockImplementation()
   const keytoolPath = Templates.installationPath(constants.KEYTOOL, input.osPlatform)

--- a/test/unit/core/package_downloader.test.mjs
+++ b/test/unit/core/package_downloader.test.mjs
@@ -22,7 +22,7 @@ import * as os from 'os'
 import { IllegalArgumentError, MissingArgumentError, ResourceNotFoundError } from '../../../src/core/errors.mjs'
 
 describe('PackageDownloader', () => {
-  const testLogger = core.logging.NewLogger('debug')
+  const testLogger = core.logging.NewLogger('debug', true)
   const downloader = new core.PackageDownloader(testLogger)
 
   describe('urlExists', () => {

--- a/test/unit/core/platform_installer.test.mjs
+++ b/test/unit/core/platform_installer.test.mjs
@@ -25,7 +25,7 @@ import {
   MissingArgumentError
 } from '../../../src/core/errors.mjs'
 describe('PackageInstaller', () => {
-  const testLogger = core.logging.NewLogger('debug')
+  const testLogger = core.logging.NewLogger('debug', true)
   const configManager = new ConfigManager(testLogger)
   const k8 = new core.K8(configManager, testLogger)
   const installer = new PlatformInstaller(testLogger, k8, configManager)

--- a/test/unit/core/platform_installer.test.mjs
+++ b/test/unit/core/platform_installer.test.mjs
@@ -28,7 +28,7 @@ describe('PackageInstaller', () => {
   const testLogger = core.logging.NewLogger('debug')
   const configManager = new ConfigManager(testLogger)
   const k8 = new core.K8(configManager, testLogger)
-  const installer = new PlatformInstaller(testLogger, k8)
+  const installer = new PlatformInstaller(testLogger, k8, configManager)
 
   describe('validatePlatformReleaseDir', () => {
     it('should fail for missing path', async () => {

--- a/test/unit/core/zippy.test.mjs
+++ b/test/unit/core/zippy.test.mjs
@@ -22,7 +22,7 @@ import fs from 'fs'
 import path from 'path'
 import { Zippy } from '../../../src/core/zippy.mjs'
 describe('Zippy', () => {
-  const testLogger = core.logging.NewLogger('debug')
+  const testLogger = core.logging.NewLogger('debug', true)
   const zippy = new Zippy(testLogger)
 
   describe('unzip', () => {


### PR DESCRIPTION
## Description

This pull request changes the following:

* adds the `solo node refresh` subcommand
* fix `.github/workflows/flow-update-readme.yaml` typo
* add Jest default reporter summary threshold
* added better error handling for `checkNetworkNodeProxyUp`
* enhanced `stopPortForward` to test for port to be closed before continuing
* updated `config.txt` to include fully qualified DNS from Kube DNS
* added dev mode to test loggers for better reporting on failures

### Related Issues

* Closes #96 
* Depends on https://github.com/hashgraph/full-stack-testing/pull/815