### PR TITLE
ci: use cgroups in github agent runner

### DIFF
--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -62,7 +62,7 @@ permissions:
   statuses: write
 
 env:
-  CG_EXEC: export UID=$(id -u); CGROUP_LOGLEVEL=DEBUG cgexec -g cpu,memory:user.slice/user-${UID}.slice/user@${UID}.service/e2e-${{ github.run_id }}
+  CG_EXEC: "export R_UID=$(id -u); CGROUP_LOGLEVEL=DEBUG cgexec -g cpu,memory:user.slice/user-${R_UID}.slice/user@${R_UID}.service/e2e-${{ github.run_id }}"
   # CG_EXEC: cgexec -g cpu,memory:e2e-${{ github.run_id }} --sticky ionice -c 2 -n 2 nice -n 19
 
 jobs:

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -62,7 +62,7 @@ permissions:
   statuses: write
 
 env:
-  CG_EXEC: CGROUP_LOGLEVEL=DEBUG cgexec -g cpu,memory:e2e-${{ github.run_id }}
+  CG_EXEC: CGROUP_LOGLEVEL=DEBUG cgexec -g cpu,memory:user.slice/user-$(id -u).slice/user@$(id -u).service/e2e-${{ github.run_id }}
   # CG_EXEC: cgexec -g cpu,memory:e2e-${{ github.run_id }} --sticky ionice -c 2 -n 2 nice -n 19
 
 jobs:
@@ -82,7 +82,9 @@ jobs:
             E2E_MEM_LIMIT="30064771072"
             AGENT_MEM_LIMIT="2147483648"
             E2E_GROUP_NAME="e2e-${{ github.run_id }}"
+            E2E_GROUP_NAME_FQ="user.slice/user-$(id -u).slice/user@$(id -u).service/${E2E_GROUP_NAME}"
             AGENT_GROUP_NAME="agent-${{ github.run_id }}"
+            AGENT_GROUP_NAME_FQ="user.slice/user-$(id -u).slice/user@$(id -u).service/${AGENT_GROUP_NAME}"
           echo "::endgroup::"
 
           echo "::group::Install Control Group Tools"
@@ -93,22 +95,22 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Create Control Groups"
-            sudo cgcreate -g cpu,memory:${E2E_GROUP_NAME} -a ${USR_ID}:${GRP_ID} -t ${USR_ID}:${GRP_ID}
-            sudo cgcreate -g cpu,memory:${AGENT_GROUP_NAME} -a ${USR_ID}:${GRP_ID} -t ${USR_ID}:${GRP_ID}
+            sudo cgcreate -g cpu,memory:${E2E_GROUP_NAME_FQ} -a ${USR_ID}:${GRP_ID} -t ${USR_ID}:${GRP_ID}
+            sudo cgcreate -g cpu,memory:${AGENT_GROUP_NAME_FQ} -a ${USR_ID}:${GRP_ID} -t ${USR_ID}:${GRP_ID}
           echo "::endgroup::"
 
           echo "::group::Set Control Group Limits"
-            cgset -r cpu.weight=768 ${E2E_GROUP_NAME}
-            cgset -r cpu.weight=500 ${AGENT_GROUP_NAME}
-            cgset -r memory.max=${E2E_MEM_LIMIT} ${E2E_GROUP_NAME}
-            cgset -r memory.max=${AGENT_MEM_LIMIT} ${AGENT_GROUP_NAME}
-            cgset -r memory.swap.max=${E2E_MEM_LIMIT} ${E2E_GROUP_NAME}
-            cgset -r memory.swap.max=${AGENT_MEM_LIMIT} ${AGENT_GROUP_NAME}
+            cgset -r cpu.weight=768 ${E2E_GROUP_NAME_FQ}
+            cgset -r cpu.weight=500 ${AGENT_GROUP_NAME_FQ}
+            cgset -r memory.max=${E2E_MEM_LIMIT} ${E2E_GROUP_NAME_FQ}
+            cgset -r memory.max=${AGENT_MEM_LIMIT} ${AGENT_GROUP_NAME_FQ}
+            cgset -r memory.swap.max=${E2E_MEM_LIMIT} ${E2E_GROUP_NAME_FQ}
+            cgset -r memory.swap.max=${AGENT_MEM_LIMIT} ${AGENT_GROUP_NAME_FQ}
           echo "::endgroup::"
 
           echo "::group::Move Runner Processes to Control Groups"
