### PR TITLE
ci: reduce number of e2e running concurrently but without increasing total time for PR checks

### DIFF
--- a/.github/workflows/flow-build-application.yaml
+++ b/.github/workflows/flow-build-application.yaml
@@ -84,6 +84,7 @@ jobs:
     needs:
       - env-vars
       - code-style
+      - e2e-tests
     with:
       custom-job-label: Mirror Node
       npm-test-script: test-${{ needs.env-vars.outputs.e2e-mirror-node-test-subdir }}
@@ -135,6 +136,7 @@ jobs:
     needs:
       - env-vars
       - code-style
+      - e2e-mirror-node-tests
     with:
       custom-job-label: Relay
       npm-test-script: test-${{ needs.env-vars.outputs.e2e-relay-test-subdir }}

--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -66,10 +66,12 @@ jobs:
 
   e2e-mirror-node-tests:
     name: E2E Tests
+    if: ${{ !cancelled() && always() }}
     uses: ./.github/workflows/zxc-e2e-test.yaml
     needs:
       - env-vars
       - code-style
+      - e2e-tests
     with:
       custom-job-label: Mirror Node
       npm-test-script: test-${{ needs.env-vars.outputs.e2e-mirror-node-test-subdir }}
@@ -114,10 +116,12 @@ jobs:
 
   e2e-relay-tests:
     name: E2E Tests
+    if: ${{ !cancelled() && always() }}
     uses: ./.github/workflows/zxc-e2e-test.yaml
     needs:
       - env-vars
       - code-style
+      - e2e-mirror-node-tests
     with:
       custom-job-label: Relay
       npm-test-script: test-${{ needs.env-vars.outputs.e2e-relay-test-subdir }}


### PR DESCRIPTION
## Description

This pull request changes the following:

* update `flow-pull-request-checks.yaml` and `flow-build-application.yaml`
  * make `e2e-mirror-node-tests` run after `e2e-tests`
  * make `e2e-relay-tests` run after `e2e-mirror-node-tests`

### Related Issues

* Closes #366 
