### PR TITLE
fix: update default full stack chart version

### DIFF
--- a/version.mjs
+++ b/version.mjs
@@ -21,5 +21,5 @@
 
 export const JAVA_VERSION = '21.0.1+12'
 export const HELM_VERSION = 'v3.14.2'
-export const FST_CHART_VERSION = 'v0.26.0'
+export const FST_CHART_VERSION = 'v0.27.2'
 export const HEDERA_PLATFORM_VERSION = 'v0.49.0-alpha.2'


### PR DESCRIPTION
## Description

This pull request changes the following:

* Updates default Full Stack helm chart version.

### Related Issues

* Closes #361
