### PR TITLE
feat: add node logs command

### DIFF
--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -182,7 +182,7 @@ jobs:
         uses: actions/upload-artifact@65462800fd760344b1a7b4382951275a0abb4808 # v4.3.3
         with:
           name: solo-${{ inputs.npm-test-script }}.log
-          path: ~/.solo/logs/solo.log
+          path: ~/.solo/logs/*
           overwrite: true
           if-no-files-found: error
 

--- a/src/commands/node.mjs
+++ b/src/commands/node.mjs
@@ -1092,7 +1092,7 @@ export class NodeCommand extends BaseCommand {
       {
         title: 'Copy logs from all nodes',
         task: (ctx, _) => {
-          getNodeLogs(this.k8)
+          getNodeLogs(this.k8, flags.namespace)
         }
       }
     ], {
@@ -1687,7 +1687,7 @@ export class NodeCommand extends BaseCommand {
           })
           .command({
             command: 'logs',
-            desc: 'Download logs from nodes',
+            desc: 'Download application logs from the network nodes and stores them in <SOLO_LOGS_DIR>/<namespace>/<podName>/ directory',
             builder: y => flags.setCommandFlags(y,
               flags.nodeIDs
             ),

--- a/src/commands/node.mjs
+++ b/src/commands/node.mjs
@@ -1075,23 +1075,20 @@ export class NodeCommand extends BaseCommand {
   }
 
   async logs (argv) {
+    const self = this
+
     const tasks = new Listr([
       {
         title: 'Initialize',
         task: async (ctx, task) => {
-          self.configManager.update(argv)
           await prompts.execute(task, self.configManager, [
             flags.nodeIDs
           ])
 
-          const config = {
+          ctx.config = {
             nodeIds: helpers.parseNodeIds(self.configManager.getFlag(flags.nodeIDs))
           }
-          await self.initializeSetup(config, self.configManager, self.k8)
-
-          // set config in the context for later tasks to use
-          ctx.config = config
-          self.logger.debug('Initialized config', { config })
+          self.logger.debug('Initialized config', { config: ctx.config })
         }
       },
       {

--- a/src/commands/node.mjs
+++ b/src/commands/node.mjs
@@ -1700,7 +1700,7 @@ export class NodeCommand extends BaseCommand {
           })
           .command({
             command: 'logs',
-            desc: 'Download logs from a node',
+            desc: 'Download logs from nodes',
             builder: y => flags.setCommandFlags(y,
               flags.nodeIDs
             ),

--- a/src/commands/node.mjs
+++ b/src/commands/node.mjs
@@ -1094,7 +1094,7 @@ export class NodeCommand extends BaseCommand {
       {
         title: 'Copy logs from all nodes',
         task: (ctx, _) => {
-          getNodeLogs(this.k8, ctx.config.nodeIds)
+          getNodeLogs(this.k8)
         }
       }
     ], {

--- a/src/core/helpers.mjs
+++ b/src/core/helpers.mjs
@@ -185,20 +185,17 @@ export function validatePath (input) {
 }
 
 /**
- * Download logs files from the network pods and save to local solo log directory
+ * Download logs files from all network pods and save to local solo log directory
  * @param k8
  *    an instance of core/K8
- * @param nodeIds
- *    a list of node ids
  * @returns A promise that resolves when the logs are downloaded
  */
