### PR TITLE
chore: bump fst chart version to 0.29.0

### DIFF
--- a/version.mjs
+++ b/version.mjs
@@ -21,5 +21,5 @@
 
 export const JAVA_VERSION = '21.0.1+12'
 export const HELM_VERSION = 'v3.14.2'
-export const FST_CHART_VERSION = 'v0.28.2'
+export const FST_CHART_VERSION = 'v0.29.0'
 export const HEDERA_PLATFORM_VERSION = 'v0.49.0-alpha.2'


### PR DESCRIPTION
## Description

Increases the version of the full-stack-testing charts to `v0.29.0`

### Related Issues

* Closes #