-            sudo cgclassify --sticky -g cpu,memory:${AGENT_GROUP_NAME} $(pgrep 'Runner.Listener' | tr '\n' ' ')
-            sudo cgclassify -g cpu,memory:${AGENT_GROUP_NAME} $(pgrep 'Runner.Worker' | tr '\n' ' ')
+            sudo cgclassify --sticky -g cpu,memory:${AGENT_GROUP_NAME_FQ} $(pgrep 'Runner.Listener' | tr '\n' ' ')
+            sudo cgclassify -g cpu,memory:${AGENT_GROUP_NAME_FQ} $(pgrep 'Runner.Worker' | tr '\n' ' ')
           echo "::endgroup::"
           
           set +x

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -62,7 +62,7 @@ permissions:
   statuses: write
 
 env:
-  CG_EXEC: UID=$(id -u); CGROUP_LOGLEVEL=DEBUG cgexec -g cpu,memory:user.slice/user-${UID}.slice/user@${UID}.service/e2e-${{ github.run_id }}
+  CG_EXEC: export UID=$(id -u); CGROUP_LOGLEVEL=DEBUG cgexec -g cpu,memory:user.slice/user-${UID}.slice/user@${UID}.service/e2e-${{ github.run_id }}
   # CG_EXEC: cgexec -g cpu,memory:e2e-${{ github.run_id }} --sticky ionice -c 2 -n 2 nice -n 19
 
 jobs:

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -97,12 +97,12 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Set Control Group Limits"
-            cgset -r cpu.shares=768 ${E2E_GROUP_NAME}
-            cgset -r cpu.shares=500 ${AGENT_GROUP_NAME}
-            cgset -r memory.limit_in_bytes=${E2E_MEM_LIMIT} ${E2E_GROUP_NAME}
-            cgset -r memory.limit_in_bytes=${AGENT_MEM_LIMIT} ${AGENT_GROUP_NAME}
-            cgset -r memory.memsw.limit_in_bytes=${E2E_MEM_LIMIT} ${E2E_GROUP_NAME}
-            cgset -r memory.memsw.limit_in_bytes=${AGENT_MEM_LIMIT} ${AGENT_GROUP_NAME}
+            sudo cgset -r cpu.shares=768 ${E2E_GROUP_NAME}
+            sudo cgset -r cpu.shares=500 ${AGENT_GROUP_NAME}
+            sudo cgset -r memory.limit_in_bytes=${E2E_MEM_LIMIT} ${E2E_GROUP_NAME}
+            sudo cgset -r memory.limit_in_bytes=${AGENT_MEM_LIMIT} ${AGENT_GROUP_NAME}
+            sudo cgset -r memory.memsw.limit_in_bytes=${E2E_MEM_LIMIT} ${E2E_GROUP_NAME}
+            sudo cgset -r memory.memsw.limit_in_bytes=${AGENT_MEM_LIMIT} ${AGENT_GROUP_NAME}
           echo "::endgroup::"
 
           echo "::group::Move Runner Processes to Control Groups"

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -146,11 +146,16 @@ jobs:
 
       - name: Setup E2E Tests
         run: | 
+          set -x
           npm link
           ${CG_EXEC} ./test/e2e/setup-e2e.sh
+          set +x
 
       - name: Run E2E Tests
-        run: ${CG_EXEC} npm run ${{ inputs.npm-test-script }}
+        run: |
+          set -x
+          ${CG_EXEC} npm run ${{ inputs.npm-test-script }}
+          set +x
 
       - name: Upload E2E Logs to GitHub
         if: ${{ !cancelled() }}

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -62,7 +62,7 @@ permissions:
   statuses: write
 
 env:
-  CG_EXEC: CGROUP_LOGLEVEL=DEBUG cgexec -g cpu,memory:user.slice/user-$(id -u).slice/user@$(id -u).service/e2e-${{ github.run_id }}
+  CG_EXEC: CGROUP_LOGLEVEL=DEBUG cgexec -g 'cpu,memory:user.slice/user-$(id -u).slice/user@$(id -u).service/e2e-${{ github.run_id }}'
   # CG_EXEC: cgexec -g cpu,memory:e2e-${{ github.run_id }} --sticky ionice -c 2 -n 2 nice -n 19
 
 jobs:

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -62,7 +62,8 @@ permissions:
   statuses: write
 
 env:
-  CG_EXEC: cgexec -g cpu,memory:e2e-${{ github.run_id }} --sticky ionice -c 2 -n 2 nice -n 19
+  CG_EXEC: cgexec -g cpu,memory:e2e-${{ github.run_id }}
+  # CG_EXEC: cgexec -g cpu,memory:e2e-${{ github.run_id }} --sticky ionice -c 2 -n 2 nice -n 19
 
 jobs:
   e2e-test:
@@ -97,12 +98,12 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Set Control Group Limits"
-            sudo cgset -r cpu.weight=768 ${E2E_GROUP_NAME}
-            sudo cgset -r cpu.weight=500 ${AGENT_GROUP_NAME}
-            sudo cgset -r memory.max=${E2E_MEM_LIMIT} ${E2E_GROUP_NAME}
-            sudo cgset -r memory.max=${AGENT_MEM_LIMIT} ${AGENT_GROUP_NAME}
-            sudo cgset -r memory.swap.max=${E2E_MEM_LIMIT} ${E2E_GROUP_NAME}
-            sudo cgset -r memory.swap.max=${AGENT_MEM_LIMIT} ${AGENT_GROUP_NAME}
+            cgset -r cpu.weight=768 ${E2E_GROUP_NAME}
+            cgset -r cpu.weight=500 ${AGENT_GROUP_NAME}
+            cgset -r memory.max=${E2E_MEM_LIMIT} ${E2E_GROUP_NAME}
+            cgset -r memory.max=${AGENT_MEM_LIMIT} ${AGENT_GROUP_NAME}
+            cgset -r memory.swap.max=${E2E_MEM_LIMIT} ${E2E_GROUP_NAME}
+            cgset -r memory.swap.max=${AGENT_MEM_LIMIT} ${AGENT_GROUP_NAME}
           echo "::endgroup::"
 
           echo "::group::Move Runner Processes to Control Groups"

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -74,6 +74,7 @@ jobs:
 
       - name: Setup Control Groups
         run: |
+          set -x
           echo "::group::Get System Configuration"
             USR_ID="$(id -un)"
             GRP_ID="$(id -gn)"
@@ -108,6 +109,8 @@ jobs:
             sudo cgclassify --sticky -g cpu,memory:${AGENT_GROUP_NAME} $(pgrep 'Runner.Listener' | tr '\n' ' ')
             sudo cgclassify -g cpu,memory:${AGENT_GROUP_NAME} $(pgrep 'Runner.Worker' | tr '\n' ' ')
           echo "::endgroup::"
+          
+          set +x
 
       - name: Setup Node with Retry
         uses: Wandalen/wretry.action@6feedb7dedadeb826de0f45ff482b53b379a7844 # v3.5.0

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -62,7 +62,7 @@ permissions:
   statuses: write
 
 env:
-  CG_EXEC: "export R_UID=$(id -u); CGROUP_LOGLEVEL=DEBUG cgexec -g cpu,memory:user.slice/user-${R_UID}.slice/user@${R_UID}.service/e2e-${{ github.run_id }}"
+  CG_EXEC: export R_UID=$(id -u); CGROUP_LOGLEVEL=DEBUG cgexec -g cpu,memory:user.slice/user-${R_UID}.slice/user@${R_UID}.service/e2e-${{ github.run_id }}
   # CG_EXEC: cgexec -g cpu,memory:e2e-${{ github.run_id }} --sticky ionice -c 2 -n 2 nice -n 19
 
 jobs:
@@ -152,13 +152,13 @@ jobs:
           set -x
           npm link
           cat /proc/self/cgroup