-export async function getNodeLogs (k8, nodeIds) {
-  for (const nodeId of nodeIds) {
-    const podName = Templates.renderNetworkPodName(nodeId)
-
-    const targetDir = `${SOLO_LOGS_DIR}/${nodeId}`
+export async function getNodeLogs (k8) {
+  const pods = await k8.getPodsByLabel(['fullstack.hedera.com/type=network-node'])
+  for (const pod of pods) {
+    const podName = pod.metadata.name
+    const targetDir = `${SOLO_LOGS_DIR}/${podName}`
     fs.mkdirSync(targetDir, { recursive: true })
-
     await k8.copyFrom(podName, ROOT_CONTAINER, `${HEDERA_HAPI_PATH}/output/swirlds.log`, targetDir)
     await k8.copyFrom(podName, ROOT_CONTAINER, `${HEDERA_HAPI_PATH}/output/hgcaa.log`, targetDir)
   }

--- a/src/core/helpers.mjs
+++ b/src/core/helpers.mjs
@@ -186,7 +186,7 @@ export function validatePath (input) {
 
 /**
  * Download logs files from all network pods and save to local solo log directory
- * @param k8
+ * @param {k8}
  *    an instance of core/K8
  * @returns {Promise<void>} A promise that resolves when the logs are downloaded
  */

--- a/test/e2e/commands/account.test.mjs
+++ b/test/e2e/commands/account.test.mjs
@@ -37,6 +37,7 @@ import {
 } from '../../test_util.js'
 import { AccountCommand } from '../../../src/commands/account.mjs'
 import { flags } from '../../../src/commands/index.mjs'
+import { getNodeLogs } from '../../../src/core/helpers.mjs'
 
 describe('AccountCommand', () => {
   const testName = 'account-cmd-e2e'
@@ -62,6 +63,7 @@ describe('AccountCommand', () => {
   const accountCmd = new AccountCommand(bootstrapResp.opts, testSystemAccounts)
 
   afterAll(async () => {
+    await getNodeLogs(k8, namespace)
     await k8.deleteNamespace(namespace)
     await accountManager.close()
     await nodeCmd.close()

--- a/test/e2e/commands/cluster.test.mjs
+++ b/test/e2e/commands/cluster.test.mjs
@@ -34,7 +34,7 @@ import {
   logging
 } from '../../../src/core/index.mjs'
 import { flags } from '../../../src/commands/index.mjs'
-import { sleep } from '../../../src/core/helpers.mjs'
+import { getNodeLogs, sleep } from '../../../src/core/helpers.mjs'
 import * as version from '../../../version.mjs'
 
 describe('ClusterCommand', () => {
@@ -66,6 +66,7 @@ describe('ClusterCommand', () => {
   const clusterCmd = bootstrapResp.cmd.clusterCmd
 
   afterAll(async () => {
+    await getNodeLogs(k8, namespace)
     await k8.deleteNamespace(namespace)
     await accountManager.close()
   })

--- a/test/e2e/commands/mirror_node.test.mjs
+++ b/test/e2e/commands/mirror_node.test.mjs
@@ -71,7 +71,7 @@ describe('MirrorNodeCommand', () => {
   })
 
   afterAll(async () => {
-    await getNodeLogs(k8)
+    await getNodeLogs(k8, namespace)
     await k8.deleteNamespace(namespace)
     await accountManager.close()
 

--- a/test/e2e/commands/mirror_node.test.mjs
+++ b/test/e2e/commands/mirror_node.test.mjs
@@ -36,12 +36,11 @@ import {
   TEST_CLUSTER
 } from '../../test_util.js'
 import * as version from '../../../version.mjs'
-import { getNodeLogs, sleep } from '../../../src/core/helpers.mjs'
+import { getNodeLogs, parseNodeIds, sleep } from '../../../src/core/helpers.mjs'
 import { MirrorNodeCommand } from '../../../src/commands/mirror_node.mjs'
 import * as core from '../../../src/core/index.mjs'
 import { TopicCreateTransaction, TopicMessageSubmitTransaction } from '@hashgraph/sdk'
 import * as http from 'http'
-import * as helpers from '../../../src/core/helpers.mjs'
 
 describe('MirrorNodeCommand', () => {
   const testName = 'mirror-cmd-e2e'
@@ -72,7 +71,7 @@ describe('MirrorNodeCommand', () => {
   })
 
   afterAll(async () => {
-    await getNodeLogs(k8, helpers.parseNodeIds(argv[flags.nodeIDs.name]))
+    await getNodeLogs(k8, parseNodeIds(argv[flags.nodeIDs.name]))
     await k8.deleteNamespace(namespace)
     await accountManager.close()
 

--- a/test/e2e/commands/mirror_node.test.mjs
+++ b/test/e2e/commands/mirror_node.test.mjs
@@ -36,11 +36,12 @@ import {
   TEST_CLUSTER
 } from '../../test_util.js'
 import * as version from '../../../version.mjs'
-import { sleep } from '../../../src/core/helpers.mjs'
+import { getNodeLogs, sleep } from '../../../src/core/helpers.mjs'
 import { MirrorNodeCommand } from '../../../src/commands/mirror_node.mjs'
 import * as core from '../../../src/core/index.mjs'
 import { TopicCreateTransaction, TopicMessageSubmitTransaction } from '@hashgraph/sdk'
 import * as http from 'http'
+import * as helpers from '../../../src/core/helpers.mjs'
 
 describe('MirrorNodeCommand', () => {
   const testName = 'mirror-cmd-e2e'
@@ -71,6 +72,7 @@ describe('MirrorNodeCommand', () => {
   })
 
   afterAll(async () => {
+    await getNodeLogs(k8, helpers.parseNodeIds(argv[flags.nodeIDs.name]))
     await k8.deleteNamespace(namespace)
     await accountManager.close()
 

--- a/test/e2e/commands/mirror_node.test.mjs
+++ b/test/e2e/commands/mirror_node.test.mjs
@@ -36,7 +36,7 @@ import {
   TEST_CLUSTER
 } from '../../test_util.js'
 import * as version from '../../../version.mjs'
-import { getNodeLogs, parseNodeIds, sleep } from '../../../src/core/helpers.mjs'
+import { getNodeLogs, sleep } from '../../../src/core/helpers.mjs'
 import { MirrorNodeCommand } from '../../../src/commands/mirror_node.mjs'
 import * as core from '../../../src/core/index.mjs'
 import { TopicCreateTransaction, TopicMessageSubmitTransaction } from '@hashgraph/sdk'
@@ -71,7 +71,7 @@ describe('MirrorNodeCommand', () => {
   })
 
   afterAll(async () => {
-    await getNodeLogs(k8, parseNodeIds(argv[flags.nodeIDs.name]))
+    await getNodeLogs(k8)
     await k8.deleteNamespace(namespace)
     await accountManager.close()
 

--- a/test/e2e/commands/network.test.mjs
+++ b/test/e2e/commands/network.test.mjs
@@ -34,7 +34,7 @@ import {
 } from '../../../src/core/index.mjs'
 import { flags } from '../../../src/commands/index.mjs'
 import * as version from '../../../version.mjs'
-import { sleep } from '../../../src/core/helpers.mjs'
+import { getNodeLogs, sleep } from '../../../src/core/helpers.mjs'
 import path from 'path'
 import fs from 'fs'
 
@@ -67,6 +67,7 @@ describe('NetworkCommand', () => {
   const clusterCmd = bootstrapResp.cmd.clusterCmd
 
   afterAll(async () => {
+    await getNodeLogs(k8, namespace)
     await k8.deleteNamespace(namespace)
     await accountManager.close()
   })

--- a/test/e2e/commands/node-local-hedera.test.mjs
+++ b/test/e2e/commands/node-local-hedera.test.mjs
@@ -27,6 +27,7 @@ import {
   getDefaultArgv,
   TEST_CLUSTER
 } from '../../test_util.js'
+import { getNodeLogs } from '../../../src/core/helpers.mjs'
 
 describe('Node local build', () => {
   const LOCAL_HEDERA = 'local-hedera-app'
@@ -41,6 +42,7 @@ describe('Node local build', () => {
 
   let hederaK8
   afterAll(async () => {
+    await getNodeLogs(hederaK8, LOCAL_HEDERA)
     await hederaK8.deleteNamespace(LOCAL_HEDERA)
   }, 120000)
 

--- a/test/e2e/commands/node-local-ptt.test.mjs
+++ b/test/e2e/commands/node-local-ptt.test.mjs
@@ -27,6 +27,7 @@ import {
   getDefaultArgv,
   TEST_CLUSTER
 } from '../../test_util.js'
+import { getNodeLogs } from '../../../src/core/helpers.mjs'
 
 describe('Node local build', () => {
   const LOCAL_PTT = 'local-ptt-app'
@@ -41,6 +42,7 @@ describe('Node local build', () => {
 
   let pttK8
   afterAll(async () => {
+    await getNodeLogs(pttK8, LOCAL_PTT)
     await pttK8.deleteNamespace(LOCAL_PTT)
   }, 120000)
 

--- a/test/e2e/commands/relay.test.mjs
+++ b/test/e2e/commands/relay.test.mjs
@@ -33,7 +33,7 @@ import {
   TEST_CLUSTER
 } from '../../test_util.js'
 import * as version from '../../../version.mjs'
-import { sleep } from '../../../src/core/helpers.mjs'
+import { getNodeLogs, sleep } from '../../../src/core/helpers.mjs'
 import { RelayCommand } from '../../../src/commands/relay.mjs'
 
 describe('RelayCommand', () => {
@@ -58,6 +58,7 @@ describe('RelayCommand', () => {
   const relayCmd = new RelayCommand(bootstrapResp.opts)
 
   afterAll(async () => {
+    await getNodeLogs(k8, namespace)
     await k8.deleteNamespace(namespace)
   })
 

--- a/test/e2e/e2e_node_util.js
+++ b/test/e2e/e2e_node_util.js
@@ -43,7 +43,7 @@ import {
   HEDERA_PLATFORM_VERSION_TAG,
   TEST_CLUSTER
 } from '../test_util.js'
-import { getNodeLogs, parseNodeIds, sleep } from '../../src/core/helpers.mjs'
+import { getNodeLogs, sleep } from '../../src/core/helpers.mjs'
 import path from 'path'
 import fs from 'fs'
 import crypto from 'crypto'
@@ -76,7 +76,7 @@ export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag 
     }, defaultTimeout)
 
     afterAll(async () => {
-      await getNodeLogs(k8, parseNodeIds(argv[flags.nodeIDs.name]))
+      await getNodeLogs(k8)
       await k8.deleteNamespace(namespace)
     }, defaultTimeout)
 

--- a/test/e2e/e2e_node_util.js
+++ b/test/e2e/e2e_node_util.js
@@ -76,7 +76,7 @@ export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag 
     }, defaultTimeout)
 
     afterAll(async () => {
-      await getNodeLogs(k8)
+      await getNodeLogs(k8, namespace)
       await k8.deleteNamespace(namespace)
     }, defaultTimeout)
 

--- a/test/e2e/e2e_node_util.js
+++ b/test/e2e/e2e_node_util.js
@@ -43,10 +43,12 @@ import {
   HEDERA_PLATFORM_VERSION_TAG,
   TEST_CLUSTER
 } from '../test_util.js'
-import { sleep } from '../../src/core/helpers.mjs'
+import { getNodeLogs, sleep } from '../../src/core/helpers.mjs'
 import path from 'path'
 import fs from 'fs'
 import crypto from 'crypto'
+import { ROOT_CONTAINER } from '../../src/core/constants.mjs'
+import * as helpers from '../../../src/core/helpers.mjs'
 
 export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag = HEDERA_PLATFORM_VERSION_TAG) {
   const defaultTimeout = 120000
@@ -75,6 +77,7 @@ export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag 
     }, defaultTimeout)
 
     afterAll(async () => {
+      await getNodeLogs(k8, helpers.parseNodeIds(argv[flags.nodeIDs.name]))
       await k8.deleteNamespace(namespace)
     }, defaultTimeout)
 
@@ -308,7 +311,7 @@ export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag 
   async function addKeyHashToMap (k8, nodeId, keyDir, uniqueNodeDestDir, keyHashMap, privateKeyFileName) {
     await k8.copyFrom(
       Templates.renderNetworkPodName(nodeId),
-      'root-container',
+      ROOT_CONTAINER,
       path.join(keyDir, privateKeyFileName),
       uniqueNodeDestDir)
     const keyBytes = await fs.readFileSync(path.join(uniqueNodeDestDir, privateKeyFileName))

--- a/test/e2e/e2e_node_util.js
+++ b/test/e2e/e2e_node_util.js
@@ -43,12 +43,11 @@ import {
   HEDERA_PLATFORM_VERSION_TAG,
   TEST_CLUSTER
 } from '../test_util.js'
-import { getNodeLogs, sleep } from '../../src/core/helpers.mjs'
+import { getNodeLogs, parseNodeIds, sleep } from '../../src/core/helpers.mjs'
 import path from 'path'
 import fs from 'fs'
 import crypto from 'crypto'
 import { ROOT_CONTAINER } from '../../src/core/constants.mjs'
-import * as helpers from '../../../src/core/helpers.mjs'
 
 export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag = HEDERA_PLATFORM_VERSION_TAG) {
   const defaultTimeout = 120000
@@ -77,7 +76,7 @@ export function e2eNodeKeyRefreshAddTest (keyFormat, testName, mode, releaseTag 
     }, defaultTimeout)
 
     afterAll(async () => {
-      await getNodeLogs(k8, helpers.parseNodeIds(argv[flags.nodeIDs.name]))
+      await getNodeLogs(k8, parseNodeIds(argv[flags.nodeIDs.name]))
       await k8.deleteNamespace(namespace)
     }, defaultTimeout)
 


### PR DESCRIPTION
## Description

This pull request changes the following:

* Add help function to download swirlds.log and hgcaa.log
* Add logs command so we can use `solo node logs` to download logs to ~/.solo directory

### Related Issues

* Closes #336
