### PR TITLE
fix: refactor waitForPod and waitForPodConditions to stabilize code timeouts during e2e tests

### DIFF
--- a/src/commands/network.mjs
+++ b/src/commands/network.mjs
@@ -184,7 +184,7 @@ export class NetworkCommand extends BaseCommand {
               subTasks.push({
                 title: `Check Node: ${chalk.yellow(nodeId)}`,
                 task: () =>
-                  self.k8.waitForPod(constants.POD_STATUS_RUNNING, [
+                  self.k8.waitForPods([constants.POD_PHASE_RUNNING], [
                     'fullstack.hedera.com/type=network-node',
                     `fullstack.hedera.com/node-name=${nodeId}`
                   ], 1, 60 * 15, 1000) // timeout 15 minutes
@@ -374,7 +374,7 @@ export class NetworkCommand extends BaseCommand {
       {
         title: 'Waiting for network pods to be ready',
         task: async (ctx, _) => {
-          await this.k8.waitForPod(constants.POD_STATUS_RUNNING, [
+          await this.k8.waitForPods([constants.POD_PHASE_RUNNING], [
             'fullstack.hedera.com/type=network-node'
           ], 1)
         }

--- a/src/commands/node.mjs
+++ b/src/commands/node.mjs
@@ -1781,6 +1781,9 @@ export class NodeCommand extends BaseCommand {
     }
   }
 
+  // TODO: have the haproxy use the data plane api to decide liveness/readiness probe check, and don't expose port 5555 to the world. curl the 5555 endpoint
+  // TODO: open a ticket to fix the haproxy readiness probe separately
+  // TODO: get rid of the need to kill the haproxy
   async getNodeProxyStatus (url) {
     try {
       this.logger.debug(`Fetching proxy status from: ${url}`)

--- a/src/commands/node.mjs
+++ b/src/commands/node.mjs
@@ -779,7 +779,7 @@ export class NodeCommand extends BaseCommand {
               throw new FullstackTestingError(`failed to stop portForward for podName ${podName} with localPort ${localPort}: ${e.message}`, e)
             }
             try {
-              await this.k8.recyclePodByLabels(podLabels, 50)
+              await this.k8.recyclePodByLabels(podLabels)
             } catch (e) {
               throw new FullstackTestingError(`failed to recycle pod for podName ${podName} with localPort ${localPort}: ${e.message}`, e)
             }

--- a/src/commands/node.mjs
+++ b/src/commands/node.mjs
@@ -1781,9 +1781,6 @@ export class NodeCommand extends BaseCommand {
     }
   }
 
-  // TODO: have the haproxy use the data plane api to decide liveness/readiness probe check, and don't expose port 5555 to the world. curl the 5555 endpoint
-  // TODO: open a ticket to fix the haproxy readiness probe separately
-  // TODO: get rid of the need to kill the haproxy
   async getNodeProxyStatus (url) {
     try {
       this.logger.debug(`Fetching proxy status from: ${url}`)

--- a/src/commands/relay.mjs
+++ b/src/commands/relay.mjs
@@ -159,7 +159,7 @@ export class RelayCommand extends BaseCommand {
 
           await self.chartManager.install(namespace, releaseName, chartPath, '', valuesArg)
 
-          await self.k8.waitForPod(constants.POD_STATUS_RUNNING, [
+          await self.k8.waitForPods([constants.POD_PHASE_RUNNING], [
             'app=hedera-json-rpc-relay',
             `app.kubernetes.io/instance=${releaseName}`
           ], 1, 900, 1000)

--- a/src/core/constants.mjs
+++ b/src/core/constants.mjs
@@ -90,7 +90,7 @@ export const ACCOUNT_CREATE_BATCH_SIZE = process.env.ACCOUNT_CREATE_BATCH_SIZE |
 export const NODE_PROXY_USER_ID = process.env.NODE_PROXY_USER_ID || 'admin'
 export const NODE_PROXY_PASSWORD = process.env.NODE_PROXY_PASSWORD || 'adminpwd'
 
-export const POD_STATUS_RUNNING = 'Running'
+export const POD_PHASE_RUNNING = 'Running'
 
 export const POD_CONDITION_INITIALIZED = 'Initialized'
 export const POD_CONDITION_READY = 'Ready'

--- a/src/core/k8.mjs
+++ b/src/core/k8.mjs
@@ -831,7 +831,7 @@ export class K8 {
           let predicateMatchCount = 0
 
           for (const item of resp.body.items) {
-            if (phases.includes(item.status.phase)) {
+            if (phases.includes(item.status?.phase)) {
               phaseMatchCount++
             }
 
@@ -889,13 +889,15 @@ export class K8 {
     if (!conditionsMap || conditionsMap.size === 0) throw new MissingArgumentError('pod conditions are required')
 
     return await this.waitForPods([constants.POD_PHASE_RUNNING], labels, podCount, maxAttempts, delay, (pod) => {
-      for (const cond of pod?.status?.conditions) {
-        for (const entry of conditionsMap.entries()) {
-          const condType = entry[0]
-          const condStatus = entry[1]
-          if (cond.type === condType && cond.status === condStatus) {
-            this.logger.debug(`Pod condition met for ${pod.metadata.name} [type: ${cond.type} status: ${cond.status}]`)
-            return true
+      if (pod.status?.conditions?.length > 0) {
+        for (const cond of pod.status.conditions) {
+          for (const entry of conditionsMap.entries()) {
+            const condType = entry[0]
+            const condStatus = entry[1]
+            if (cond.type === condType && cond.status === condStatus) {
+              this.logger.debug(`Pod condition met for ${pod.metadata.name} [type: ${cond.type} status: ${cond.status}]`)
+              return true
+            }
           }
         }
       }

--- a/src/core/k8.mjs
+++ b/src/core/k8.mjs
@@ -767,7 +767,7 @@ export class K8 {
     }
   }
 
-  async recyclePodByLabels (podLabels, maxAttempts = 50, delay = 2000, waitForPodMaxAttempts = 10, waitForPodDelay = 2000) {
+  async recyclePodByLabels (podLabels, maxAttempts = 30, delay = 2000, waitForPodMaxAttempts = 10, waitForPodDelay = 2000) {
     const podArray = await this.getPodsByLabel(podLabels)
     for (const pod of podArray) {
       const podName = pod.metadata.name
@@ -888,7 +888,7 @@ export class K8 {
     podCount = 1, maxAttempts = 10, delay = 500) {
     if (!conditionsMap || conditionsMap.size === 0) throw new MissingArgumentError('pod conditions are required')
 
-    await this.waitForPods([constants.POD_PHASE_RUNNING], labels, podCount, maxAttempts, delay, (pod) => {
+    return await this.waitForPods([constants.POD_PHASE_RUNNING], labels, podCount, maxAttempts, delay, (pod) => {
       for (const cond of pod.status.conditions) {
         for (const entry of conditionsMap.entries()) {
           const condType = entry[0]

--- a/src/core/k8.mjs
+++ b/src/core/k8.mjs
@@ -889,7 +889,7 @@ export class K8 {
     if (!conditionsMap || conditionsMap.size === 0) throw new MissingArgumentError('pod conditions are required')
 
     return await this.waitForPods([constants.POD_PHASE_RUNNING], labels, podCount, maxAttempts, delay, (pod) => {
-      for (const cond of pod.status.conditions) {
+      for (const cond of pod?.status?.conditions) {
         for (const entry of conditionsMap.entries()) {
           const condType = entry[0]
           const condStatus = entry[1]

--- a/test/e2e/core/k8_e2e.test.mjs
+++ b/test/e2e/core/k8_e2e.test.mjs
@@ -127,7 +127,7 @@ describe('K8', () => {
       'fullstack.hedera.com/type=network-node'
     ]
 
-    const pods = await k8.waitForPod(constants.POD_STATUS_RUNNING, labels, 1)
+    const pods = await k8.waitForPods([constants.POD_PHASE_RUNNING], labels, 1)
     expect(pods.length).toStrictEqual(1)
   })
 
@@ -149,7 +149,7 @@ describe('K8', () => {
       .set(constants.POD_CONDITION_INITIALIZED, constants.POD_CONDITION_STATUS_TRUE)
       .set(constants.POD_CONDITION_POD_SCHEDULED, constants.POD_CONDITION_STATUS_TRUE)
       .set(constants.POD_CONDITION_READY, constants.POD_CONDITION_STATUS_TRUE)
-    const pods = await k8.waitForPodCondition(conditions, labels, 1)
+    const pods = await k8.waitForPodConditions(conditions, labels, 1)
     expect(pods.length).toStrictEqual(1)
   })
 

--- a/test/unit/core/k8.test.mjs
+++ b/test/unit/core/k8.test.mjs
@@ -90,12 +90,13 @@ describe('K8 Unit Tests', () => {
     }))
 
     const result = await k8.waitForPodConditions(K8.PodReadyCondition, ['labels'], 1, maxNumOfFailures, 0)
+    expect(result).not.toBeNull()
     expect(result[0]).toBe(expectedResult[0])
   }, 20000)
 
   it('recyclePodByLabels with first time failure, later success', async () => {
     const waitForPodMaxAttempts = 120
-    const numOfFailures = (waitForPodMaxAttempts + 1) * 2 - 1
+    const numOfFailures = waitForPodMaxAttempts * 2 - 1
     for (let i = 0; i < numOfFailures; i++) {
       k8.kubeClient.listNamespacedPod.mockReturnValueOnce(Promise.resolve({
         body: {

--- a/test/unit/core/k8.test.mjs
+++ b/test/unit/core/k8.test.mjs
@@ -1,0 +1,145 @@
+/**
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the ""License"");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an ""AS IS"" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import { describe, expect, it, jest } from '@jest/globals'
+import { constants, K8 } from '../../../src/core/index.mjs'
+import { getTestConfigManager, testLogger } from '../../test_util.js'
+import { flags } from '../../../src/commands/index.mjs'
+
+describe('K8 Unit Tests', () => {
+  it('waitForPod with first time failure, later success', async () => {
+    const k8Spy = jest.spyOn(K8.prototype, 'init').mockImplementation(() => {})
+    const argv = { }
+    argv[flags.namespace.name] = 'namespace'
+
+    const configManager = getTestConfigManager('k8-solo.config')
+    configManager.update(argv, true)
+    const k8 = new K8(configManager, testLogger)
+    const expectedResult = [{ metadata: { name: 'pod' } }]
+    k8.kubeClient = {
+      listNamespacedPod: jest.fn()
+    }
+    const numOfFailures = 500
+    for (let i = 0; i < numOfFailures; i++) {
+      k8.kubeClient.listNamespacedPod.mockReturnValueOnce(Promise.resolve({
+        body: {
+          items: []
+        }
+      }))
+    }
+    k8.kubeClient.listNamespacedPod.mockReturnValueOnce(Promise.resolve({
+      body: {
+        items: expectedResult
+      }
+    }))
+
+    const result = await k8.waitForPod('status', ['labels'], 1, numOfFailures, 1)
+    expect(result).toBe(expectedResult)
+    k8Spy.mockRestore()
+  })
+
+  it('waitForPodCondition with first time failure, later success', async () => {
+    const k8Spy = jest.spyOn(K8.prototype, 'init').mockImplementation(() => {})
+    const argv = { }
+    argv[flags.namespace.name] = 'namespace'
+
+    const configManager = getTestConfigManager('k8-solo.config')
+    configManager.update(argv, true)
+    const k8 = new K8(configManager, testLogger)
+    const expectedResult = [
+      {
+        metadata: { name: 'pod' },
+        status: {
+          conditions: [
+            {
+              type: constants.POD_CONDITION_READY,
+              status: constants.POD_CONDITION_STATUS_TRUE
+            }
+          ]
+        }
+      }
+    ]
+    k8.kubeClient = {
+      listNamespacedPod: jest.fn()
+    }
+    const numOfFailures = 50
+    for (let i = 0; i < numOfFailures * numOfFailures - 1; i++) {
+      k8.kubeClient.listNamespacedPod.mockReturnValueOnce(Promise.resolve({
+        body: {
+          items: []
+        }
+      }))
+    }
+    k8.kubeClient.listNamespacedPod.mockReturnValueOnce(Promise.resolve({
+      body: {
+        items: expectedResult
+      }
+    }))
+
+    const result = await k8.waitForPodCondition(K8.PodReadyCondition, ['labels'], 1, numOfFailures, 0)
+    expect(result[0]).toBe(expectedResult[0])
+    k8Spy.mockRestore()
+  }, 20000)
+
+  it('recyclePodByLabels with first time failure, later success', async () => {
+    const k8InitSpy = jest.spyOn(K8.prototype, 'init').mockImplementation(() => {})
+    const expectedResult = [
+      {
+        metadata: { name: 'pod' },
+        status: {
+          conditions: [
+            {
+              type: constants.POD_CONDITION_READY,
+              status: constants.POD_CONDITION_STATUS_TRUE
+            }
+          ]
+        }
+      }
+    ]
+    const k8GetPodsByLabelSpy = jest.spyOn(K8.prototype, 'getPodsByLabel').mockResolvedValue(expectedResult)
+
+    const argv = { }
+    argv[flags.namespace.name] = 'namespace'
+
+    const configManager = getTestConfigManager('k8-solo.config')
+    configManager.update(argv, true)
+    const k8 = new K8(configManager, testLogger)
+    k8.kubeClient = {
+      listNamespacedPod: jest.fn(),
+      deleteNamespacedPod: jest.fn()
+    }
+    const waitForPodMaxAttempts = 120
+    const numOfFailures = (waitForPodMaxAttempts + 1) * 2 - 1
+    for (let i = 0; i < numOfFailures; i++) {
+      k8.kubeClient.listNamespacedPod.mockReturnValueOnce(Promise.resolve({
+        body: {
+          items: []
+        }
+      }))
+    }
+    k8.kubeClient.listNamespacedPod.mockReturnValueOnce(Promise.resolve({
+      body: {
+        items: expectedResult
+      }
+    }))
+
+    const result = await k8.recyclePodByLabels(['labels'], 2, 0, waitForPodMaxAttempts, 0)
+    expect(result[0]).toBe(expectedResult[0])
+
+    k8InitSpy.mockRestore()
+    k8GetPodsByLabelSpy.mockRestore()
+  }, 20000)
+})

--- a/test/unit/core/k8.test.mjs
+++ b/test/unit/core/k8.test.mjs
@@ -14,113 +14,86 @@
  * limitations under the License.
  *
  */
-import { describe, expect, it, jest } from '@jest/globals'
+import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals'
 import { constants, K8 } from '../../../src/core/index.mjs'
 import { getTestConfigManager, testLogger } from '../../test_util.js'
 import { flags } from '../../../src/commands/index.mjs'
 
 describe('K8 Unit Tests', () => {
-  it('waitForPod with first time failure, later success', async () => {
-    const k8Spy = jest.spyOn(K8.prototype, 'init').mockImplementation(() => {})
-    const argv = { }
-    argv[flags.namespace.name] = 'namespace'
+  const argv = { }
+  const expectedResult = [
+    {
+      metadata: { name: 'pod' },
+      status: {
+        phase: constants.POD_PHASE_RUNNING,
+        conditions: [
+          {
+            type: constants.POD_CONDITION_READY,
+            status: constants.POD_CONDITION_STATUS_TRUE
+          }
+        ]
+      }
+    }
+  ]
+  const k8InitSpy = jest.spyOn(K8.prototype, 'init').mockImplementation(() => {})
+  const k8GetPodsByLabelSpy = jest.spyOn(K8.prototype, 'getPodsByLabel').mockResolvedValue(expectedResult)
+  let k8
 
+  beforeAll(() => {
+    argv[flags.namespace.name] = 'namespace'
     const configManager = getTestConfigManager('k8-solo.config')
     configManager.update(argv, true)
-    const k8 = new K8(configManager, testLogger)
-    const expectedResult = [{ metadata: { name: 'pod' } }]
-    k8.kubeClient = {
-      listNamespacedPod: jest.fn()
-    }
-    const numOfFailures = 500
-    for (let i = 0; i < numOfFailures; i++) {
-      k8.kubeClient.listNamespacedPod.mockReturnValueOnce(Promise.resolve({
-        body: {
-          items: []
-        }
-      }))
-    }
-    k8.kubeClient.listNamespacedPod.mockReturnValueOnce(Promise.resolve({
-      body: {
-        items: expectedResult
-      }
-    }))
-
-    const result = await k8.waitForPod('status', ['labels'], 1, numOfFailures, 1)
-    expect(result).toBe(expectedResult)
-    k8Spy.mockRestore()
-  })
-
-  it('waitForPodCondition with first time failure, later success', async () => {
-    const k8Spy = jest.spyOn(K8.prototype, 'init').mockImplementation(() => {})
-    const argv = { }
-    argv[flags.namespace.name] = 'namespace'
-
-    const configManager = getTestConfigManager('k8-solo.config')
-    configManager.update(argv, true)
-    const k8 = new K8(configManager, testLogger)
-    const expectedResult = [
-      {
-        metadata: { name: 'pod' },
-        status: {
-          conditions: [
-            {
-              type: constants.POD_CONDITION_READY,
-              status: constants.POD_CONDITION_STATUS_TRUE
-            }
-          ]
-        }
-      }
-    ]
-    k8.kubeClient = {
-      listNamespacedPod: jest.fn()
-    }
-    const numOfFailures = 50
-    for (let i = 0; i < numOfFailures * numOfFailures - 1; i++) {
-      k8.kubeClient.listNamespacedPod.mockReturnValueOnce(Promise.resolve({
-        body: {
-          items: []
-        }
-      }))
-    }
-    k8.kubeClient.listNamespacedPod.mockReturnValueOnce(Promise.resolve({
-      body: {
-        items: expectedResult
-      }
-    }))
-
-    const result = await k8.waitForPodCondition(K8.PodReadyCondition, ['labels'], 1, numOfFailures, 0)
-    expect(result[0]).toBe(expectedResult[0])
-    k8Spy.mockRestore()
-  }, 20000)
-
-  it('recyclePodByLabels with first time failure, later success', async () => {
-    const k8InitSpy = jest.spyOn(K8.prototype, 'init').mockImplementation(() => {})
-    const expectedResult = [
-      {
-        metadata: { name: 'pod' },
-        status: {
-          conditions: [
-            {
-              type: constants.POD_CONDITION_READY,
-              status: constants.POD_CONDITION_STATUS_TRUE
-            }
-          ]
-        }
-      }
-    ]
-    const k8GetPodsByLabelSpy = jest.spyOn(K8.prototype, 'getPodsByLabel').mockResolvedValue(expectedResult)
-
-    const argv = { }
-    argv[flags.namespace.name] = 'namespace'
-
-    const configManager = getTestConfigManager('k8-solo.config')
-    configManager.update(argv, true)
-    const k8 = new K8(configManager, testLogger)
+    k8 = new K8(configManager, testLogger)
     k8.kubeClient = {
       listNamespacedPod: jest.fn(),
       deleteNamespacedPod: jest.fn()
     }
+  })
+
+  afterAll(() => {
+    k8InitSpy.mockRestore()
+    k8GetPodsByLabelSpy.mockRestore()
+  })
+
+  it('waitForPods with first time failure, later success', async () => {
+    const maxNumOfFailures = 500
+    for (let i = 0; i < maxNumOfFailures - 1; i++) {
+      k8.kubeClient.listNamespacedPod.mockReturnValueOnce(Promise.resolve({
+        body: {
+          items: []
+        }
+      }))
+    }
+    k8.kubeClient.listNamespacedPod.mockReturnValueOnce(Promise.resolve({
+      body: {
+        items: expectedResult
+      }
+    }))
+
+    const result = await k8.waitForPods([constants.POD_PHASE_RUNNING], ['labels'], 1, maxNumOfFailures, 0)
+    expect(result).toBe(expectedResult)
+  })
+
+  it('waitForPodConditions with first time failure, later success', async () => {
+    const maxNumOfFailures = 500
+    for (let i = 0; i < maxNumOfFailures - 1; i++) {
+      k8.kubeClient.listNamespacedPod.mockReturnValueOnce(Promise.resolve({
+        body: {
+          items: []
+        }
+      }))
+    }
+    k8.kubeClient.listNamespacedPod.mockReturnValueOnce(Promise.resolve({
+      body: {
+        items: expectedResult
+      }
+    }))
+
+    const result = await k8.waitForPodConditions(K8.PodReadyCondition, ['labels'], 1, maxNumOfFailures, 0)
+    expect(result[0]).toBe(expectedResult[0])
+  }, 20000)
+
+  it('recyclePodByLabels with first time failure, later success', async () => {
     const waitForPodMaxAttempts = 120
     const numOfFailures = (waitForPodMaxAttempts + 1) * 2 - 1
     for (let i = 0; i < numOfFailures; i++) {
@@ -138,8 +111,5 @@ describe('K8 Unit Tests', () => {
 
     const result = await k8.recyclePodByLabels(['labels'], 2, 0, waitForPodMaxAttempts, 0)
     expect(result[0]).toBe(expectedResult[0])
-
-    k8InitSpy.mockRestore()
-    k8GetPodsByLabelSpy.mockRestore()
   }, 20000)
 })


### PR DESCRIPTION
## Description

This pull request changes the following:

* refactored K8 waitForPod
  * handle a predicate function
  * renamed to waitForPods
  * take an array of phases
* refactored K8 waitForPodCondition
  * renamed to waitForPodConditions
  * removed promise/delay/retry loop and instead call waitForPods with predicate to check conditions
* added `test/unit/core/k8.test.mjs` for some negative tests

### Related Issues

* Closes #315