-          ${CG_EXEC} ./test/e2e/setup-e2e.sh
+          ${{ env.CG_EXEC }} ./test/e2e/setup-e2e.sh
           set +x
 
       - name: Run E2E Tests
         run: |
           set -x
-          ${CG_EXEC} npm run ${{ inputs.npm-test-script }}
+          ${{ env.CG_EXEC }} npm run ${{ inputs.npm-test-script }}
           set +x
 
       - name: Upload E2E Logs to GitHub

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -83,10 +83,8 @@ jobs:
             AGENT_MEM_LIMIT="2147483648"
             USER_SLICE="user.slice/user-$(id -u).slice"
             USER_SERVICE="${USER_SLICE}/user@$(id -u).service" 
-            E2E_GROUP_NAME="e2e-${{ github.run_id }}"
-            E2E_GROUP_NAME_FQ="${USER_SERVICE}/${E2E_GROUP_NAME}"
-            AGENT_GROUP_NAME="agent-${{ github.run_id }}"
-            AGENT_GROUP_NAME_FQ="${USER_SERVICE}/${AGENT_GROUP_NAME}"
+            E2E_GROUP_NAME="${USER_SERVICE}/e2e-${{ github.run_id }}"
+            AGENT_GROUP_NAME="${USER_SERVICE}/agent-${{ github.run_id }}"
           echo "::endgroup::"
 
           echo "::group::Install Control Group Tools"
@@ -97,22 +95,24 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Create Control Groups"
-            sudo cgcreate -g cpu,memory:${E2E_GROUP_NAME_FQ} -a ${USR_ID}:${GRP_ID} -t ${USR_ID}:${GRP_ID}
-            sudo cgcreate -g cpu,memory:${AGENT_GROUP_NAME_FQ} -a ${USR_ID}:${GRP_ID} -t ${USR_ID}:${GRP_ID}
+            sudo cgcreate -g cpu,memory:${USER_SLICE} -a ${USR_ID}:${GRP_ID} -t ${USR_ID}:${GRP_ID}
+            sudo cgcreate -g cpu,memory:${USER_SERVICE} -a ${USR_ID}:${GRP_ID} -t ${USR_ID}:${GRP_ID}
+            sudo cgcreate -g cpu,memory:${E2E_GROUP_NAME} -a ${USR_ID}:${GRP_ID} -t ${USR_ID}:${GRP_ID}
+            sudo cgcreate -g cpu,memory:${AGENT_GROUP_NAME} -a ${USR_ID}:${GRP_ID} -t ${USR_ID}:${GRP_ID}
           echo "::endgroup::"
 
           echo "::group::Set Control Group Limits"
-            cgset -r cpu.weight=768 ${E2E_GROUP_NAME_FQ}
-            cgset -r cpu.weight=500 ${AGENT_GROUP_NAME_FQ}
-            cgset -r memory.max=${E2E_MEM_LIMIT} ${E2E_GROUP_NAME_FQ}
-            cgset -r memory.max=${AGENT_MEM_LIMIT} ${AGENT_GROUP_NAME_FQ}
-            cgset -r memory.swap.max=${E2E_MEM_LIMIT} ${E2E_GROUP_NAME_FQ}
-            cgset -r memory.swap.max=${AGENT_MEM_LIMIT} ${AGENT_GROUP_NAME_FQ}
+            cgset -r cpu.weight=768 ${E2E_GROUP_NAME}
+            cgset -r cpu.weight=500 ${AGENT_GROUP_NAME}
+            cgset -r memory.max=${E2E_MEM_LIMIT} ${E2E_GROUP_NAME}
+            cgset -r memory.max=${AGENT_MEM_LIMIT} ${AGENT_GROUP_NAME}
+            cgset -r memory.swap.max=${E2E_MEM_LIMIT} ${E2E_GROUP_NAME}
+            cgset -r memory.swap.max=${AGENT_MEM_LIMIT} ${AGENT_GROUP_NAME}
           echo "::endgroup::"
 
           echo "::group::Move Runner Processes to Control Groups"
