### PR TITLE
fix: increase wait time for when recycling an haproxy pod for a node

### DIFF
--- a/src/core/k8.mjs
+++ b/src/core/k8.mjs
@@ -776,7 +776,8 @@ export class K8 {
 
     let attempts = 0
     while (attempts++ < maxAttempts) {
-      const status = await this.waitForPod(constants.POD_STATUS_RUNNING, podLabels)
+      // wait longer for pods to be deleted and recreated when running in CI with high loads of parallel runners
+      const status = await this.waitForPod(constants.POD_STATUS_RUNNING, podLabels, 1, 120, 1000)
       if (status) {
         const newPods = await this.getPodsByLabel(podLabels)
         if (newPods.length === podArray.length) return newPods

--- a/test/e2e/commands/node.test.mjs
+++ b/test/e2e/commands/node.test.mjs
@@ -46,6 +46,8 @@ import path from 'path'
 import fs from 'fs'
 import crypto from 'crypto'
 
+const defaultTimeout = 20000
+
 describe.each([
   { releaseTag: 'v0.49.0-alpha.2', keyFormat: constants.KEY_FORMAT_PFX, testName: 'node-cmd-e2e-pfx', mode: 'kill' },
   { releaseTag: 'v0.49.0-alpha.2', keyFormat: constants.KEY_FORMAT_PEM, testName: 'node-cmd-e2e-pem', mode: 'stop' }
@@ -90,7 +92,7 @@ describe.each([
       } finally {
         await nodeCmd.close()
       }
-    }, 20000)
+    }, defaultTimeout)
   })
 
   describe(`Node should refresh successfully [mode ${input.mode}, release ${input.releaseTag}, keyFormat: ${input.keyFormat}]`, () => {
@@ -176,7 +178,7 @@ describe.each([
                 `${nodeId}:${keyFileName}:${existingKeyHash}`)
         }
       }
-    })
+    }, 60000)
   })
 })
 
@@ -245,7 +247,7 @@ function nodePodShouldBeRunning (nodeCmd, namespace, nodeId) {
     } finally {
       await nodeCmd.close()
     }
-  }, 20000)
+  }, defaultTimeout)
 }
 
 function nodeRefreshShouldSucceed (nodeId, nodeCmd, argv) {
@@ -273,7 +275,7 @@ function nodeShouldNotBeActive (nodeCmd, nodeId) {
     } finally {
       await nodeCmd.close()
     }
-  }, 20000)
+  }, defaultTimeout)
 }
 
 async function nodeRefreshTestSetup (argv, testName, k8, nodeId) {


### PR DESCRIPTION
## Description

This pull request changes the following:

* increase wait time for when recycling an haproxy pod for a node that causes e2e node.test.mjs to fail and timeout when many runners are active in CI pipeline

> example failure: https://github.com/hashgraph/solo/actions/runs/9035734886/job/24831179235?pr=284

### Related Issues

* Closes #291 
