### PR TITLE
fix: use latest FST chart and a single consensus node during mirror-node e2e test

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ Then run the following command to set the kubectl context to the new cluster:
 ```bash
 kind create cluster -n "${SOLO_CLUSTER_NAME}"
 ```
+
 Example output
 
 ```
@@ -184,6 +185,7 @@ Kubernetes Namespace	: solo
 ✔ Generate gRPC TLS keys
 ✔ Finalize
 ```
+
 Key files are generated in `~/.solo/keys` directory.
 
 ```
@@ -192,6 +194,7 @@ $ ls ~/.solo/cache/keys
 hedera-node0.crt  hedera-node1.crt  hedera-node2.crt  private-node0.pfx private-node2.pfx
 hedera-node0.key  hedera-node1.key  hedera-node2.key  private-node1.pfx public.pfx
 ```
+
 * Setup cluster with shared components
   * In a separate terminal, you may run `k9s` to view the pod status.
 
@@ -213,7 +216,6 @@ Kubernetes Namespace	: solo
 ✔ Prepare chart values
 ✔ Install 'fullstack-cluster-setup' chart
 ```
-
 
 * Deploy helm chart with Hedera network components
   * It may take a while (5~15 minutes depending on your internet speed) to download various docker images and get the pods started.
@@ -334,6 +336,7 @@ Kubernetes Namespace	: solo
 ✔ Check proxy for node: node1
 ✔ Check node proxies are ACTIVE
 ```
+
 * Deploy mirror node
 
 ```
@@ -518,7 +521,9 @@ Kubernetes Namespace	: solo
 ✔ Generate gRPC TLS keys
 ✔ Finalize
 ```
+
 PEM key files are generated in `~/.solo/keys` directory.
+
 ```
 $ ls ~/.solo/cache/keys  
 a-private-node0.pem a-public-node1.pem  hedera-node1.crt    s-private-node0.pem s-public-node1.pem
@@ -526,6 +531,7 @@ a-private-node1.pem a-public-node2.pem  hedera-node1.key    s-private-node1.pem 
 a-private-node2.pem hedera-node0.crt    hedera-node2.crt    s-private-node2.pem
 a-public-node0.pem  hedera-node0.key    hedera-node2.key    s-public-node0.pem
 ```