-            sudo cgclassify --sticky -g cpu,memory:${AGENT_GROUP_NAME_FQ} $(pgrep 'Runner.Listener' | tr '\n' ' ')
-            sudo cgclassify -g cpu,memory:${AGENT_GROUP_NAME_FQ} $(pgrep 'Runner.Worker' | tr '\n' ' ')
+            sudo cgclassify --sticky -g cpu,memory:${AGENT_GROUP_NAME} $(pgrep 'Runner.Listener' | tr '\n' ' ')
+            sudo cgclassify -g cpu,memory:${AGENT_GROUP_NAME} $(pgrep 'Runner.Worker' | tr '\n' ' ')
           echo "::endgroup::"
           
           ls -al /sys/fs/cgroup/user.slice

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -81,10 +81,12 @@ jobs:
             GRP_ID="$(id -gn)"
             E2E_MEM_LIMIT="30064771072"
             AGENT_MEM_LIMIT="2147483648"
+            USER_SLICE="user.slice/user-$(id -u).slice"
+            USER_SERVICE="${USER_SLICE}/user@$(id -u).service" 
             E2E_GROUP_NAME="e2e-${{ github.run_id }}"
-            E2E_GROUP_NAME_FQ="user.slice/user-$(id -u).slice/user@$(id -u).service/${E2E_GROUP_NAME}"
+            E2E_GROUP_NAME_FQ="${USER_SERVICE}/${E2E_GROUP_NAME}"
             AGENT_GROUP_NAME="agent-${{ github.run_id }}"
-            AGENT_GROUP_NAME_FQ="user.slice/user-$(id -u).slice/user@$(id -u).service/${AGENT_GROUP_NAME}"
+            AGENT_GROUP_NAME_FQ="${USER_SERVICE}/${AGENT_GROUP_NAME}"
           echo "::endgroup::"
 
           echo "::group::Install Control Group Tools"
@@ -113,6 +115,9 @@ jobs:
             sudo cgclassify -g cpu,memory:${AGENT_GROUP_NAME_FQ} $(pgrep 'Runner.Worker' | tr '\n' ' ')
           echo "::endgroup::"
           
+          ls -al /sys/fs/cgroup/user.slice
+          ls -al /sys/fs/cgroup/${USER_SLICE}
+          ls -al /sys/fs/cgroup/${USER_SERVICE}
           set +x
 
       - name: Setup Node with Retry

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -74,7 +74,6 @@ jobs:
 
       - name: Setup Control Groups
         run: |
-          set -x
           echo "::group::Get System Configuration"
             USR_ID="$(id -un)"
             GRP_ID="$(id -gn)"
@@ -113,8 +112,6 @@ jobs:
             sudo cgclassify --sticky -g cpu,memory:${AGENT_GROUP_NAME} $(pgrep 'Runner.Listener' | tr '\n' ' ')
             sudo cgclassify -g cpu,memory:${AGENT_GROUP_NAME} $(pgrep 'Runner.Worker' | tr '\n' ' ')
           echo "::endgroup::"
-          
-          set +x
 
       - name: Setup Node with Retry
         uses: Wandalen/wretry.action@6feedb7dedadeb826de0f45ff482b53b379a7844 # v3.5.0
@@ -150,16 +147,12 @@ jobs:
 
       - name: Setup E2E Tests
         run: | 
-          set -x
           npm link
           ${{ env.CG_EXEC }} ./test/e2e/setup-e2e.sh
-          set +x
 
       - name: Run E2E Tests
         run: |
-          set -x
           ${{ env.CG_EXEC }} npm run ${{ inputs.npm-test-script }}
-          set +x
 
       - name: Upload E2E Logs to GitHub
         if: ${{ !cancelled() }}

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -155,6 +155,7 @@ jobs:
       - name: Run E2E Tests
         run: |
           set -x
+          cat /proc/self/cgroup
           ${CG_EXEC} npm run ${{ inputs.npm-test-script }}
           set +x
 

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -62,8 +62,7 @@ permissions:
   statuses: write
 
 env:
-  CG_EXEC: export R_UID=$(id -u); CGROUP_LOGLEVEL=DEBUG cgexec -g cpu,memory:user.slice/user-${R_UID}.slice/user@${R_UID}.service/e2e-${{ github.run_id }}
-  # CG_EXEC: cgexec -g cpu,memory:e2e-${{ github.run_id }} --sticky ionice -c 2 -n 2 nice -n 19
+  CG_EXEC: export R_UID=$(id -u); CGROUP_LOGLEVEL=DEBUG cgexec -g cpu,memory:user.slice/user-${R_UID}.slice/user@${R_UID}.service/e2e-${{ github.run_id }} --sticky ionice -c 2 -n 2 nice -n 19
 
 jobs:
   e2e-test:
@@ -115,9 +114,6 @@ jobs:
             sudo cgclassify -g cpu,memory:${AGENT_GROUP_NAME} $(pgrep 'Runner.Worker' | tr '\n' ' ')
           echo "::endgroup::"
           
-          ls -al /sys/fs/cgroup/user.slice
-          ls -al /sys/fs/cgroup/${USER_SLICE}
-          ls -al /sys/fs/cgroup/${USER_SERVICE}
           set +x
 
       - name: Setup Node with Retry
@@ -156,7 +152,6 @@ jobs:
         run: | 
           set -x
           npm link
-          cat /proc/self/cgroup
           ${{ env.CG_EXEC }} ./test/e2e/setup-e2e.sh
           set +x
 

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -97,12 +97,12 @@ jobs:
           echo "::endgroup::"
 
           echo "::group::Set Control Group Limits"
-            sudo cgset -r cpu.shares=768 ${E2E_GROUP_NAME}
-            sudo cgset -r cpu.shares=500 ${AGENT_GROUP_NAME}
-            sudo cgset -r memory.limit_in_bytes=${E2E_MEM_LIMIT} ${E2E_GROUP_NAME}
-            sudo cgset -r memory.limit_in_bytes=${AGENT_MEM_LIMIT} ${AGENT_GROUP_NAME}
-            sudo cgset -r memory.memsw.limit_in_bytes=${E2E_MEM_LIMIT} ${E2E_GROUP_NAME}
-            sudo cgset -r memory.memsw.limit_in_bytes=${AGENT_MEM_LIMIT} ${AGENT_GROUP_NAME}
+            sudo cgset -r cpu.weight=768 ${E2E_GROUP_NAME}
+            sudo cgset -r cpu.weight=500 ${AGENT_GROUP_NAME}
+            sudo cgset -r memory.max=${E2E_MEM_LIMIT} ${E2E_GROUP_NAME}
+            sudo cgset -r memory.max=${AGENT_MEM_LIMIT} ${AGENT_GROUP_NAME}
+            sudo cgset -r memory.swap.max=${E2E_MEM_LIMIT} ${E2E_GROUP_NAME}
+            sudo cgset -r memory.swap.max=${AGENT_MEM_LIMIT} ${AGENT_GROUP_NAME}
           echo "::endgroup::"
 
           echo "::group::Move Runner Processes to Control Groups"

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -61,6 +61,9 @@ permissions:
   checks: write
   statuses: write
 
+env:
+  CG_EXEC: cgexec -g cpu,memory:e2e-${{ github.run_id }} --sticky ionice -c 2 -n 2 nice -n 19
+
 jobs:
   e2e-test:
     name: ${{ inputs.custom-job-label || 'E2E Test' }}
