### PR TITLE
ci: revert concurrency group change

### DIFF
--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -28,7 +28,7 @@ defaults:
     shell: bash
 
 concurrency:
-  group: pr-checks-${{ github.repository }}-${{ github.ref }}
+  group: pr-checks-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:

--- a/.github/workflows/flow-pull-request-formatting.yaml
+++ b/.github/workflows/flow-pull-request-formatting.yaml
@@ -33,7 +33,7 @@ permissions:
   statuses: write
 
 concurrency:
-  group: pr-formatting-${{ github.repository }}-${{ github.ref }}
+  group: pr-formatting-${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
## Description

This pull request changes the following:

* the concurrency group change did not work as intended, reverting to prior changes

### Related Issues

* Closes #
