### PR TITLE
ci: Updated workflows to pin commits to actions

### DIFF
--- a/.github/workflows/flow-hugo-publish.yaml
+++ b/.github/workflows/flow-hugo-publish.yaml
@@ -127,7 +127,7 @@ jobs:
             --baseURL "${{ steps.pages.outputs.base_url }}/"
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
         with:
           path: ./docs/public
 
@@ -141,4 +141,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4.0.5


### PR DESCRIPTION
## Description

This pull request changes the following:

* /.github/workflows/flow-hugo-publish.yml to pin commits to actions in the workflow

### Related Issues

* Closes #324 
