### PR TITLE
ci: bump to solo linux large and auto retry setup node

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -49,10 +49,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+      - name: Setup Node with Retry
+        uses: Wandalen/wretry.action@0dd1d5d77d019a6f85beb53d29e2ea2c7294d4f2 # v3.4.0
         with:
-          node-version: 20
+          action: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+          with: |
+            node-version: 20
+            cache: npm
+          attempt_limit: 3
+          attempt_delay: 5000
 
       - name: Install Semantic Release
         run: |
@@ -110,10 +115,15 @@ jobs:
           git_commit_gpgsign: true
           git_tag_gpgsign: false
 
-      - name: Setup Node
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+      - name: Setup Node with Retry
+        uses: Wandalen/wretry.action@0dd1d5d77d019a6f85beb53d29e2ea2c7294d4f2 # v3.4.0
         with:
-          node-version: 20
+          action: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+          with: |
+            node-version: 20
+            cache: npm
+          attempt_limit: 3
+          attempt_delay: 5000
 
       - name: Setup JFrog CLI
         uses: jfrog/setup-jfrog-cli@26da2259ee7690e63b5410d7451b2938d08ce1f9 # v4.0.0

--- a/.github/workflows/flow-hugo-publish.yaml
+++ b/.github/workflows/flow-hugo-publish.yaml
@@ -41,7 +41,7 @@ permissions:
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: "pages"
+  group: pages-${{ github.repository }}-${{ github.ref }}
   cancel-in-progress: false
 
 # Default to bash

--- a/.github/workflows/flow-hugo-publish.yaml
+++ b/.github/workflows/flow-hugo-publish.yaml
@@ -65,10 +65,15 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Setup Node
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+      - name: Setup Node with Retry
+        uses: Wandalen/wretry.action@0dd1d5d77d019a6f85beb53d29e2ea2c7294d4f2 # v3.4.0
         with:
-          node-version: 20
+          action: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+          with: |
+            node-version: 20
+            cache: npm
+          attempt_limit: 3
+          attempt_delay: 5000
 
       - name: Setup Pages
         id: pages

--- a/.github/workflows/flow-hugo-publish.yaml
+++ b/.github/workflows/flow-hugo-publish.yaml
@@ -41,7 +41,7 @@ permissions:
 # Allow only one concurrent deployment, skipping runs queued between the run in-progress and latest queued.
 # However, do NOT cancel in-progress runs as we want to allow these production deployments to complete.
 concurrency:
-  group: pages-${{ github.repository }}-${{ github.ref }}
+  group: "pages"
   cancel-in-progress: false
 
 # Default to bash

--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -28,7 +28,7 @@ defaults:
     shell: bash
 
 concurrency:
-  group: pr-checks-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: pr-checks-${{ github.repository }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/flow-pull-request-formatting.yaml
+++ b/.github/workflows/flow-pull-request-formatting.yaml
@@ -33,7 +33,7 @@ permissions:
   statuses: write
 
 concurrency:
-  group: pr-formatting-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  group: pr-formatting-${{ github.repository }}-${{ github.ref }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/flow-update-readme.yaml
+++ b/.github/workflows/flow-update-readme.yaml
@@ -40,11 +40,15 @@ jobs:
           fetch-depth: 0
           token: ${{secrets.GH_ACCESS_TOKEN}}
 
-      - name: Setup Node
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+      - name: Setup Node with Retry
+        uses: Wandalen/wretry.action@0dd1d5d77d019a6f85beb53d29e2ea2c7294d4f2 # v3.4.0
         with:
-          node-version: 20
-          cache: npm
+          action: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+          with: |
+            node-version: 20
+            cache: npm
+          attempt_limit: 3
+          attempt_delay: 5000
 
       - name: Setup Kind
         uses: helm/kind-action@99576bfa6ddf9a8e612d83b513da5a75875caced # v1.9.0

--- a/.github/workflows/zxc-code-analysis.yaml
+++ b/.github/workflows/zxc-code-analysis.yaml
@@ -88,10 +88,15 @@ jobs:
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: ${{ inputs.enable-sonar-analysis && '0' || '' }}
 
-      - name: Setup Node
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+      - name: Setup Node with Retry
+        uses: Wandalen/wretry.action@0dd1d5d77d019a6f85beb53d29e2ea2c7294d4f2 # v3.4.0
         with:
-          node-version: ${{ inputs.node-version }}
+          action: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+          with: |
+            node-version: ${{ inputs.node-version }}
+            cache: npm
+          attempt_limit: 3
+          attempt_delay: 5000
 
       - name: Download Unit Test Coverage Report
         uses: actions/download-artifact@9c19ed7fe5d278cd354c7dfd5d3b88589c7e2395 # v4.1.6

--- a/.github/workflows/zxc-compile-code.yaml
+++ b/.github/workflows/zxc-compile-code.yaml
@@ -70,7 +70,7 @@ jobs:
       matrix:
         os:
           - windows-2022
-          - [self-hosted, Linux, medium, ephemeral]
+          - [self-hosted, Linux, large, ephemeral]
     steps:
       - name: Checkout Code
         uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3

--- a/.github/workflows/zxc-compile-code.yaml
+++ b/.github/workflows/zxc-compile-code.yaml
@@ -75,11 +75,15 @@ jobs:
       - name: Checkout Code
         uses: actions/checkout@1d96c772d19495a3b5c517cd2bc0cb401ea0529f # v4.1.3
 
-      - name: Setup Node
-        uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+      - name: Setup Node with Retry
+        uses: Wandalen/wretry.action@0dd1d5d77d019a6f85beb53d29e2ea2c7294d4f2 # v3.4.0
         with:
-          node-version: ${{ inputs.node-version }}
-          cache: npm
+          action: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
+          with: |
+            node-version: ${{ inputs.node-version }}
+            cache: npm
+          attempt_limit: 3
+          attempt_delay: 5000
 
       - name: Install wget
         if: ${{ runner.os == 'linux' && inputs.enable-e2e-tests && !cancelled() && !failure() }}
@@ -111,7 +115,7 @@ jobs:
         run: npm test
 
       - name: Publish Windows Unit Test Report
-        uses: EnricoMi/publish-unit-test-result-action/windows/bash@v2.15.1
+        uses: EnricoMi/publish-unit-test-result-action/windows/bash@f355d34d53ad4e7f506f699478db2dd71da9de5f # v2.15.1
         if: ${{ runner.os == 'Windows' && inputs.enable-unit-tests && steps.npm-deps.conclusion == 'success' && !cancelled() }}
         with:
           check_name: 'Unit Test Results - ${{ runner.os }}'


### PR DESCRIPTION
## Description

This pull request changes the following:

* bump e2e tests to use solo linux large
* auto retry setup-node action
* update workflow concurrency groups to be more unique

### Related Issues

* Closes #