+
 * Setup cluster with shared components
 
 ```

--- a/src/commands/mirror_node.mjs
+++ b/src/commands/mirror_node.mjs
@@ -127,35 +127,35 @@ export class MirrorNodeCommand extends BaseCommand {
               task: async (ctx, _) => self.k8.waitForPodReady([
                 'app.kubernetes.io/component=postgresql',
                 'app.kubernetes.io/name=postgres'
-              ], 1, 900, 2000)
+              ], 1, 300, 2000)
             },
             {
               title: 'Check REST API',
               task: async (ctx, _) => self.k8.waitForPodReady([
                 'app.kubernetes.io/component=rest',
                 'app.kubernetes.io/name=rest'
-              ], 1, 900, 2000)
+              ], 1, 300, 2000)
             },
             {
               title: 'Check GRPC',
               task: async (ctx, _) => self.k8.waitForPodReady([
                 'app.kubernetes.io/component=grpc',
                 'app.kubernetes.io/name=grpc'
-              ], 1, 900, 2000)
+              ], 1, 300, 2000)
             },
             {
               title: 'Check Monitor',
               task: async (ctx, _) => self.k8.waitForPodReady([
                 'app.kubernetes.io/component=monitor',
                 'app.kubernetes.io/name=monitor'
-              ], 1, 900, 2000)
+              ], 1, 300, 2000)
             },
             {
               title: 'Check Importer',
               task: async (ctx, _) => self.k8.waitForPodReady([
                 'app.kubernetes.io/component=importer',
                 'app.kubernetes.io/name=importer'
-              ], 1, 900, 2000)
+              ], 1, 300, 2000)
             },
             {
               title: 'Check Hedera Explorer',
@@ -163,7 +163,7 @@ export class MirrorNodeCommand extends BaseCommand {
               task: async (ctx, _) => self.k8.waitForPodReady([
                 'app.kubernetes.io/component=hedera-explorer',
                 'app.kubernetes.io/name=hedera-explorer'
-              ], 1, 900, 2000)
+              ], 1, 300, 2000)
             }
           ]
 

--- a/src/commands/mirror_node.mjs
+++ b/src/commands/mirror_node.mjs
@@ -134,14 +134,14 @@ export class MirrorNodeCommand extends BaseCommand {
               task: async (ctx, _) => self.k8.waitForPodReady([
                 'app.kubernetes.io/component=rest',
                 'app.kubernetes.io/name=rest'
-              ], 1, 900, 200)
+              ], 1, 900, 2000)
             },
             {
               title: 'Check GRPC',
               task: async (ctx, _) => self.k8.waitForPodReady([
                 'app.kubernetes.io/component=grpc',
                 'app.kubernetes.io/name=grpc'
-              ], 1, 900, 2000)
+              ], 1, 9000, 2000)
             },
             {
               title: 'Check Monitor',

--- a/src/commands/mirror_node.mjs
+++ b/src/commands/mirror_node.mjs
@@ -141,7 +141,7 @@ export class MirrorNodeCommand extends BaseCommand {
               task: async (ctx, _) => self.k8.waitForPodReady([
                 'app.kubernetes.io/component=grpc',
                 'app.kubernetes.io/name=grpc'
-              ], 1, 9000, 2000)
+              ], 1, 900, 2000)
             },
             {
               title: 'Check Monitor',

--- a/src/core/k8.mjs
+++ b/src/core/k8.mjs
@@ -837,6 +837,14 @@ export class K8 {
     })
   }
 
+  /**
+   * Check if pod is ready
+   * @param labels pod labels
+   * @param podCount number of pod expected
+   * @param maxAttempts maximum attempts to check
+   * @param delay delay between checks in milliseconds
+   * @return {Promise<unknown>}
+   */
   async waitForPodReady (labels = [], podCount = 1, maxAttempts = 10, delay = 500) {
     try {
       return await this.waitForPodCondition(K8.PodReadyCondition, labels, podCount, maxAttempts, delay)
@@ -844,6 +852,16 @@ export class K8 {
       throw new FullstackTestingError(`Pod not ready [maxAttempts = ${maxAttempts}]`, e)
     }
   }
+
+  /**
+   * Check pods for conditions
+   * @param conditionsMap a map of conditions and values
+   * @param labels pod labels
+   * @param podCount number of pod expected
+   * @param maxAttempts maximum attempts to check
+   * @param delay delay between checks in milliseconds
+   * @return {Promise<unknown>}
+   */
 
   async waitForPodCondition (
     conditionsMap,

--- a/test/data/warmup-cluster.sh
+++ b/test/data/warmup-cluster.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+SOLO_CLUSTER=solo-e2e
+
+SOLO_IMAGE_LIST=( \
+docker.io/bitnami/postgresql-repmgr:14.11.0-debian-12-r8 \
+docker.io/envoyproxy/envoy:v1.21.1 \
+docker.io/grafana/grafana:10.1.5 \
+docker.io/haproxytech/haproxy-alpine:2.4.25 \
+quay.io/prometheus-operator/prometheus-config-reloader:v0.68.0 \
+docker.io/otel/opentelemetry-collector-contrib:0.72.0 \
+gcr.io/hedera-registry/hedera-mirror-node-explorer:24.4.0 \
+gcr.io/hedera-registry/uploader-mirror:1.3.0 \
+gcr.io/mirrornode/hedera-mirror-grpc:0.103.0 \
+quay.io/prometheus-operator/prometheus-operator:v0.68.0 \
+gcr.io/mirrornode/hedera-mirror-importer:0.103.0 \
+gcr.io/mirrornode/hedera-mirror-monitor:0.103.0 \
+gcr.io/mirrornode/hedera-mirror-rest:0.103.0 \
+quay.io/prometheus/alertmanager:v0.26.0 \
+gcr.io/mirrornode/hedera-mirror-web3:0.103.0 \
+ghcr.io/hashgraph/full-stack-testing/ubi8-init-java21:0.24.5 \
+quay.io/prometheus/node-exporter:v1.6.1 \
+ghcr.io/hashgraph/hedera-json-rpc-relay:0.46.0 \
+quay.io/kiwigrid/k8s-sidecar:1.25.1 \
+quay.io/minio/minio:RELEASE.2024-02-09T21-25-16Z \
+quay.io/minio/operator:v5.0.7 \
+quay.io/prometheus/prometheus:v2.47.1 \
+registry.k8s.io/kube-state-metrics/kube-state-metrics:v2.10.0 \
+)
+
+function download_images() {
+    for im in "${SOLO_IMAGE_LIST[@]}"; do
+        echo "Pulling image: ${im}"
+        docker pull --quiet "${im}"
+        sleep 1
+    done
+}
+
+function load_images() {
+    for im in "${SOLO_IMAGE_LIST[@]}"; do
+        echo "Loading image: ${im}"
+        kind load docker-image "${im}" -n $SOLO_CLUSTER
+    done
+}

--- a/test/e2e/commands/mirror_node.test.mjs
+++ b/test/e2e/commands/mirror_node.test.mjs
@@ -44,7 +44,7 @@ describe('MirrorNodeCommand', () => {
   argv[flags.releaseTag.name] = 'v0.47.0-alpha.0'
   argv[flags.keyFormat.name] = constants.KEY_FORMAT_PEM
 
-  argv[flags.nodeIDs.name] = 'node0,node1,node2'
+  argv[flags.nodeIDs.name] = 'node0' // use a single node to reduce usage during e2e tests
   argv[flags.generateGossipKeys.name] = true
   argv[flags.generateTlsKeys.name] = true
   argv[flags.clusterName.name] = TEST_CLUSTER

--- a/test/e2e/commands/mirror_node.test.mjs
+++ b/test/e2e/commands/mirror_node.test.mjs
@@ -16,7 +16,7 @@
  */
 
 import {
-  afterAll, afterEach, describe,
+  afterAll, afterEach, beforeAll, describe,
   expect,
   it
 } from '@jest/globals'
@@ -58,9 +58,15 @@ describe('MirrorNodeCommand', () => {
   const downloader = new core.PackageDownloader(mirrorNodeCmd.logger)
   const accountManager = bootstrapResp.opts.accountManager
 
+  beforeAll(() => {
+    bootstrapResp.opts.logger.showUser(`------------------------- START: ${testName} ----------------------------`)
+  })
+
   afterAll(async () => {
     await k8.deleteNamespace(namespace)
     await accountManager.close()
+
+    bootstrapResp.opts.logger.showUser(`------------------------- END: ${testName} ----------------------------`)
   })
 
   afterEach(async () => {

--- a/test/e2e/commands/mirror_node.test.mjs
+++ b/test/e2e/commands/mirror_node.test.mjs
@@ -44,7 +44,7 @@ describe('MirrorNodeCommand', () => {
   argv[flags.releaseTag.name] = 'v0.47.0-alpha.0'
   argv[flags.keyFormat.name] = constants.KEY_FORMAT_PEM
 
-  argv[flags.nodeIDs.name] = 'node0' // use a single node to reduce usage during e2e tests
+  argv[flags.nodeIDs.name] = 'node0' // use a single node to reduce resource during e2e tests
   argv[flags.generateGossipKeys.name] = true
   argv[flags.generateTlsKeys.name] = true
   argv[flags.clusterName.name] = TEST_CLUSTER

--- a/test/e2e/commands/mirror_node.test.mjs
+++ b/test/e2e/commands/mirror_node.test.mjs
@@ -81,7 +81,7 @@ describe('MirrorNodeCommand', () => {
       mirrorNodeCmd.logger.showUserError(e)
       expect(e).toBeNull()
     }
-  }, 480000)
+  }, 600000)
 
   it('mirror node api and hedera explorer should success', async () => {
     await accountManager.loadNodeClient(namespace)

--- a/test/e2e/setup-e2e.sh
+++ b/test/e2e/setup-e2e.sh
@@ -13,7 +13,8 @@ kind create cluster -n "${SOLO_CLUSTER_NAME}" --image "${KIND_IMAGE}" || exit 1
 # Most of the e2e test should bootstrap its own network in its own namespace. However, some tests can use this as a
 # shared resource if required.
 # **********************************************************************************************************************
-solo init --namespace "${SOLO_NAMESPACE}" -i node0,node1,node2 -t v0.47.0 -s "${SOLO_CLUSTER_SETUP_NAMESPACE}" --dev || exit 1 # cache args for subsequent commands
+source test/data/warmup-cluster.sh; download_images; load_images
+solo init --namespace "${SOLO_NAMESPACE}" -i node0,node1,node2 -s "${SOLO_CLUSTER_SETUP_NAMESPACE}" --dev || exit 1 # cache args for subsequent commands
 solo cluster setup  || exit 1
 helm list --all-namespaces
 solo network deploy || exit 1

--- a/test/e2e/setup-e2e.sh
+++ b/test/e2e/setup-e2e.sh
@@ -13,7 +13,7 @@ kind create cluster -n "${SOLO_CLUSTER_NAME}" --image "${KIND_IMAGE}" || exit 1
 # Most of the e2e test should bootstrap its own network in its own namespace. However, some tests can use this as a
 # shared resource if required.
 # **********************************************************************************************************************
-source test/data/warmup-cluster.sh; download_images; load_images
+# source test/data/warmup-cluster.sh; download_images; load_images
 solo init --namespace "${SOLO_NAMESPACE}" -i node0,node1,node2 -s "${SOLO_CLUSTER_SETUP_NAMESPACE}" --dev || exit 1 # cache args for subsequent commands
 solo cluster setup  || exit 1
 helm list --all-namespaces

--- a/test/e2e/setup-e2e.sh
+++ b/test/e2e/setup-e2e.sh
@@ -8,19 +8,14 @@ kind delete cluster -n "${SOLO_CLUSTER_NAME}" || true
 kind create cluster -n "${SOLO_CLUSTER_NAME}" --image "${KIND_IMAGE}" || exit 1
 
 # **********************************************************************************************************************
-# Warm up the cluster by deploying the network
-# This also helps to have the cluster loaded with the images.
-# Most of the e2e test should bootstrap its own network in its own namespace. However, some tests can use this as a
-# shared resource if required.
+# Warm up the cluster
 # **********************************************************************************************************************
 source test/data/warmup-cluster.sh; download_images; load_images
+
+# **********************************************************************************************************************
+# Init and deploy a network for e2e tests in (test/e2e/core)
+# **********************************************************************************************************************
 solo init --namespace "${SOLO_NAMESPACE}" -i node0,node1,node2 -s "${SOLO_CLUSTER_SETUP_NAMESPACE}" --dev || exit 1 # cache args for subsequent commands
 solo cluster setup  || exit 1
 helm list --all-namespaces
 solo network deploy || exit 1
-
-# **********************************************************************************************************************
-# Don't delete the namespaces as some e2e tests (i.e. test/e2e/core/*.test.mjs) still uses it as shared resources.
-# **********************************************************************************************************************
-# kubectl delete ns "${SOLO_NAMESPACE}"v
-# kubectl delete ns "${SOLO_CLUSTER_SETUP_NAMESPACE}"

--- a/test/e2e/setup-e2e.sh
+++ b/test/e2e/setup-e2e.sh
@@ -13,7 +13,7 @@ kind create cluster -n "${SOLO_CLUSTER_NAME}" --image "${KIND_IMAGE}" || exit 1
 # Most of the e2e test should bootstrap its own network in its own namespace. However, some tests can use this as a
 # shared resource if required.
 # **********************************************************************************************************************
-# source test/data/warmup-cluster.sh; download_images; load_images
+source test/data/warmup-cluster.sh; download_images; load_images
 solo init --namespace "${SOLO_NAMESPACE}" -i node0,node1,node2 -s "${SOLO_CLUSTER_SETUP_NAMESPACE}" --dev || exit 1 # cache args for subsequent commands
 solo cluster setup  || exit 1
 helm list --all-namespaces

--- a/test/test_util.js
+++ b/test/test_util.js
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-import { describe, expect, it } from '@jest/globals'
+import { afterAll, beforeAll, describe, expect, it } from '@jest/globals'
 import fs from 'fs'
 import os from 'os'
 import path from 'path'
@@ -176,6 +176,14 @@ export function bootstrapNetwork (testName, argv,
   const chartManager = bootstrapResp.opts.chartManager
 
   describe(`Bootstrap network for test [release ${argv[flags.releaseTag.name]}, keyFormat: ${argv[flags.keyFormat.name]}]`, () => {
+    beforeAll(() => {
+      bootstrapResp.opts.logger.showUser(`------------------------- START: bootstrap (${testName}) ----------------------------`)
+    })
+
+    afterAll(() => {
+      bootstrapResp.opts.logger.showUser(`------------------------- END: bootstrap (${testName}) ----------------------------`)
+    })
+
     it('should cleanup previous deployment', async () => {
       await initCmd.init(argv)
 
@@ -191,7 +199,7 @@ export function bootstrapNetwork (testName, argv,
       if (!await chartManager.isChartInstalled(constants.FULLSTACK_SETUP_NAMESPACE, constants.FULLSTACK_CLUSTER_SETUP_CHART)) {
         await clusterCmd.setup(argv)
       }
-    }, 60000)
+    }, 120000)
 
     it('should succeed with network deploy', async () => {
       await networkCmd.deploy(argv)

--- a/test/unit/core/dependency_managers/dependency_manager.test.mjs
+++ b/test/unit/core/dependency_managers/dependency_manager.test.mjs
@@ -36,6 +36,6 @@ describe('DependencyManager', () => {
 
     it('should succeed during helm dependency check', async () => {
       await expect(depManager.checkDependency(constants.HELM)).resolves.toBe(true)
-    })
-  }, 10000)
+    }, 60000)
+  })
 })

--- a/version.mjs
+++ b/version.mjs
@@ -21,5 +21,5 @@
 
 export const JAVA_VERSION = '21.0.1+12'
 export const HELM_VERSION = 'v3.14.2'
-export const FST_CHART_VERSION = 'v0.24.3'
+export const FST_CHART_VERSION = 'v0.24.5'
 export const HEDERA_PLATFORM_VERSION = 'v0.47.0'


### PR DESCRIPTION
## Description

This pull request changes the following:

* use a single consensus node during mirror-node-e2e to avoid resource constraints of the runner (4 vCPU, 8 GB RAM)
   * I'll need to create a separate PR that updates resource profile to potentially accommodate more nodes in the runner 
* increase timeout for helm dependency check
* use latest FST chart version
* enable warmup-cluster.sh script to pre-load images into the cluster so that actual deployment time is reduced during e2e tests (We shall need to maintain it as we update the chart versions)

### Related Issues

* Closes #254 
