### PR TITLE
fix: revert to sleep and remove jest.runAllTicks from e2e test

### DIFF
--- a/src/commands/mirror_node.mjs
+++ b/src/commands/mirror_node.mjs
@@ -66,7 +66,8 @@ export class MirrorNodeCommand extends BaseCommand {
           ctx.config = {
             namespace: self.configManager.getFlag(flags.namespace),
             chartDir: self.configManager.getFlag(flags.chartDirectory),
-            deployHederaExplorer: self.configManager.getFlag(flags.deployHederaExplorer)
+            deployHederaExplorer: self.configManager.getFlag(flags.deployHederaExplorer),
+            fstChartVersion: this.configManager.getFlag(flags.fstChartVersion)
           }
 
           ctx.config.chartPath = await self.prepareChartPath(ctx.config.chartDir,
@@ -104,7 +105,8 @@ export class MirrorNodeCommand extends BaseCommand {
                   ctx.config.namespace,
                   constants.FULLSTACK_DEPLOYMENT_CHART,
                   ctx.config.chartPath,
-                  ctx.config.valuesArg
+                  ctx.config.valuesArg,
+                  ctx.config.fstChartVersion
                 )
               }
             }
@@ -214,7 +216,8 @@ export class MirrorNodeCommand extends BaseCommand {
 
           ctx.config = {
             namespace: self.configManager.getFlag(flags.namespace),
-            chartDir: self.configManager.getFlag(flags.chartDirectory)
+            chartDir: self.configManager.getFlag(flags.chartDirectory),
+            fstChartVersion: this.configManager.getFlag(flags.fstChartVersion)
           }
 
           ctx.config.chartPath = await self.prepareChartPath(ctx.config.chartDir,
@@ -238,7 +241,8 @@ export class MirrorNodeCommand extends BaseCommand {
             ctx.config.namespace,
             constants.FULLSTACK_DEPLOYMENT_CHART,
             ctx.config.chartPath,
-            ctx.config.valuesArg
+            ctx.config.valuesArg,
+            ctx.config.fstChartVersion
           )
         }
       },

--- a/src/commands/network.mjs
+++ b/src/commands/network.mjs
@@ -366,7 +366,8 @@ export class NetworkCommand extends BaseCommand {
             ctx.config.namespace,
             constants.FULLSTACK_DEPLOYMENT_CHART,
             ctx.config.chartPath,
-            ctx.config.valuesArg
+            ctx.config.valuesArg,
+            ctx.config.fstChartVersion
           )
         }
       },

