### PR TITLE
fix: updates to accommodate haproxy changes in FST charts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -515,3 +515,4 @@ node_modules/
 coverage/
 deleteme.yaml
 /.nyc_output/
+/.nvmrc

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "check": "remark . --quiet --frail && eslint .",
     "format": "remark . --quiet --frail --output && eslint --fix .",
     "test-setup": "./test/e2e/setup-e2e.sh",
-    "test-coverage": "npm run test && npm run test-setup &&  npm run test-e2e-all && npm run report-coverage"
+    "test-coverage": "npm run test-setup &&  npm run test-e2e-all && npm run report-coverage"
   },
   "keywords": [
     "solo",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "check": "remark . --quiet --frail && eslint .",
     "format": "remark . --quiet --frail --output && eslint --fix .",
     "test-setup": "./test/e2e/setup-e2e.sh",
-    "test-coverage": "npm run test-setup &&  npm run test-e2e-all && npm run report-coverage"
+    "test-coverage": "npm run test && npm run test-setup && npm run test-e2e-all && npm run report-coverage"
   },
   "keywords": [
     "solo",

--- a/resources/templates/log4j2.xml
+++ b/resources/templates/log4j2.xml
@@ -161,6 +161,7 @@
         <MarkerFilter marker="ADV_CRYPTO_SYSTEM"      onMatch="DENY"   onMismatch="NEUTRAL"/>
 
         <!-- Startup/Restart/Reconnect -->
+        <MarkerFilter marker="CONFIG"                 onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="STARTUP"                onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="PLATFORM_STATUS"        onMatch="ACCEPT" onMismatch="NEUTRAL"/>
         <MarkerFilter marker="RECONNECT"              onMatch="ACCEPT" onMismatch="NEUTRAL"/>

--- a/src/commands/flags.mjs
+++ b/src/commands/flags.mjs
@@ -402,7 +402,7 @@ export const settingTxt = {
 export const app = {
   name: 'app',
   definition: {
-    describe: 'Testing app anme',
+    describe: 'Testing app name',
     defaultValue: '',
     type: 'string'
   }

--- a/src/commands/mirror_node.mjs
+++ b/src/commands/mirror_node.mjs
@@ -94,7 +94,7 @@ export class MirrorNodeCommand extends BaseCommand {
             {
               title: 'Prepare address book',
               task: async (ctx, _) => {
-                ctx.addressBook = await self.accountManager.prepareAddressBookBase64()
+                ctx.addressBook = await self.accountManager.prepareAddressBookBase64(ctx.config.namespace)
                 ctx.config.valuesArg += ` --set "hedera-mirror-node.importer.addressBook=${ctx.addressBook}"`
               }
             },

--- a/src/commands/network.mjs
+++ b/src/commands/network.mjs
@@ -211,7 +211,7 @@ export class NetworkCommand extends BaseCommand {
               subTasks.push({
                 title: `Check HAProxy for: ${chalk.yellow(nodeId)}`,
                 task: () =>
-                  self.k8.waitForPodReady([
+                  self.k8.waitForPods([constants.POD_PHASE_RUNNING], [
                     'fullstack.hedera.com/type=haproxy'
                   ], 1, 60 * 15, 1000) // timeout 15 minutes
               })
@@ -222,7 +222,7 @@ export class NetworkCommand extends BaseCommand {
               subTasks.push({
                 title: `Check Envoy Proxy for: ${chalk.yellow(nodeId)}`,
                 task: () =>
-                  self.k8.waitForPodReady([
+                  self.k8.waitForPods([constants.POD_PHASE_RUNNING], [
                     'fullstack.hedera.com/type=envoy-proxy'
                   ], 1, 60 * 15, 1000) // timeout 15 minutes
               })

--- a/src/commands/network.mjs
+++ b/src/commands/network.mjs
@@ -174,7 +174,7 @@ export class NetworkCommand extends BaseCommand {
         }
       },
       {
-        title: 'Check node pods are ready',
+        title: 'Check node pods are running',
         task:
           async (ctx, task) => {
             const subTasks = []
@@ -201,7 +201,7 @@ export class NetworkCommand extends BaseCommand {
           }
       },
       {
-        title: 'Check proxy pods are ready',
+        title: 'Check proxy pods are running',
         task:
           async (ctx, task) => {
             const subTasks = []
@@ -372,7 +372,7 @@ export class NetworkCommand extends BaseCommand {
         }
       },
       {
-        title: 'Waiting for network pods to be ready',
+        title: 'Waiting for network pods to be running',
         task: async (ctx, _) => {
           await this.k8.waitForPods([constants.POD_PHASE_RUNNING], [
             'fullstack.hedera.com/type=network-node'

--- a/src/commands/node.mjs
+++ b/src/commands/node.mjs
@@ -77,7 +77,7 @@ export class NodeCommand extends BaseCommand {
     const podName = Templates.renderNetworkPodName(nodeId)
 
     try {
-      await this.k8.waitForPodReady([
+      await this.k8.waitForPods([constants.POD_PHASE_RUNNING], [
         'fullstack.hedera.com/type=network-node',
         `fullstack.hedera.com/node-name=${nodeId}`
       ], 1, maxAttempts, delay)

--- a/src/core/account_manager.mjs
+++ b/src/core/account_manager.mjs
@@ -234,9 +234,10 @@ export class AccountManager {
       this.logger.debug(`creating client from network configuration: ${JSON.stringify(nodes)}`)
       this._nodeClient = Client.fromConfig({ network: nodes })
       this._nodeClient.setOperator(operatorId, operatorKey)
-      // TODO: need updated version of SDK to set log file
-      const sdkLogger = new Logger(LogLevel.Trace, `${constants.SOLO_LOGS_DIR}/hashgraph-sdk.log`)
-      this._nodeClient.setLogger(sdkLogger)
+      // TODO: need updated version of SDK to set log file, once it is writing to the file, we can remove the if devMode check and just always set it: https://github.com/hashgraph/solo/issues/331
+      if (this.logger.devMode) {
+        this._nodeClient.setLogger(new Logger(LogLevel.Trace, `${constants.SOLO_LOGS_DIR}/hashgraph-sdk.log`))
+      }
       this._nodeClient.setMaxAttempts(constants.NODE_CLIENT_MAX_ATTEMPTS)
       this._nodeClient.setMinBackoff(constants.NODE_CLIENT_MIN_BACKOFF)
       this._nodeClient.setMaxBackoff(constants.NODE_CLIENT_MAX_BACKOFF)

--- a/src/core/account_manager.mjs
+++ b/src/core/account_manager.mjs
@@ -585,14 +585,17 @@ export class AccountManager {
     // ensure serviceEndpoint.ipAddressV4 value for all nodes in the addressBook is a 4 bytes array instead of string
     // See: https://github.com/hashgraph/hedera-protobufs/blob/main/services/basic_types.proto#L1309
     const addressBook = HashgraphProto.proto.NodeAddressBook.decode(addressBookBytes)
+    const hasAlphaRegEx = /[a-zA-Z]+/
     let modified = false
     for (const nodeAddress of addressBook.nodeAddress) {
-      // overwrite ipAddressV4 as 4 bytes array if required
-      if (nodeAddress.serviceEndpoint[0].ipAddressV4.byteLength !== 4) {
-        const ipAddress = nodeAddress.serviceEndpoint[0].ipAddressV4.toString()
-        const parts = ipAddress.split('.')
+      const address = nodeAddress.serviceEndpoint[0].ipAddressV4.toString()
+
+      // overwrite ipAddressV4 as 4 bytes array if required, unless there is alpha, which means it is a domain name
+      if (nodeAddress.serviceEndpoint[0].ipAddressV4.byteLength !== 4 && !hasAlphaRegEx.test(address)) {
+        const parts = address.split('.')
+
         if (parts.length !== 4) {
-          throw new FullstackTestingError(`expected node IP address to have 4 parts, found ${parts.length}: ${ipAddress}`)
+          throw new FullstackTestingError(`expected node IP address to have 4 parts, found ${parts.length}: ${address}`)
         }
 
         nodeAddress.serviceEndpoint[0].ipAddressV4 = Uint8Array.from(parts)

--- a/src/core/account_manager.mjs
+++ b/src/core/account_manager.mjs
@@ -27,6 +27,8 @@ import {
   Hbar,
   HbarUnit,
   KeyList,
+  Logger,
+  LogLevel,
   PrivateKey,
   Status,
   TransferTransaction
@@ -224,6 +226,13 @@ export class AccountManager {
       this.logger.debug(`creating client from network configuration: ${JSON.stringify(nodes)}`)
       this._nodeClient = Client.fromConfig({ network: nodes })
       this._nodeClient.setOperator(operatorId, operatorKey)
+      // TODO: need updated version of SDK to set log file
+      const sdkLogger = new Logger(LogLevel.Trace, `${constants.SOLO_LOGS_DIR}/hashgraph-sdk.log`)
+      this._nodeClient.setLogger(sdkLogger)
+      this._nodeClient.setMaxAttempts(constants.NODE_CLIENT_MAX_ATTEMPTS)
+      this._nodeClient.setMinBackoff(constants.NODE_CLIENT_MIN_BACKOFF)
+      this._nodeClient.setMaxBackoff(constants.NODE_CLIENT_MAX_BACKOFF)
+      this._nodeClient.setRequestTimeout(constants.NODE_CLIENT_REQUEST_TIMEOUT)
       return this._nodeClient
     } catch (e) {
       throw new FullstackTestingError(`failed to setup node client: ${e.message}`, e)

--- a/src/core/config_manager.mjs
+++ b/src/core/config_manager.mjs
@@ -115,7 +115,7 @@ export class ConfigManager {
           switch (flag.definition.type) {
             case 'string':
               if (val && (flag.name === flags.chartDirectory.name || flag.name === flags.cacheDir.name)) {
-                this.logger.debug(`Resolving directory path for '${flag.name}': ${val}`)
+                this.logger.debug(`Resolving directory path for '${flag.name}': ${val}, to: ${paths.resolve(val)}, note: ~/ is not supported`)
                 val = paths.resolve(val)
               }
               this.logger.debug(`Setting flag '${flag.name}' of type '${flag.definition.type}': ${val}`)

--- a/src/core/constants.mjs
+++ b/src/core/constants.mjs
@@ -146,3 +146,9 @@ export const PROFILE_LOCAL = 'local'
 
 export const ALL_PROFILES = [PROFILE_LOCAL, PROFILE_TINY, PROFILE_SMALL, PROFILE_MEDIUM, PROFILE_LARGE]
 export const DEFAULT_PROFILE_FILE = `${SOLO_CACHE_DIR}/profiles/custom-spec.yaml`
+
+// ------ Hedera SDK Related ------
+export const NODE_CLIENT_MAX_ATTEMPTS = process.env.NODE_CLIENT_MAX_ATTEMPTS || 60
+export const NODE_CLIENT_MIN_BACKOFF = process.env.NODE_CLIENT_MIN_BACKOFF || 1000
+export const NODE_CLIENT_MAX_BACKOFF = process.env.NODE_CLIENT_MAX_BACKOFF || 1000
+export const NODE_CLIENT_REQUEST_TIMEOUT = process.env.NODE_CLIENT_REQUEST_TIMEOUT || 120000

--- a/src/core/k8.mjs
+++ b/src/core/k8.mjs
@@ -767,31 +767,6 @@ export class K8 {
     }
   }
 
-  async recyclePodByLabels (podLabels, maxAttempts = 30, delay = 2000, waitForPodMaxAttempts = 10, waitForPodDelay = 2000) {
-    const podArray = await this.getPodsByLabel(podLabels)
-    for (const pod of podArray) {
-      const podName = pod.metadata.name
-      await this.kubeClient.deleteNamespacedPod(podName, this.configManager.getFlag(flags.namespace))
-    }
-
-    let attempts = 0
-    while (attempts++ < maxAttempts) {
-      try {
-        const pods = await this.waitForPods([constants.POD_PHASE_RUNNING],
-          podLabels, 1, waitForPodMaxAttempts, waitForPodDelay)
-        if (pods.length === podArray.length) {
-          return pods
-        }
-      } catch (e) {
-        this.logger.warn(`deleted pod still not running [${podLabels.join(',')}, attempt: ${attempts}/${maxAttempts}]`)
-      }
-
-      await sleep(delay)
-    }
-
-    throw new FullstackTestingError(`pods are not running after deletion with labels [${podLabels.join(',')}]`)
-  }
-
   /**
    * Wait for pod
    * @param phases an array of acceptable phases of the pods

--- a/src/core/network_node_services.mjs
+++ b/src/core/network_node_services.mjs
@@ -1,0 +1,147 @@
+/**
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the ""License"");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an ""AS IS"" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+export class NetworkNodeServices {
+  constructor (builder) {
+    this.nodeName = builder.nodeName
+    this.haProxyName = builder.haProxyName
+    this.haProxyLoadBalancerIp = builder.haProxyLoadBalancerIp
+    this.haProxyClusterIp = builder.haProxyClusterIp
+    this.haProxyGrpcPort = builder.haProxyGrpcPort
+    this.haProxyGrpcsPort = builder.haProxyGrpcsPort
+    this.accountId = builder.accountId
+    this.haProxyAppSelector = builder.haProxyAppSelector
+    this.haProxyPodName = builder.haProxyPodName
+    this.nodeServiceName = builder.nodeServiceName
+    this.nodeServiceClusterIp = builder.nodeServiceClusterIp
+    this.nodeServiceLoadBalancerIp = builder.nodeServiceLoadBalancerIp
+    this.nodeServiceGossipPort = builder.nodeServiceGossipPort
+    this.nodeServiceGrpcPort = builder.nodeServiceGrpcPort
+    this.nodeServiceGrpcsPort = builder.nodeServiceGrpcsPort
+    this.envoyProxyName = builder.envoyProxyName
+    this.envoyProxyClusterIp = builder.envoyProxyClusterIp
+    this.envoyProxyLoadBalancerIp = builder.envoyProxyLoadBalancerIp
+    this.envoyProxyGrpcWebPort = builder.envoyProxyGrpcWebPort
+  }
+
+  key () {
+    return this.nodeName
+  }
+}
+
+export class NetworkNodeServicesBuilder {
+  constructor (nodeName) {
+    this.nodeName = nodeName
+  }
+
+  withAccountId (accountId) {
+    this.accountId = accountId
+    return this
+  }
+
+  withHaProxyName (haProxyName) {
+    this.haProxyName = haProxyName
+    return this
+  }
+
+  withHaProxyClusterIp (haProxyClusterIp) {
+    this.haProxyClusterIp = haProxyClusterIp
+    return this
+  }
+
+  withHaProxyLoadBalancerIp (haProxyLoadBalancerIp) {
+    this.haProxyLoadBalancerIp = haProxyLoadBalancerIp
+    return this
+  }
+
+  withHaProxyGrpcPort (haProxyGrpcPort) {
+    this.haProxyGrpcPort = haProxyGrpcPort
+    return this
+  }
+
+  withHaProxyGrpcsPort (haProxyGrpcsPort) {
+    this.haProxyGrpcsPort = haProxyGrpcsPort
+    return this
+  }
+
+  withHaProxyAppSelector (haProxyAppSelector) {
+    this.haProxyAppSelector = haProxyAppSelector
+    return this
+  }
+
+  withHaProxyPodName (haProxyPodName) {
+    this.haProxyPodName = haProxyPodName
+    return this
+  }
+
+  withNodeServiceName (nodeServiceName) {
+    this.nodeServiceName = nodeServiceName
+    return this
+  }
+
+  withNodeServiceClusterIp (nodeServiceClusterIp) {
+    this.nodeServiceClusterIp = nodeServiceClusterIp
+    return this
+  }
+
+  withNodeServiceLoadBalancerIp (nodeServiceLoadBalancerIp) {
+    this.nodeServiceLoadBalancerIp = nodeServiceLoadBalancerIp
+    return this
+  }
+
+  withNodeServiceGossipPort (nodeServiceGossipPort) {
+    this.nodeServiceGossipPort = nodeServiceGossipPort
+    return this
+  }
+
+  withNodeServiceGrpcPort (nodeServiceGrpcPort) {
+    this.nodeServiceGrpcPort = nodeServiceGrpcPort
+    return this
+  }
+
+  withNodeServiceGrpcsPort (nodeServiceGrpcsPort) {
+    this.nodeServiceGrpcsPort = nodeServiceGrpcsPort
+    return this
+  }
+
+  withEnvoyProxyName (envoyProxyName) {
+    this.envoyProxyName = envoyProxyName
+    return this
+  }
+
+  withEnvoyProxyClusterIp (envoyProxyClusterIp) {
+    this.envoyProxyClusterIp = envoyProxyClusterIp
+    return this
+  }
+
+  withEnvoyProxyLoadBalancerIp (envoyProxyLoadBalancerIp) {
+    this.envoyProxyLoadBalancerIp = envoyProxyLoadBalancerIp
+    return this
+  }
+
+  withEnvoyProxyGrpcWebPort (envoyProxyGrpcWebPort) {
+    this.envoyProxyGrpcWebPort = envoyProxyGrpcWebPort
+    return this
+  }
+
+  build () {
+    return new NetworkNodeServices(this)
+  }
+
+  key () {
+    return this.nodeName
+  }
+}

--- a/src/core/platform_installer.mjs
+++ b/src/core/platform_installer.mjs
@@ -302,7 +302,7 @@ export class PlatformInstaller {
         const nodeNickName = nodeId
 
         const internalIP = Templates.renderFullyQualifiedNetworkPodName(this._getNamespace(), nodeId)
-        const externalIP = networkNodeServices.nodeServiceClusterIp
+        const externalIP = Templates.renderFullyQualifiedNetworkSvcName(this._getNamespace(), nodeId)
 
         const account = networkNodeServices.accountId
         if (releaseVersion.minor >= 40) {

--- a/src/core/templates.mjs
+++ b/src/core/templates.mjs
@@ -29,6 +29,10 @@ export class Templates {
     return `network-${nodeId}-svc`
   }
 
+  static nodeIdFromNetworkSvcName (svcName) {
+    return svcName.split('-').slice(1, -1).join('-')
+  }
+
   static renderNetworkHeadlessSvcName (nodeId) {
     return `network-${nodeId}`
   }
@@ -170,5 +174,10 @@ export class Templates {
 
   static renderFullyQualifiedNetworkSvcName (namespace, nodeId) {
     return `${Templates.renderNetworkSvcName(nodeId)}.${namespace}.svc.cluster.local`
+  }
+
+  static nodeIdFromFullyQualifiedNetworkSvcName (svcName) {
+    const parts = svcName.split('.')
+    return this.nodeIdFromNetworkSvcName(parts[0])
   }
 }

--- a/src/core/templates.mjs
+++ b/src/core/templates.mjs
@@ -26,6 +26,10 @@ export class Templates {
   }
 
   static renderNetworkSvcName (nodeId) {
+    return `network-${nodeId}-svc`
+  }
+
+  static renderNetworkHeadlessSvcName (nodeId) {
     return `network-${nodeId}`
   }
 
@@ -161,7 +165,7 @@ export class Templates {
   }
 
   static renderFullyQualifiedNetworkPodName (namespace, nodeId) {
-    return `${Templates.renderNetworkPodName(nodeId)}.${Templates.renderNetworkSvcName(nodeId)}.${namespace}.svc.cluster.local`
+    return `${Templates.renderNetworkPodName(nodeId)}.${Templates.renderNetworkHeadlessSvcName(nodeId)}.${namespace}.svc.cluster.local`
   }
 
   static renderFullyQualifiedNetworkSvcName (namespace, nodeId) {

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -51,9 +51,9 @@ export function main (argv) {
     const chartManager = new ChartManager(helm, logger)
     const configManager = new ConfigManager(logger)
     const k8 = new K8(configManager, logger)
-    const platformInstaller = new PlatformInstaller(logger, k8, configManager)
-    const keyManager = new KeyManager(logger)
     const accountManager = new AccountManager(logger, k8)
+    const platformInstaller = new PlatformInstaller(logger, k8, configManager, accountManager)
+    const keyManager = new KeyManager(logger)
     const profileManager = new ProfileManager(logger, configManager)
 
     // set cluster and namespace in the global configManager from kubernetes context

--- a/test/e2e/commands/account.test.mjs
+++ b/test/e2e/commands/account.test.mjs
@@ -68,7 +68,7 @@ describe('AccountCommand', () => {
   describe('node proxies should be UP', () => {
     for (const nodeId of argv[flags.nodeIDs.name].split(',')) {
       it(`proxy should be UP: ${nodeId} `, async () => {
-        await self.k8.waitForPodReady(
+        await k8.waitForPodReady(
           [`app=haproxy-${nodeId}`, 'fullstack.hedera.com/type=haproxy'],
           1, 300, 2000)
       }, 30000)

--- a/test/e2e/commands/account.test.mjs
+++ b/test/e2e/commands/account.test.mjs
@@ -66,10 +66,11 @@ describe('AccountCommand', () => {
   })
 
   describe('node proxies should be UP', () => {
-    let localPort = 30399
     for (const nodeId of argv[flags.nodeIDs.name].split(',')) {
       it(`proxy should be UP: ${nodeId} `, async () => {
-        await nodeCmd.checkNetworkNodeProxyUp(nodeId, localPort++)
+        await self.k8.waitForPodReady(
+          [`app=haproxy-${nodeId}`, 'fullstack.hedera.com/type=haproxy'],
+          1, 300, 2000)
       }, 30000)
     }
   })

--- a/test/e2e/commands/account.test.mjs
+++ b/test/e2e/commands/account.test.mjs
@@ -18,7 +18,8 @@
 
 import { AccountId, PrivateKey } from '@hashgraph/sdk'
 import {
-  afterAll, beforeAll,
+  afterAll,
+  beforeAll,
   describe,
   expect,
   it
@@ -30,6 +31,7 @@ import * as version from '../../../version.mjs'
 import {
   bootstrapNetwork,
   getDefaultArgv,
+  HEDERA_PLATFORM_VERSION_TAG,
   TEST_CLUSTER,
   testLogger
 } from '../../test_util.js'
@@ -43,7 +45,7 @@ describe('AccountCommand', () => {
   const testSystemAccounts = [[3, 5]]
   const argv = getDefaultArgv()
   argv[flags.namespace.name] = namespace
-  argv[flags.releaseTag.name] = 'v0.47.0-alpha.0'
+  argv[flags.releaseTag.name] = HEDERA_PLATFORM_VERSION_TAG
   argv[flags.keyFormat.name] = constants.KEY_FORMAT_PEM
   argv[flags.nodeIDs.name] = 'node0'
   argv[flags.generateGossipKeys.name] = true

--- a/test/e2e/commands/account.test.mjs
+++ b/test/e2e/commands/account.test.mjs
@@ -52,6 +52,8 @@ describe('AccountCommand', () => {
   argv[flags.generateTlsKeys.name] = true
   argv[flags.clusterName.name] = TEST_CLUSTER
   argv[flags.fstChartVersion.name] = version.FST_CHART_VERSION
+  // set the env variable SOLO_FST_CHARTS_DIR if developer wants to use local FST charts
+  argv[flags.chartDirectory.name] = process.env.SOLO_FST_CHARTS_DIR ? process.env.SOLO_FST_CHARTS_DIR : undefined
   const bootstrapResp = bootstrapNetwork(testName, argv)
   const k8 = bootstrapResp.opts.k8
   const accountManager = bootstrapResp.opts.accountManager

--- a/test/e2e/commands/cluster.test.mjs
+++ b/test/e2e/commands/cluster.test.mjs
@@ -54,6 +54,8 @@ describe('ClusterCommand', () => {
   argv[flags.clusterName.name] = TEST_CLUSTER
   argv[flags.fstChartVersion.name] = version.FST_CHART_VERSION
   argv[flags.force.name] = true
+  // set the env variable SOLO_FST_CHARTS_DIR if developer wants to use local FST charts
+  argv[flags.chartDirectory.name] = process.env.SOLO_FST_CHARTS_DIR ? process.env.SOLO_FST_CHARTS_DIR : undefined
 
   const bootstrapResp = bootstrapTestVariables(testName, argv)
   const k8 = bootstrapResp.opts.k8

--- a/test/e2e/commands/cluster.test.mjs
+++ b/test/e2e/commands/cluster.test.mjs
@@ -20,11 +20,13 @@ import {
   beforeEach,
   describe,
   expect,
-  it, jest
+  it,
+  jest
 } from '@jest/globals'
 import {
   bootstrapTestVariables,
   getDefaultArgv,
+  HEDERA_PLATFORM_VERSION_TAG,
   TEST_CLUSTER
 } from '../../test_util.js'
 import {
@@ -44,7 +46,7 @@ describe('ClusterCommand', () => {
   const namespace = testName
   const argv = getDefaultArgv()
   argv[flags.namespace.name] = namespace
-  argv[flags.releaseTag.name] = 'v0.47.0-alpha.0'
+  argv[flags.releaseTag.name] = HEDERA_PLATFORM_VERSION_TAG
   argv[flags.keyFormat.name] = constants.KEY_FORMAT_PEM
   argv[flags.nodeIDs.name] = 'node0'
   argv[flags.generateGossipKeys.name] = true

--- a/test/e2e/commands/mirror_node.test.mjs
+++ b/test/e2e/commands/mirror_node.test.mjs
@@ -29,6 +29,7 @@ import {
   constants
 } from '../../../src/core/index.mjs'
 import {
+  balanceQueryShouldSucceed,
   bootstrapNetwork,
   getDefaultArgv,
   HEDERA_PLATFORM_VERSION_TAG,
@@ -77,6 +78,8 @@ describe('MirrorNodeCommand', () => {
   afterEach(async () => {
     await sleep(500) // give a few ticks so that connections can close
   })
+
+  balanceQueryShouldSucceed(accountManager, mirrorNodeCmd, namespace)
 
   it('mirror node deploy should success', async () => {
     expect.assertions(1)

--- a/test/e2e/commands/mirror_node.test.mjs
+++ b/test/e2e/commands/mirror_node.test.mjs
@@ -170,7 +170,7 @@ describe('MirrorNodeCommand', () => {
       mirrorNodeCmd.logger.showUserError(e)
       expect(e).toBeNull()
     }
-  }, 240000)
+  }, 300000)
 
   it('mirror node destroy should success', async () => {
     expect.assertions(1)

--- a/test/e2e/commands/mirror_node.test.mjs
+++ b/test/e2e/commands/mirror_node.test.mjs
@@ -57,6 +57,8 @@ describe('MirrorNodeCommand', () => {
   argv[flags.fstChartVersion.name] = version.FST_CHART_VERSION
   argv[flags.force.name] = true
   argv[flags.relayReleaseTag.name] = flags.relayReleaseTag.definition.defaultValue
+  // set the env variable SOLO_FST_CHARTS_DIR if developer wants to use local FST charts
+  argv[flags.chartDirectory.name] = process.env.SOLO_FST_CHARTS_DIR ? process.env.SOLO_FST_CHARTS_DIR : undefined
 
   const bootstrapResp = bootstrapNetwork(testName, argv)
   const k8 = bootstrapResp.opts.k8

--- a/test/e2e/commands/mirror_node.test.mjs
+++ b/test/e2e/commands/mirror_node.test.mjs
@@ -17,7 +17,10 @@
  */
 
 import {
-  afterAll, afterEach, beforeAll, describe,
+  afterAll,
+  afterEach,
+  beforeAll,
+  describe,
   expect,
   it
 } from '@jest/globals'
@@ -28,6 +31,7 @@ import {
 import {
   bootstrapNetwork,
   getDefaultArgv,
+  HEDERA_PLATFORM_VERSION_TAG,
   TEST_CLUSTER
 } from '../../test_util.js'
 import * as version from '../../../version.mjs'
@@ -42,7 +46,7 @@ describe('MirrorNodeCommand', () => {
   const namespace = testName
   const argv = getDefaultArgv()
   argv[flags.namespace.name] = namespace
-  argv[flags.releaseTag.name] = 'v0.47.0-alpha.0'
+  argv[flags.releaseTag.name] = HEDERA_PLATFORM_VERSION_TAG
   argv[flags.keyFormat.name] = constants.KEY_FORMAT_PEM
 
   argv[flags.nodeIDs.name] = 'node0' // use a single node to reduce resource during e2e tests

--- a/test/e2e/commands/network.test.mjs
+++ b/test/e2e/commands/network.test.mjs
@@ -48,6 +48,8 @@ describe('NetworkCommand', () => {
   argv[flags.deployMinio.name] = true
   argv[flags.fstChartVersion.name] = version.FST_CHART_VERSION
   argv[flags.force.name] = true
+  // set the env variable SOLO_FST_CHARTS_DIR if developer wants to use local FST charts
+  argv[flags.chartDirectory.name] = process.env.SOLO_FST_CHARTS_DIR ? process.env.SOLO_FST_CHARTS_DIR : undefined
 
   const bootstrapResp = bootstrapTestVariables(testName, argv)
   const k8 = bootstrapResp.opts.k8

--- a/test/e2e/commands/network.test.mjs
+++ b/test/e2e/commands/network.test.mjs
@@ -17,14 +17,16 @@
  */
 
 import {
-  afterAll, beforeAll,
+  afterAll,
+  beforeAll,
   describe,
   expect,
   it
 } from '@jest/globals'
 import {
   bootstrapTestVariables,
-  getDefaultArgv
+  getDefaultArgv,
+  HEDERA_PLATFORM_VERSION_TAG
 } from '../../test_util.js'
 import {
   constants
@@ -38,7 +40,7 @@ describe('NetworkCommand', () => {
   const namespace = testName
   const argv = getDefaultArgv()
   argv[flags.namespace.name] = namespace
-  argv[flags.releaseTag.name] = 'v0.47.0-alpha.0'
+  argv[flags.releaseTag.name] = HEDERA_PLATFORM_VERSION_TAG
   argv[flags.keyFormat.name] = constants.KEY_FORMAT_PEM
   argv[flags.nodeIDs.name] = 'node0'
   argv[flags.generateGossipKeys.name] = true

--- a/test/e2e/commands/node-local-hedera.test.mjs
+++ b/test/e2e/commands/node-local-hedera.test.mjs
@@ -36,6 +36,9 @@ describe('Node local build', () => {
   argv[flags.generateGossipKeys.name] = true
   argv[flags.generateTlsKeys.name] = true
   argv[flags.clusterName.name] = TEST_CLUSTER
+  // set the env variable SOLO_FST_CHARTS_DIR if developer wants to use local FST charts
+  argv[flags.chartDirectory.name] = process.env.SOLO_FST_CHARTS_DIR ? process.env.SOLO_FST_CHARTS_DIR : undefined
+
   let hederaK8
   afterAll(async () => {
     await hederaK8.deleteNamespace(LOCAL_HEDERA)

--- a/test/e2e/commands/node-local-ptt.test.mjs
+++ b/test/e2e/commands/node-local-ptt.test.mjs
@@ -36,6 +36,9 @@ describe('Node local build', () => {
   argv[flags.generateGossipKeys.name] = true
   argv[flags.generateTlsKeys.name] = true
   argv[flags.clusterName.name] = TEST_CLUSTER
+  // set the env variable SOLO_FST_CHARTS_DIR if developer wants to use local FST charts
+  argv[flags.chartDirectory.name] = process.env.SOLO_FST_CHARTS_DIR ? process.env.SOLO_FST_CHARTS_DIR : undefined
+
   let pttK8
   afterAll(async () => {
     await pttK8.deleteNamespace(LOCAL_PTT)

--- a/test/e2e/commands/relay.test.mjs
+++ b/test/e2e/commands/relay.test.mjs
@@ -16,7 +16,9 @@
  */
 
 import {
-  afterAll, afterEach, describe,
+  afterAll,
+  afterEach,
+  describe,
   expect,
   it
 } from '@jest/globals'
@@ -27,6 +29,7 @@ import {
 import {
   bootstrapNetwork,
   getDefaultArgv,
+  HEDERA_PLATFORM_VERSION_TAG,
   TEST_CLUSTER
 } from '../../test_util.js'
 import * as version from '../../../version.mjs'
@@ -38,7 +41,7 @@ describe('RelayCommand', () => {
   const namespace = testName
   const argv = getDefaultArgv()
   argv[flags.namespace.name] = namespace
-  argv[flags.releaseTag.name] = 'v0.47.0-alpha.0'
+  argv[flags.releaseTag.name] = HEDERA_PLATFORM_VERSION_TAG
   argv[flags.keyFormat.name] = constants.KEY_FORMAT_PEM
 
   argv[flags.nodeIDs.name] = 'node0,node1'

--- a/test/e2e/core/k8_e2e.test.mjs
+++ b/test/e2e/core/k8_e2e.test.mjs
@@ -176,11 +176,4 @@ describe('K8', () => {
     const pvcs = await k8.listPvcsByNamespace(k8._getNamespace())
     expect(pvcs.length).toBeGreaterThan(0)
   }, defaultTimeout)
-
-  it('should be able to recycle pod by labels', async () => {
-    const podLabels = ['app=haproxy-node0', 'fullstack.hedera.com/type=haproxy']
-    const podArray1 = await k8.getPodsByLabel(podLabels)
-    const podsArray2 = await k8.recyclePodByLabels(podLabels)
-    expect(podsArray2.length >= podArray1.length).toBeTruthy()
-  }, 120000)
 })

--- a/test/e2e/core/platform_installer_e2e.test.mjs
+++ b/test/e2e/core/platform_installer_e2e.test.mjs
@@ -25,13 +25,15 @@ import * as fs from 'fs'
 import { K8 } from '../../../src/core/k8.mjs'
 
 import { getTestCacheDir, getTmpDir, testLogger } from '../../test_util.js'
+import { AccountManager } from '../../../src/core/account_manager.mjs'
 
 const defaultTimeout = 20000
 
 describe('PackageInstallerE2E', () => {
   const configManager = new ConfigManager(testLogger)
   const k8 = new K8(configManager, testLogger)
-  const installer = new PlatformInstaller(testLogger, k8, configManager)
+  const accountManager = new AccountManager(testLogger, k8)
+  const installer = new PlatformInstaller(testLogger, k8, configManager, accountManager)
   const testCacheDir = getTestCacheDir()
   const podName = 'network-node0-0'
   const packageVersion = 'v0.42.5'

--- a/test/e2e/e2e_node_util.js
+++ b/test/e2e/e2e_node_util.js
@@ -49,7 +49,7 @@ import fs from 'fs'
 import crypto from 'crypto'
 
 export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag = HEDERA_PLATFORM_VERSION_TAG) {
-  const defaultTimeout = 20000
+  const defaultTimeout = 120000
 
   describe(`NodeCommand [testName ${testName}, mode ${mode}, keyFormat: ${keyFormat}, release ${releaseTag}]`, () => {
     const namespace = testName
@@ -72,11 +72,11 @@ export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag 
     afterEach(async () => {
       await nodeCmd.close()
       await accountManager.close()
-    }, 120000)
+    }, defaultTimeout)
 
     afterAll(async () => {
       await k8.deleteNamespace(namespace)
-    }, 120000)
+    }, defaultTimeout)
 
     describe(`Node should have started successfully [mode ${mode}, release ${releaseTag}, keyFormat: ${keyFormat}]`, () => {
       balanceQueryShouldSucceed(accountManager, nodeCmd, namespace)
@@ -96,7 +96,7 @@ export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag 
         } finally {
           await nodeCmd.close()
         }
-      }, 60000)
+      }, defaultTimeout)
     })
 
     describe(`Node should refresh successfully [mode ${mode}, release ${releaseTag}, keyFormat: ${keyFormat}]`, () => {
@@ -138,7 +138,7 @@ export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag 
         configManager.update(argv, true)
         existingServiceMap = await accountManager.getNodeServiceMap(namespace)
         existingNodeIdsPrivateKeysHash = await getNodeIdsPrivateKeysHash(existingServiceMap, namespace, keyFormat, k8, getTmpDir())
-      }, 120000)
+      }, defaultTimeout)
 
       it(`${nodeId} should not exist`, async () => {
         try {
@@ -182,7 +182,7 @@ export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag 
                 `${nodeId}:${keyFileName}:${existingKeyHash}`)
           }
         }
-      }, 60000)
+      }, defaultTimeout)
     })
   })
 
@@ -216,7 +216,7 @@ export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag 
         nodeCmd.logger.showUserError(e)
         expect(e).toBeNull()
       }
-    }, 60000)
+    }, defaultTimeout)
   }
 
   function nodePodShouldBeRunning (nodeCmd, namespace, nodeId) {
@@ -229,7 +229,7 @@ export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag 
       } finally {
         await nodeCmd.close()
       }
-    }, 60000)
+    }, defaultTimeout)
   }
 
   function nodeRefreshShouldSucceed (nodeId, nodeCmd, argv) {

--- a/test/e2e/e2e_node_util.js
+++ b/test/e2e/e2e_node_util.js
@@ -17,7 +17,6 @@
  */
 
 import {
-  AccountBalanceQuery,
   AccountCreateTransaction,
   Hbar,
   HbarUnit,
@@ -36,6 +35,7 @@ import {
   constants, Templates
 } from '../../src/core/index.mjs'
 import {
+  balanceQueryShouldSucceed,
   bootstrapNetwork,
   getDefaultArgv,
   getTestConfigManager,
@@ -214,28 +214,6 @@ export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag 
         expect(e).toBeNull()
       }
     }, 60000)
-  }
-
-  function balanceQueryShouldSucceed (accountManager, nodeCmd, namespace) {
-    it('Balance query should succeed', async () => {
-      expect.assertions(3)
-
-      try {
-        expect(accountManager._nodeClient).toBeNull()
-        await accountManager.loadNodeClient(namespace)
-        expect(accountManager._nodeClient).not.toBeNull()
-
-        const balance = await new AccountBalanceQuery()
-          .setAccountId(accountManager._nodeClient.getOperator().accountId)
-          .execute(accountManager._nodeClient)
-
-        expect(balance.hbars).not.toBeNull()
-      } catch (e) {
-        nodeCmd.logger.showUserError(e)
-        expect(e).toBeNull()
-      }
-      await sleep(1000)
-    }, 120000)
   }
 
   function nodePodShouldBeRunning (nodeCmd, namespace, nodeId) {

--- a/test/e2e/e2e_node_util.js
+++ b/test/e2e/e2e_node_util.js
@@ -78,7 +78,7 @@ export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag 
       await k8.deleteNamespace(namespace)
     }, 120000)
 
-    describe.skip(`Node should have started successfully [mode ${mode}, release ${releaseTag}, keyFormat: ${keyFormat}]`, () => {
+    describe(`Node should have started successfully [mode ${mode}, release ${releaseTag}, keyFormat: ${keyFormat}]`, () => {
       balanceQueryShouldSucceed(accountManager, nodeCmd, namespace)
 
       accountCreationShouldSucceed(accountManager, nodeCmd, namespace)
@@ -99,7 +99,7 @@ export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag 
       }, 60000)
     })
 
-    describe.skip(`Node should refresh successfully [mode ${mode}, release ${releaseTag}, keyFormat: ${keyFormat}]`, () => {
+    describe(`Node should refresh successfully [mode ${mode}, release ${releaseTag}, keyFormat: ${keyFormat}]`, () => {
       const nodeId = 'node0'
 
       beforeAll(async () => {

--- a/test/e2e/e2e_node_util.js
+++ b/test/e2e/e2e_node_util.js
@@ -84,7 +84,9 @@ export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag 
         expect.assertions(1)
 
         try {
-          await expect(nodeCmd.checkNetworkNodeProxyUp('node0', 30499, 30, 10000)).resolves.toBeTruthy()
+          await expect(self.k8.waitForPodReady(
+            ['app=haproxy-node0', 'fullstack.hedera.com/type=haproxy'],
+            1, 300, 1000)).resolves.toBeTruthy()
         } catch (e) {
           nodeCmd.logger.showUserError(e)
           expect(e).toBeNull()

--- a/test/e2e/e2e_node_util.js
+++ b/test/e2e/e2e_node_util.js
@@ -61,6 +61,9 @@ export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag 
     argv[flags.generateGossipKeys.name] = true
     argv[flags.generateTlsKeys.name] = true
     argv[flags.clusterName.name] = TEST_CLUSTER
+    // set the env variable SOLO_FST_CHARTS_DIR if developer wants to use local FST charts
+    argv[flags.chartDirectory.name] = process.env.SOLO_FST_CHARTS_DIR ? process.env.SOLO_FST_CHARTS_DIR : undefined
+
     const bootstrapResp = bootstrapNetwork(testName, argv)
     const accountManager = bootstrapResp.opts.accountManager
     const k8 = bootstrapResp.opts.k8
@@ -72,10 +75,10 @@ export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag 
     }, 120000)
 
     afterAll(async () => {
-      await k8.deleteNamespace(namespace)
+      // await k8.deleteNamespace(namespace)
     }, 120000)
 
-    describe(`Node should have started successfully [mode ${mode}, release ${releaseTag}, keyFormat: ${keyFormat}]`, () => {
+    describe.skip(`Node should have started successfully [mode ${mode}, release ${releaseTag}, keyFormat: ${keyFormat}]`, () => {
       balanceQueryShouldSucceed(accountManager, nodeCmd, namespace)
 
       accountCreationShouldSucceed(accountManager, nodeCmd, namespace)
@@ -96,7 +99,7 @@ export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag 
       }, 60000)
     })
 
-    describe(`Node should refresh successfully [mode ${mode}, release ${releaseTag}, keyFormat: ${keyFormat}]`, () => {
+    describe.skip(`Node should refresh successfully [mode ${mode}, release ${releaseTag}, keyFormat: ${keyFormat}]`, () => {
       const nodeId = 'node0'
 
       beforeAll(async () => {
@@ -274,13 +277,13 @@ export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag 
     }
   }
 
-  async function getNodeIdsPrivateKeysHash (existingServiceMap, namespace, keyFormat, k8, destDir) {
+  async function getNodeIdsPrivateKeysHash (networkNodeServicesMap, namespace, keyFormat, k8, destDir) {
     const dataKeysDir = `${constants.HEDERA_HAPI_PATH}/data/keys`
     const tlsKeysDir = constants.HEDERA_HAPI_PATH
     const nodeKeyHashMap = new Map()
-    for (const serviceObject of existingServiceMap.values()) {
+    for (const networkNodeServices of networkNodeServicesMap.values()) {
       const keyHashMap = new Map()
-      const nodeId = serviceObject.node
+      const nodeId = networkNodeServices.nodeName
       const uniqueNodeDestDir = path.join(destDir, nodeId)
       if (!fs.existsSync(uniqueNodeDestDir)) {
         fs.mkdirSync(uniqueNodeDestDir, { recursive: true })

--- a/test/e2e/e2e_node_util.js
+++ b/test/e2e/e2e_node_util.js
@@ -38,7 +38,9 @@ import {
 import {
   bootstrapNetwork,
   getDefaultArgv,
-  getTestConfigManager, getTmpDir,
+  getTestConfigManager,
+  getTmpDir,
+  HEDERA_PLATFORM_VERSION_TAG,
   TEST_CLUSTER
 } from '../test_util.js'
 import { sleep } from '../../src/core/helpers.mjs'
@@ -46,7 +48,7 @@ import path from 'path'
 import fs from 'fs'
 import crypto from 'crypto'
 
-export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag = 'v0.49.0-alpha.2') {
+export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag = HEDERA_PLATFORM_VERSION_TAG) {
   const defaultTimeout = 20000
 
   describe(`NodeCommand [testName ${testName}, mode ${mode}, keyFormat: ${keyFormat}, release ${releaseTag}]`, () => {

--- a/test/e2e/e2e_node_util.js
+++ b/test/e2e/e2e_node_util.js
@@ -75,7 +75,7 @@ export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag 
     }, 120000)
 
     afterAll(async () => {
-      // await k8.deleteNamespace(namespace)
+      await k8.deleteNamespace(namespace)
     }, 120000)
 
     describe.skip(`Node should have started successfully [mode ${mode}, release ${releaseTag}, keyFormat: ${keyFormat}]`, () => {

--- a/test/e2e/e2e_node_util.js
+++ b/test/e2e/e2e_node_util.js
@@ -229,7 +229,7 @@ export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag 
       } finally {
         await nodeCmd.close()
       }
-    }, defaultTimeout)
+    }, 60000)
   }
 
   function nodeRefreshShouldSucceed (nodeId, nodeCmd, argv) {

--- a/test/e2e/e2e_node_util.js
+++ b/test/e2e/e2e_node_util.js
@@ -84,7 +84,7 @@ export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag 
         expect.assertions(1)
 
         try {
-          await expect(self.k8.waitForPodReady(
+          await expect(k8.waitForPodReady(
             ['app=haproxy-node0', 'fullstack.hedera.com/type=haproxy'],
             1, 300, 1000)).resolves.toBeTruthy()
         } catch (e) {

--- a/test/e2e/setup-e2e.sh
+++ b/test/e2e/setup-e2e.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 readonly KIND_IMAGE="kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72"
+echo "SOLO_FST_CHARTS_DIR: ${SOLO_FST_CHARTS_DIR}"
 
 SOLO_CLUSTER_NAME=solo-e2e
 SOLO_NAMESPACE=solo-e2e
@@ -14,8 +15,9 @@ kind create cluster -n "${SOLO_CLUSTER_NAME}" --image "${KIND_IMAGE}" || exit 1
 
 # **********************************************************************************************************************
 # Init and deploy a network for e2e tests in (test/e2e/core)
+# -d ${SOLO_CHARTS_DIR} is optional, if you want to use a local chart, it will be ignored if not set
 # **********************************************************************************************************************
-solo init --namespace "${SOLO_NAMESPACE}" -i node0 -s "${SOLO_CLUSTER_SETUP_NAMESPACE}" --dev || exit 1 # cache args for subsequent commands
+solo init --namespace "${SOLO_NAMESPACE}" -i node0 -s "${SOLO_CLUSTER_SETUP_NAMESPACE}" -d "${SOLO_FST_CHARTS_DIR}" --dev || exit 1 # cache args for subsequent commands
 solo cluster setup  || exit 1
 helm list --all-namespaces
 solo network deploy || exit 1

--- a/test/test_util.js
+++ b/test/test_util.js
@@ -42,6 +42,7 @@ import {
   PlatformInstaller, ProfileManager,
   Zippy
 } from '../src/core/index.mjs'
+import { AccountBalanceQuery } from '@hashgraph/sdk'
 
 export const testLogger = logging.NewLogger('debug', true)
 export const TEST_CLUSTER = 'solo-e2e'
@@ -228,4 +229,26 @@ export function bootstrapNetwork (testName, argv,
   })
 
   return bootstrapResp
+}
+
+export function balanceQueryShouldSucceed (accountManager, cmd, namespace) {
+  it('Balance query should succeed', async () => {
+    expect.assertions(3)
+
+    try {
+      expect(accountManager._nodeClient).toBeNull()
+      await accountManager.loadNodeClient(namespace)
+      expect(accountManager._nodeClient).not.toBeNull()
+
+      const balance = await new AccountBalanceQuery()
+        .setAccountId(accountManager._nodeClient.getOperator().accountId)
+        .execute(accountManager._nodeClient)
+
+      expect(balance.hbars).not.toBeNull()
+    } catch (e) {
+      cmd.logger.showUserError(e)
+      expect(e).toBeNull()
+    }
+    await sleep(1000)
+  }, 120000)
 }

--- a/test/test_util.js
+++ b/test/test_util.js
@@ -79,6 +79,7 @@ export function getDefaultArgv () {
   for (const f of flags.allFlags) {
     argv[f.name] = f.definition.defaultValue
   }
+
   return argv
 }
 
@@ -115,8 +116,8 @@ export function bootstrapTestVariables (testName, argv,
   const helm = new Helm(testLogger)
   const chartManager = new ChartManager(helm, testLogger)
   const k8 = k8Arg || new K8(configManager, testLogger)
-  const platformInstaller = new PlatformInstaller(testLogger, k8, configManager)
   const accountManager = new AccountManager(testLogger, k8, constants)
+  const platformInstaller = new PlatformInstaller(testLogger, k8, configManager, accountManager)
   const profileManager = new ProfileManager(testLogger, configManager)
   const opts = {
     logger: testLogger,

--- a/test/test_util.js
+++ b/test/test_util.js
@@ -45,6 +45,7 @@ import {
 
 export const testLogger = logging.NewLogger('debug', true)
 export const TEST_CLUSTER = 'solo-e2e'
+export const HEDERA_PLATFORM_VERSION_TAG = 'v0.49.0-alpha.2'
 
 export function getTestCacheDir (testName) {
   const baseDir = 'test/data/tmp'

--- a/test/unit/core/k8.test.mjs
+++ b/test/unit/core/k8.test.mjs
@@ -127,13 +127,4 @@ describe('K8 Unit Tests', () => {
       expect(e.message).toContain('Expected number of pod (1) not found for labels: labels, phases: Running [attempts = ')
     }
   })
-
-  it('recyclePodByLabels with first time failure, later success', async () => {
-    const waitForPodMaxAttempts = 120
-    const numOfFailures = waitForPodMaxAttempts * 2
-    listNamespacedPodMockSetup(k8, numOfFailures, expectedResult)
-
-    const result = await k8.recyclePodByLabels(['labels'], 2, 0, waitForPodMaxAttempts, 0)
-    expect(result[0]).toBe(expectedResult[0])
-  }, defaultTimeout)
 })

--- a/test/unit/core/platform_installer.test.mjs
+++ b/test/unit/core/platform_installer.test.mjs
@@ -24,11 +24,13 @@ import {
   IllegalArgumentError,
   MissingArgumentError
 } from '../../../src/core/errors.mjs'
+import { AccountManager } from '../../../src/core/account_manager.mjs'
 describe('PackageInstaller', () => {
   const testLogger = core.logging.NewLogger('debug', true)
   const configManager = new ConfigManager(testLogger)
   const k8 = new core.K8(configManager, testLogger)
-  const installer = new PlatformInstaller(testLogger, k8, configManager)
+  const accountManager = new AccountManager(testLogger, k8)
+  const installer = new PlatformInstaller(testLogger, k8, configManager, accountManager)
 
   describe('validatePlatformReleaseDir', () => {
     it('should fail for missing path', async () => {

--- a/version.mjs
+++ b/version.mjs
@@ -22,4 +22,4 @@
 export const JAVA_VERSION = '21.0.1+12'
 export const HELM_VERSION = 'v3.14.2'
 export const FST_CHART_VERSION = 'v0.24.5'
-export const HEDERA_PLATFORM_VERSION = 'v0.48.0'
+export const HEDERA_PLATFORM_VERSION = 'v0.49.0-alpha.2'

--- a/version.mjs
+++ b/version.mjs
@@ -21,5 +21,5 @@
 
 export const JAVA_VERSION = '21.0.1+12'
 export const HELM_VERSION = 'v3.14.2'
-export const FST_CHART_VERSION = 'v0.24.5'
+export const FST_CHART_VERSION = 'v0.24.5' // TODO update after I tag the release
 export const HEDERA_PLATFORM_VERSION = 'v0.49.0-alpha.2'

--- a/version.mjs
+++ b/version.mjs
@@ -21,5 +21,5 @@
 
 export const JAVA_VERSION = '21.0.1+12'
 export const HELM_VERSION = 'v3.14.2'
-export const FST_CHART_VERSION = 'v0.24.5' // TODO update after I tag the release
+export const FST_CHART_VERSION = 'v0.26.0'
 export const HEDERA_PLATFORM_VERSION = 'v0.49.0-alpha.2'


### PR DESCRIPTION
## Description

This pull request changes the following:

* use `Running` phase for proxy check during `solo network deploy`
* remove haproxy recycle pod logic, instead use waitForPodReady which uses the PodCondition[Ready] = true that the haproxy is now setting based on the startupProbe
* removed checkNetworkNodeProxyUp
* use in test cases HEDERA_PLATFORM_VERSION = 'v0.49.0-alpha.2' since this is the first version to support FQDN correctly
* enhanced prepareAddressBookBase64 to convert FQDN to IP addresses to support Mirror Node
* enhanced nodeClient creation to set more robust timeouts and backoffs
* refactored getNodeServiceMap() to use a new class NetworkNodeServices to strongly type variables and give it more attributes that can be provide more reuse
* updated prepareConfigTxt() to use accountId from services instead of dynamically constructing it which could be wrong in some scenarios
* added the ability to set a local environment variable `SOLO_FST_CHARTS_DIR` to point to the developers FST chart directory for running tests locally against a chart that hasn't been released yet

### Related Issues

* Closes #312
* Relates to https://github.com/hashgraph/solo/issues/331
