### PR TITLE
feat: mount application.env as a configMap

### DIFF
--- a/src/commands/init.mjs
+++ b/src/commands/init.mjs
@@ -161,7 +161,8 @@ export class InitCommand extends BaseCommand {
           flags.keyFormat,
           flags.fstChartVersion,
           flags.profileName,
-          flags.profileFile
+          flags.profileFile,
+          flags.applicationEnv
         )
       },
       handler: (argv) => {

--- a/src/commands/network.mjs
+++ b/src/commands/network.mjs
@@ -73,9 +73,9 @@ export class NetworkCommand extends BaseCommand {
     }
 
     const profileName = this.configManager.getFlag(flags.profileName)
-    const profileValuesFile = await this.profileManager.prepareValuesForFstChart(profileName)
-    if (profileValuesFile) {
-      valuesArg += this.prepareValuesFiles(profileValuesFile)
+    this.profileValuesFile = await this.profileManager.prepareValuesForFstChart(profileName, config.applicationEnv)
+    if (this.profileValuesFile) {
+      valuesArg += this.prepareValuesFiles(this.profileValuesFile)
     }
 
     // do not deploy mirror node until after we have the updated address book
@@ -126,7 +126,8 @@ export class NetworkCommand extends BaseCommand {
       tlsClusterIssuerType: this.configManager.getFlag(flags.tlsClusterIssuerType),
       enableHederaExplorerTls: this.configManager.getFlag(flags.enableHederaExplorerTls),
       hederaExplorerTlsHostName: this.configManager.getFlag(flags.hederaExplorerTlsHostName),
-      enablePrometheusSvcMonitor: this.configManager.getFlag(flags.enablePrometheusSvcMonitor)
+      enablePrometheusSvcMonitor: this.configManager.getFlag(flags.enablePrometheusSvcMonitor),
+      applicationEnv: this.configManager.getFlag(flags.applicationEnv)
     }
 
     // compute values
@@ -418,7 +419,8 @@ export class NetworkCommand extends BaseCommand {
               flags.enablePrometheusSvcMonitor,
               flags.fstChartVersion,
               flags.profileFile,
-              flags.profileName
+              flags.profileName,
+              flags.applicationEnv
             ),
             handler: argv => {
               networkCmd.logger.debug('==== Running \'network deploy\' ===')
@@ -469,7 +471,8 @@ export class NetworkCommand extends BaseCommand {
               flags.enableHederaExplorerTls,
               flags.hederaExplorerTlsLoadBalancerIp,
               flags.hederaExplorerTlsHostName,
-              flags.enablePrometheusSvcMonitor
+              flags.enablePrometheusSvcMonitor,
+              flags.applicationEnv
             ),
             handler: argv => {
               networkCmd.logger.debug('==== Running \'chart upgrade\' ===')

--- a/src/commands/node.mjs
+++ b/src/commands/node.mjs
@@ -640,7 +640,6 @@ export class NodeCommand extends BaseCommand {
           ctx.config = {
             namespace: self.configManager.getFlag(flags.namespace),
             nodeIds: helpers.parseNodeIds(self.configManager.getFlag(flags.nodeIDs)),
-            applicationEnv: self.configManager.getFlag(flags.applicationEnv),
             cacheDir: self.configManager.getFlag(flags.cacheDir)
           }
 
@@ -907,7 +906,6 @@ export class NodeCommand extends BaseCommand {
             releaseTag: self.configManager.getFlag(flags.releaseTag),
             cacheDir: self.configManager.getFlag(flags.cacheDir),
             force: self.configManager.getFlag(flags.force),
-            applicationEnv: self.configManager.getFlag(flags.applicationEnv),
             keyFormat: self.configManager.getFlag(flags.keyFormat),
             devMode: self.configManager.getFlag(flags.devMode),
             curDate: new Date()
@@ -1481,15 +1479,6 @@ export class NodeCommand extends BaseCommand {
         title: `Start node: ${chalk.yellow(nodeId)}`,
         task: async () => {
           await this.k8.execContainer(podName, constants.ROOT_CONTAINER, ['bash', '-c', `rm -rf ${constants.HEDERA_HAPI_PATH}/output/*`])
-
-          // copy application.env file if required
-          if (config.applicationEnv) {
-            const stagingDir = Templates.renderStagingDir(this.configManager, flags)
-            const applicationEnvFile = path.join(stagingDir, 'application.env')
-            fs.cpSync(config.applicationEnv, applicationEnvFile)
-            await this.k8.copyTo(podName, constants.ROOT_CONTAINER, applicationEnvFile, `${constants.HEDERA_HAPI_PATH}`)
-          }
-
           await this.k8.execContainer(podName, constants.ROOT_CONTAINER, ['systemctl', 'restart', 'network-node'])
         }
       })
@@ -1576,8 +1565,7 @@ export class NodeCommand extends BaseCommand {
             desc: 'Start a node',
             builder: y => flags.setCommandFlags(y,
               flags.namespace,
-              flags.nodeIDs,
-              flags.applicationEnv
+              flags.nodeIDs
             ),
             handler: argv => {
               nodeCmd.logger.debug('==== Running \'node start\' ===')
@@ -1643,7 +1631,6 @@ export class NodeCommand extends BaseCommand {
               flags.nodeIDs,
               flags.releaseTag,
               flags.cacheDir,
-              flags.applicationEnv,
               flags.keyFormat
             ),
             handler: argv => {

--- a/src/core/profile_manager.mjs
+++ b/src/core/profile_manager.mjs
@@ -213,9 +213,10 @@ export class ProfileManager {
   /**
    * Prepare a values file for FST Helm chart
    * @param profileName resource profile name
+   * @param applicationEnvFilePath path to the application.env file
    * @return {Promise<string>} return the full path to the values file
    */
-  prepareValuesForFstChart (profileName) {
+  prepareValuesForFstChart (profileName, applicationEnvFilePath = null) {
     if (!profileName) throw new MissingArgumentError('profileName is required')
     const profile = this.getProfile(profileName)
 
@@ -228,6 +229,11 @@ export class ProfileManager {
     this.resourcesForHaProxyPod(profile, yamlRoot)
     this.resourcesForEnvoyProxyPod(profile, yamlRoot)
     this.resourcesForMinioTenantPod(profile, yamlRoot)
+
+    // TODO add the application.env file contents
+    // if (applicationEnvFilePath) {
+    //   this.setFileContentsAsValue(applicationEnvFilePath, 'hedera.configMaps.applicationEnv', yamlRoot)
+    // }
 
     // write the yaml
     const cachedValuesFile = path.join(this.cacheDir, `fst-${profileName}.yaml`)

--- a/src/core/profile_manager.mjs
+++ b/src/core/profile_manager.mjs
@@ -230,10 +230,9 @@ export class ProfileManager {
     this.resourcesForEnvoyProxyPod(profile, yamlRoot)
     this.resourcesForMinioTenantPod(profile, yamlRoot)
 
-    // TODO add the application.env file contents
-    // if (applicationEnvFilePath) {
-    //   this.setFileContentsAsValue(applicationEnvFilePath, 'hedera.configMaps.applicationEnv', yamlRoot)
-    // }
+    if (applicationEnvFilePath) {
+      this._setFileContentsAsValue('hedera.configMaps.applicationEnv', applicationEnvFilePath, yamlRoot)
+    }
 
     // write the yaml
     const cachedValuesFile = path.join(this.cacheDir, `fst-${profileName}.yaml`)
@@ -313,5 +312,17 @@ export class ProfileManager {
         resolve(cachedValuesFile)
       })
     })
+  }
+
+  /**
+   * Writes the contents of a file as a value for the given nested item path in the yaml object
+   * @param {string} itemPath nested item path in the yaml object to store the file contents
+   * @param {string} valueFilePath path to the file whose contents will be stored in the yaml object
+   * @param {Object} yamlRoot root of the yaml object
+   * @private
+   */
+  _setFileContentsAsValue (itemPath, valueFilePath, yamlRoot) {
+    const fileContents = fs.readFileSync(valueFilePath, 'utf8')
+    this._setValue(itemPath, fileContents, yamlRoot)
   }
 }

--- a/src/core/profile_manager.mjs
+++ b/src/core/profile_manager.mjs
@@ -212,11 +212,11 @@ export class ProfileManager {
 
   /**
    * Prepare a values file for FST Helm chart
-   * @param profileName resource profile name
-   * @param applicationEnvFilePath path to the application.env file
+   * @param {string} profileName resource profile name
+   * @param {string} applicationEnvFilePath path to the application.env file
    * @return {Promise<string>} return the full path to the values file
    */
-  prepareValuesForFstChart (profileName, applicationEnvFilePath = null) {
+  prepareValuesForFstChart (profileName, applicationEnvFilePath = '') {
     if (!profileName) throw new MissingArgumentError('profileName is required')
     const profile = this.getProfile(profileName)
 

--- a/test/unit/core/profile_manager.test.mjs
+++ b/test/unit/core/profile_manager.test.mjs
@@ -68,7 +68,7 @@ describe('ProfileManager', () => {
       expect(fs.existsSync(valuesFile)).toBeTruthy()
 
       // validate the yaml
-      const valuesYaml = yaml.load(fs.readFileSync(valuesFile))
+      const valuesYaml = yaml.load(fs.readFileSync(valuesFile).toString())
       expect(valuesYaml.hedera.nodes.length).toStrictEqual(3)
       expect(valuesYaml.defaults.root.resources.limits.cpu).not.toBeNull()
       expect(valuesYaml.defaults.root.resources.limits.memory).not.toBeNull()
@@ -98,7 +98,7 @@ describe('ProfileManager', () => {
       expect(fs.existsSync(valuesFile)).toBeTruthy()
 
       // validate yaml
-      const valuesYaml = yaml.load(fs.readFileSync(valuesFile))
+      const valuesYaml = yaml.load(fs.readFileSync(valuesFile).toString())
       expect(valuesYaml['hedera-mirror-node'].postgresql.persistence.size).not.toBeNull()
       expect(valuesYaml['hedera-mirror-node'].postgresql.postgresql.resources.limits.cpu).not.toBeNull()
       expect(valuesYaml['hedera-mirror-node'].postgresql.postgresql.resources.limits.memory).not.toBeNull()
@@ -118,9 +118,20 @@ describe('ProfileManager', () => {
       const valuesFile = await profileManager.prepareValuesForRpcRelayChart(input.profileName)
       expect(fs.existsSync(valuesFile)).toBeTruthy()
       // validate yaml
-      const valuesYaml = yaml.load(fs.readFileSync(valuesFile))
+      const valuesYaml = yaml.load(fs.readFileSync(valuesFile).toString())
       expect(valuesYaml.resources.limits.cpu).not.toBeNull()
       expect(valuesYaml.resources.limits.memory).not.toBeNull()
     })
+  })
+
+  it('prepareValuesForFstChart should set the value of a key to the contents of a file', async () => {
+    configManager.setFlag(flags.profileFile, testProfileFile)
+    // profileManager.loadProfiles(true)
+    const file = path.join(tmpDir, '_setFileContentsAsValue.txt')
+    const fileContents = '# row 1\n# row 2\n# row 3'
+    fs.writeFileSync(file, fileContents)
+    const cachedValuesFile = await profileManager.prepareValuesForFstChart('test', file)
+    const valuesYaml = yaml.load(fs.readFileSync(cachedValuesFile).toString())
+    expect(valuesYaml.hedera.configMaps.applicationEnv).toEqual(fileContents)
   })
 })


### PR DESCRIPTION
## Description

This pull request changes the following:

* mount `/etc/network-node/application.env` as a configMap to the network nodes

### Related Issues

* Closes #110 