--- a/src/commands/node.mjs
+++ b/src/commands/node.mjs
@@ -62,6 +62,7 @@ export class NodeCommand extends BaseCommand {
    * @returns {Promise<void>}
    */
   async close () {
+    this.accountManager.close()
     if (this._portForwards) {
       for (const srv of this._portForwards) {
         await this.k8.stopPortForward(srv)
@@ -1124,6 +1125,9 @@ export class NodeCommand extends BaseCommand {
           ctx.config.chartPath = await self.prepareChartPath(ctx.config.chartDir,
             constants.FULLSTACK_TESTING_CHART, constants.FULLSTACK_DEPLOYMENT_CHART)
 
+          // initialize Node Client with existing network nodes prior to adding the new node which isn't functioning, yet
+          await this.accountManager.loadNodeClient(ctx.config.namespace)
+
           self.logger.debug('Initialized config', { config })
         }
       },
@@ -1423,6 +1427,8 @@ export class NodeCommand extends BaseCommand {
       await tasks.run()
     } catch (e) {
       throw new FullstackTestingError(`Error in setting up nodes: ${e.message}`, e)
+    } finally {
+      await self.close()
     }
 
     return true

--- a/src/commands/node.mjs
+++ b/src/commands/node.mjs
@@ -1114,7 +1114,8 @@ export class NodeCommand extends BaseCommand {
             keyFormat: self.configManager.getFlag(flags.keyFormat),
             devMode: self.configManager.getFlag(flags.devMode),
             chartDir: self.configManager.getFlag(flags.chartDirectory),
-            curDate: new Date()
+            curDate: new Date(),
+            fstChartVersion: self.configManager.getFlag(flags.fstChartVersion)
           }
 
           await self.initializeSetup(config, self.configManager, self.k8)
@@ -1167,7 +1168,7 @@ export class NodeCommand extends BaseCommand {
           let valuesArg = ''
           let index = 0
           for (const node of values.hedera.nodes) {
-            valuesArg += `--set hedera.nodes[${index}].name=${node.name} --set hedera.nodes[${index}].accountId=${node.accountId} `
+            valuesArg += ` --set "hedera.nodes[${index}].accountId=${node.accountId}" --set "hedera.nodes[${index}].name=${node.name}"`
             index++
           }
 
@@ -1175,7 +1176,8 @@ export class NodeCommand extends BaseCommand {
             ctx.config.namespace,
             constants.FULLSTACK_DEPLOYMENT_CHART,
             ctx.config.chartPath,
-            valuesArg
+            valuesArg,
+            ctx.config.fstChartVersion
           )
           ctx.config.allNodeIds = [...ctx.config.existingNodeIds, ...ctx.config.nodeIds]
         }

--- a/src/core/chart_manager.mjs
+++ b/src/core/chart_manager.mjs
@@ -126,10 +126,15 @@ export class ChartManager {
     return true
   }
 
-  async upgrade (namespaceName, chartReleaseName, chartPath, valuesArg = '') {
+  async upgrade (namespaceName, chartReleaseName, chartPath, valuesArg = '', version = '') {
+    let versionArg = ''
+    if (version) {
+      versionArg = `--version ${version}`
+    }
+
     try {
       this.logger.debug(chalk.cyan('> upgrading chart:'), chalk.yellow(`${chartReleaseName}`))
-      await this.helm.upgrade(`-n ${namespaceName} ${chartReleaseName} ${chartPath} --reuse-values ${valuesArg}`)
+      await this.helm.upgrade(`-n ${namespaceName} ${chartReleaseName} ${chartPath} ${versionArg} --reuse-values ${valuesArg}`)
       this.logger.debug(chalk.green('OK'), `chart '${chartReleaseName}' is upgraded`)
     } catch (e) {
       throw new FullstackTestingError(`failed to upgrade chart ${chartReleaseName}: ${e.message}`, e)

--- a/src/core/k8.mjs
+++ b/src/core/k8.mjs
@@ -712,11 +712,11 @@ export class K8 {
     await new Promise((resolve, reject) => {
       server.close((e) => {
         if (e) {
-          if (e.message.contains('Server is not running')) {
+          if (e.message?.contains('Server is not running')) {
             this.logger.debug(`Server not running, port-forwarder [${server.info}]`)
             resolve()
           } else {
-            this.logger.debug(`Failed to stop port-forwarder [${server.info}]: ${e.message}`)
+            this.logger.debug(`Failed to stop port-forwarder [${server.info}]: ${e.message}`, e)
             reject(e)
           }
         } else {

--- a/src/core/k8.mjs
+++ b/src/core/k8.mjs
@@ -712,7 +712,7 @@ export class K8 {
     await new Promise((resolve, reject) => {
       server.close((e) => {
         if (e) {
-          if (e.message?.contains('Server is not running')) {
+          if (e.message?.includes('Server is not running')) {
             this.logger.debug(`Server not running, port-forwarder [${server.info}]`)
             resolve()
           } else {

--- a/test/e2e/commands/mirror_node.test.mjs
+++ b/test/e2e/commands/mirror_node.test.mjs
@@ -60,6 +60,7 @@ describe('MirrorNodeCommand', () => {
 
   afterAll(async () => {
     await k8.deleteNamespace(namespace)
+    await accountManager.close()
   })
 
   afterEach(async () => {
@@ -152,6 +153,8 @@ describe('MirrorNodeCommand', () => {
     } catch (e) {
       mirrorNodeCmd.logger.showUserError(e)
       expect(e).toBeNull()
+    } finally {
+      await accountManager.close()
     }
   }, 240000)
 

--- a/test/e2e/commands/mirror_node.test.mjs
+++ b/test/e2e/commands/mirror_node.test.mjs
@@ -75,7 +75,7 @@ describe('MirrorNodeCommand', () => {
       mirrorNodeCmd.logger.showUserError(e)
       expect(e).toBeNull()
     }
-  }, 360000)
+  }, 480000)
 
   it('mirror node api and hedera explorer should success', async () => {
     await accountManager.loadNodeClient(namespace)
@@ -153,8 +153,6 @@ describe('MirrorNodeCommand', () => {
     } catch (e) {
       mirrorNodeCmd.logger.showUserError(e)
       expect(e).toBeNull()
-    } finally {
-      await accountManager.close()
     }
   }, 240000)
 

--- a/test/e2e/commands/node.test.mjs
+++ b/test/e2e/commands/node.test.mjs
@@ -69,7 +69,7 @@ describe.each([
   }, 120000)
 
   afterAll(async () => {
-    // await k8.deleteNamespace(namespace)
+    await k8.deleteNamespace(namespace)
   }, 120000)
 
   describe(`Node should have started successfully [mode ${input.mode}, release ${input.releaseTag}, keyFormat: ${input.keyFormat}]`, () => {

--- a/test/e2e/commands/node.test.mjs
+++ b/test/e2e/commands/node.test.mjs
@@ -27,8 +27,7 @@ import {
   beforeAll,
   describe,
   expect,
-  it,
-  jest
+  it
 } from '@jest/globals'
 import { flags } from '../../../src/commands/index.mjs'
 import {
@@ -230,7 +229,7 @@ function balanceQueryShouldSucceed (accountManager, nodeCmd, namespace) {
       nodeCmd.logger.showUserError(e)
       expect(e).toBeNull()
     }
-    jest.runAllTicks()
+    await sleep(1000)
   }, 120000)
 }
 

--- a/test/e2e/commands/relay.test.mjs
+++ b/test/e2e/commands/relay.test.mjs
@@ -88,5 +88,5 @@ describe('RelayCommand', () => {
       relayCmd.logger.showUserError(e)
       expect(e).toBeNull()
     }
-  }, 60000)
+  }, 120000)
 })


### PR DESCRIPTION
## Description

This pull request changes the following:

* removes 'jest.runAllTicks()' in 1test/e2e/commands/node.test.mjs` as it was causing inconsistent failures
* increased timeout on relay test
* added fst chart version to helm upgrade calls which was missing and causing issues

### Related Issues

* Closes #
