### PR TITLE
ci: increase chart version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hashgraph/solo",
-  "version": "0.24.0",
+  "version": "0.24.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hashgraph/solo",
-      "version": "0.24.0",
+      "version": "0.24.5",
       "license": "Apache2.0",
       "os": [
         "darwin",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/solo",
-  "version": "0.24.0",
+  "version": "0.24.5",
   "description": "An opinionated CLI tool to deploy and manage private Hedera Networks.",
   "main": "src/index.mjs",
   "type": "module",

--- a/version.mjs
+++ b/version.mjs
@@ -21,5 +21,5 @@
 
 export const JAVA_VERSION = '21.0.1+12'
 export const HELM_VERSION = 'v3.14.2'
-export const FST_CHART_VERSION = 'v0.24.3'
+export const FST_CHART_VERSION = 'v0.24.5'
 export const HEDERA_PLATFORM_VERSION = 'v0.47.0'


### PR DESCRIPTION
## Description

This pull request changes the following:

* Increase chart version so we can use newer version of mirror node chart, which takes less time to spin up GRPC

### Related Issues

* Closes #