@@ -68,6 +71,43 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
+
+      - name: Setup Control Groups
+        run: |
+          echo "::group::Get System Configuration"
+            USR_ID="$(id -un)"
+            GRP_ID="$(id -gn)"
+            E2E_MEM_LIMIT="30064771072"
+            AGENT_MEM_LIMIT="2147483648"
+            E2E_GROUP_NAME="e2e-${{ github.run_id }}"
+            AGENT_GROUP_NAME="agent-${{ github.run_id }}"
+          echo "::endgroup::"
+
+          echo "::group::Install Control Group Tools"
+            if ! command -v cgcreate >/dev/null 2>&1; then
+              sudo apt-get update
+              sudo apt-get install -y cgroup-tools
+            fi
+          echo "::endgroup::"
+
+          echo "::group::Create Control Groups"
+            sudo cgcreate -g cpu,memory:${E2E_GROUP_NAME} -a ${USR_ID}:${GRP_ID} -t ${USR_ID}:${GRP_ID}
+            sudo cgcreate -g cpu,memory:${AGENT_GROUP_NAME} -a ${USR_ID}:${GRP_ID} -t ${USR_ID}:${GRP_ID}
+          echo "::endgroup::"
+
+          echo "::group::Set Control Group Limits"
+            cgset -r cpu.shares=768 ${E2E_GROUP_NAME}
+            cgset -r cpu.shares=500 ${AGENT_GROUP_NAME}
+            cgset -r memory.limit_in_bytes=${E2E_MEM_LIMIT} ${E2E_GROUP_NAME}
+            cgset -r memory.limit_in_bytes=${AGENT_MEM_LIMIT} ${AGENT_GROUP_NAME}
+            cgset -r memory.memsw.limit_in_bytes=${E2E_MEM_LIMIT} ${E2E_GROUP_NAME}
+            cgset -r memory.memsw.limit_in_bytes=${AGENT_MEM_LIMIT} ${AGENT_GROUP_NAME}
+          echo "::endgroup::"
+
+          echo "::group::Move Runner Processes to Control Groups"
+            sudo cgclassify --sticky -g cpu,memory:${AGENT_GROUP_NAME} $(pgrep 'Runner.Listener' | tr '\n' ' ')
+            sudo cgclassify -g cpu,memory:${AGENT_GROUP_NAME} $(pgrep 'Runner.Worker' | tr '\n' ' ')
+          echo "::endgroup::"
 
       - name: Setup Node with Retry
         uses: Wandalen/wretry.action@6feedb7dedadeb826de0f45ff482b53b379a7844 # v3.5.0
@@ -104,10 +144,10 @@ jobs:
       - name: Setup E2E Tests
         run: | 
           npm link
-          ./test/e2e/setup-e2e.sh
+          ${CG_EXEC} ./test/e2e/setup-e2e.sh
 
       - name: Run E2E Tests
-        run: npm run ${{ inputs.npm-test-script }}
+        run: ${CG_EXEC} npm run ${{ inputs.npm-test-script }}
 
       - name: Upload E2E Logs to GitHub
         if: ${{ !cancelled() }}

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -62,7 +62,7 @@ permissions:
   statuses: write
 
 env:
-  CG_EXEC: cgexec -g cpu,memory:e2e-${{ github.run_id }}
+  CG_EXEC: CGROUP_LOGLEVEL=DEBUG cgexec -g cpu,memory:e2e-${{ github.run_id }}
   # CG_EXEC: cgexec -g cpu,memory:e2e-${{ github.run_id }} --sticky ionice -c 2 -n 2 nice -n 19
 
 jobs:
@@ -149,13 +149,13 @@ jobs:
         run: | 
           set -x
           npm link
+          cat /proc/self/cgroup
           ${CG_EXEC} ./test/e2e/setup-e2e.sh
           set +x
 
       - name: Run E2E Tests
         run: |
           set -x
-          cat /proc/self/cgroup
           ${CG_EXEC} npm run ${{ inputs.npm-test-script }}
           set +x
 

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -62,7 +62,7 @@ permissions:
   statuses: write
 
 env:
-  CG_EXEC: CGROUP_LOGLEVEL=DEBUG cgexec -g 'cpu,memory:user.slice/user-$(id -u).slice/user@$(id -u).service/e2e-${{ github.run_id }}'
+  CG_EXEC: UID=$(id -u); CGROUP_LOGLEVEL=DEBUG cgexec -g cpu,memory:user.slice/user-${UID}.slice/user@${UID}.service/e2e-${{ github.run_id }}
   # CG_EXEC: cgexec -g cpu,memory:e2e-${{ github.run_id }} --sticky ionice -c 2 -n 2 nice -n 19
 
 jobs:


### PR DESCRIPTION
## Description

This pull request changes the following:

* add use of cgroups into `.github/workflows/zxc-e2e-test.yaml` to ensure that runner retains enough resources to stay connected to GitHub and not get canclled

### Related Issues

* Closes #293 
