### PR TITLE
fix: use path.join instead of forward slashes to support Windows

### DIFF
--- a/src/commands/cluster.mjs
+++ b/src/commands/cluster.mjs
@@ -22,6 +22,7 @@ import { BaseCommand } from './base.mjs'
 import chalk from 'chalk'
 import { constants } from '../core/index.mjs'
 import * as prompts from './prompts.mjs'
+import path from 'path'
 
 /**
  * Define the core functionalities of 'cluster' command
@@ -329,7 +330,7 @@ export class ClusterCommand extends BaseCommand {
   ) {
     let valuesArg = ''
     if (chartDir) {
-      valuesArg = `-f ${chartDir}/fullstack-cluster-setup/values.yaml`
+      valuesArg = `-f ${path.join(chartDir, 'fullstack-cluster-setup', 'values.yaml')}`
     }
 
     valuesArg += ` --set cloud.prometheusStack.enabled=${prometheusStackEnabled}`
@@ -353,7 +354,7 @@ export class ClusterCommand extends BaseCommand {
   async prepareChartPath (chartDir = flags.chartDirectory.definition.default) {
     let chartPath = 'full-stack-testing/fullstack-cluster-setup'
     if (chartDir) {
-      chartPath = `${chartDir}/fullstack-cluster-setup`
+      chartPath = path.join(chartDir, 'fullstack-cluster-setup')
       await this.helm.dependency('update', chartPath)
     }
 

--- a/src/commands/flags.mjs
+++ b/src/commands/flags.mjs
@@ -456,7 +456,7 @@ export const applicationProperties = {
   name: 'application-properties',
   definition: {
     describe: 'application.properties file for node',
-    defaultValue: path.join(constants.SOLO_CACHE_DIR, '/templates/application.properties'),
+    defaultValue: path.join(constants.SOLO_CACHE_DIR, 'templates', 'application.properties'),
     type: 'string'
   }
 }
@@ -478,7 +478,7 @@ export const apiPermissionProperties = {
   name: 'api-permission-properties',
   definition: {
     describe: 'api-permission.properties file for node',
-    defaultValue: path.join(constants.SOLO_CACHE_DIR, '/templates/api-permission.properties'),
+    defaultValue: path.join(constants.SOLO_CACHE_DIR, 'templates', 'api-permission.properties'),
     type: 'string'
   }
 }
@@ -489,7 +489,7 @@ export const bootstrapProperties = {
   name: 'bootstrap-properties',
   definition: {
     describe: 'bootstrap.properties file for node',
-    defaultValue: path.join(constants.SOLO_CACHE_DIR, '/templates/bootstrap.properties'),
+    defaultValue: path.join(constants.SOLO_CACHE_DIR, 'templates', 'bootstrap.properties'),
     type: 'string'
   }
 }
@@ -500,7 +500,7 @@ export const settingTxt = {
   name: 'settings-txt',
   definition: {
     describe: 'settings.txt file for node',
-    defaultValue: path.join(constants.SOLO_CACHE_DIR, '/templates/settings.txt'),
+    defaultValue: path.join(constants.SOLO_CACHE_DIR, 'templates', 'settings.txt'),
     type: 'string'
   }
 }
@@ -544,7 +544,7 @@ export const log4j2Xml = {
   name: 'log4j2-xml',
   definition: {
     describe: 'log4j2.xml file for node',
-    defaultValue: path.join(constants.SOLO_CACHE_DIR, '/templates/log4j2.xml'),
+    defaultValue: path.join(constants.SOLO_CACHE_DIR, 'templates', 'log4j2.xml'),
     type: 'string'
   }
 }

--- a/src/commands/flags.mjs
+++ b/src/commands/flags.mjs
@@ -17,6 +17,7 @@
 import { constants } from '../core/index.mjs'
 import * as core from '../core/index.mjs'
 import * as version from '../../version.mjs'
+import path from 'path'
 
 /**
  * @typedef {Object} CommandFlag
@@ -455,7 +456,7 @@ export const applicationProperties = {
   name: 'application-properties',
   definition: {
     describe: 'application.properties file for node',
-    defaultValue: `${constants.SOLO_CACHE_DIR}/templates/application.properties`,
+    defaultValue: path.join(constants.SOLO_CACHE_DIR, '/templates/application.properties'),
     type: 'string'
   }
 }
@@ -477,7 +478,7 @@ export const apiPermissionProperties = {
   name: 'api-permission-properties',
   definition: {
     describe: 'api-permission.properties file for node',
-    defaultValue: `${constants.SOLO_CACHE_DIR}/templates/api-permission.properties`,
+    defaultValue: path.join(constants.SOLO_CACHE_DIR, '/templates/api-permission.properties'),
     type: 'string'
   }
 }
@@ -488,7 +489,7 @@ export const bootstrapProperties = {
   name: 'bootstrap-properties',
   definition: {
     describe: 'bootstrap.properties file for node',
-    defaultValue: `${constants.SOLO_CACHE_DIR}/templates/bootstrap.properties`,
+    defaultValue: path.join(constants.SOLO_CACHE_DIR, '/templates/bootstrap.properties'),
     type: 'string'
   }
 }
@@ -499,7 +500,7 @@ export const settingTxt = {
   name: 'settings-txt',
   definition: {
     describe: 'settings.txt file for node',
-    defaultValue: `${constants.SOLO_CACHE_DIR}/templates/settings.txt`,
+    defaultValue: path.join(constants.SOLO_CACHE_DIR, '/templates/settings.txt'),
     type: 'string'
   }
 }
@@ -543,7 +544,7 @@ export const log4j2Xml = {
   name: 'log4j2-xml',
   definition: {
     describe: 'log4j2.xml file for node',
-    defaultValue: `${constants.SOLO_CACHE_DIR}/templates/log4j2.xml`,
+    defaultValue: path.join(constants.SOLO_CACHE_DIR, '/templates/log4j2.xml'),
     type: 'string'
   }
 }

--- a/src/commands/network.mjs
+++ b/src/commands/network.mjs
@@ -23,6 +23,7 @@ import * as flags from './flags.mjs'
 import { constants } from '../core/index.mjs'
 import * as prompts from './prompts.mjs'
 import * as helpers from '../core/helpers.mjs'
+import path from 'path'
 
 export class NetworkCommand extends BaseCommand {
   constructor (opts) {

--- a/src/commands/network.mjs
+++ b/src/commands/network.mjs
@@ -90,7 +90,7 @@ export class NetworkCommand extends BaseCommand {
   async prepareValuesArg (config = {}) {
     let valuesArg = ''
     if (config.chartDirectory) {
-      valuesArg = `-f ${config.chartDirectory}/fullstack-deployment/values.yaml`
+      valuesArg = `-f ${path.join(config.chartDirectory, 'fullstack-deployment', 'values.yaml')}`
     }
 
     if (config.valuesFile) {

--- a/src/commands/node.mjs
+++ b/src/commands/node.mjs
@@ -471,7 +471,7 @@ export class NodeCommand extends BaseCommand {
       }
 
       const fileName = path.basename(keyFile)
-      fs.cpSync(keyFile, `${destDir}/${fileName}`)
+      fs.cpSync(keyFile, path.join(destDir, fileName))
     }
   }
 
@@ -586,13 +586,13 @@ export class NodeCommand extends BaseCommand {
     // transaction size is 6Kb and in practice we need to send the file as 4Kb chunks.
     // Note however that in DAB phase-2, we won't need to trigger this fake upgrade process
     const zipper = new Zippy(this.logger)
-    const upgradeConfigDir = `${stagingDir}/mock-upgrade/data/config`
+    const upgradeConfigDir = path.join(stagingDir, 'mock-upgrade', 'data', 'config')
     if (!fs.existsSync(upgradeConfigDir)) {
       fs.mkdirSync(upgradeConfigDir, { recursive: true })
     }
 
     // bump field hedera.config.version
-    const fileBytes = fs.readFileSync(`${stagingDir}/templates/application.properties`)
+    const fileBytes = fs.readFileSync(path.join(stagingDir, 'templates', 'application.properties'))
     const lines = fileBytes.toString().split('\n')
     const newLines = []
     for (let line of lines) {
@@ -606,9 +606,9 @@ export class NodeCommand extends BaseCommand {
         newLines.push(line)
       }
     }
-    fs.writeFileSync(`${upgradeConfigDir}/application.properties`, newLines.join('\n'))
+    fs.writeFileSync(path.join(upgradeConfigDir, 'application.properties'), newLines.join('\n'))
 
-    return await zipper.zip(`${stagingDir}/mock-upgrade`, `${stagingDir}/mock-upgrade.zip`)
+    return await zipper.zip(path.join(stagingDir, 'mock-upgrade'), path.join(stagingDir, 'mock-upgrade.zip'))
   }
 
   async uploadUpgradeZip (upgradeZipFile, nodeClient) {
@@ -1683,7 +1683,7 @@ export class NodeCommand extends BaseCommand {
         task: async (ctx, task) => {
           const config = /** @type {NodeAddConfigClass} **/ ctx.config
           const signingCertFile = Templates.renderGossipPemPublicKeyFile(constants.SIGNING_KEY_PREFIX, config.nodeId)
-          const signingCertFullPath = `${config.keysDir}/${signingCertFile}`
+          const signingCertFullPath = path.join(config.keysDir, signingCertFile)
           const signingCertPem = fs.readFileSync(signingCertFullPath).toString()
           const decodedDers = x509.PemConverter.decode(signingCertPem)
           if (!decodedDers || decodedDers.length === 0) {
@@ -1697,7 +1697,7 @@ export class NodeCommand extends BaseCommand {
         task: async (ctx, task) => {
           const config = /** @type {NodeAddConfigClass} **/ ctx.config
           const tlsCertFile = Templates.renderTLSPemPublicKeyFile(config.nodeId)
-          const tlsCertFullPath = `${config.keysDir}/${tlsCertFile}`
+          const tlsCertFullPath = path.join(config.keysDir, tlsCertFile)
           const tlsCertPem = fs.readFileSync(tlsCertFullPath).toString()
           const tlsCertDers = x509.PemConverter.decode(tlsCertPem)
           if (!tlsCertDers || tlsCertDers.length === 0) {
@@ -1945,7 +1945,7 @@ export class NodeCommand extends BaseCommand {
           // zip the contents of the newest folder on node1 within /opt/hgcapp/services-hedera/HapiApp2.0/data/saved/com.hedera.services.ServicesMain/0/123/
           const zipFileName = await self.k8.execContainer(node1FullyQualifiedPodName, constants.ROOT_CONTAINER, ['bash', '-c', `cd ${upgradeDirectory} && mapfile -t states < <(ls -1t .) && jar cf "\${states[0]}.zip" -C "\${states[0]}" . && echo -n \${states[0]}.zip`])
           await self.k8.copyFrom(node1FullyQualifiedPodName, constants.ROOT_CONTAINER, `${upgradeDirectory}/${zipFileName}`, config.stagingDir)
-          config.lastStateZipPath = `${config.stagingDir}/${zipFileName}`
+          config.lastStateZipPath = path.join(config.stagingDir, zipFileName)
         }
       },
       {
@@ -2187,8 +2187,8 @@ export class NodeCommand extends BaseCommand {
 
         case constants.KEY_FORMAT_PFX: {
           const privateKeyFile = Templates.renderGossipPfxPrivateKeyFile(nodeId)
-          fs.cpSync(`${keysDir}/${privateKeyFile}`, `${stagingKeysDir}/${privateKeyFile}`)
-          fs.cpSync(`${keysDir}/${constants.PUBLIC_PFX}`, `${stagingKeysDir}/${constants.PUBLIC_PFX}`)
+          fs.cpSync(path.join(keysDir, privateKeyFile), path.join(stagingKeysDir, privateKeyFile))
+          fs.cpSync(path.join(keysDir, constants.PUBLIC_PFX), path.join(stagingKeysDir, constants.PUBLIC_PFX))
           break
         }
 

--- a/src/core/account_manager.mjs
+++ b/src/core/account_manager.mjs
@@ -39,6 +39,7 @@ import { FullstackTestingError, MissingArgumentError } from './errors.mjs'
 import { Templates } from './templates.mjs'
 import ip from 'ip'
 import { NetworkNodeServicesBuilder } from './network_node_services.mjs'
+import path from 'path'
 
 const REASON_FAILED_TO_GET_KEYS = 'failed to get keys for accountId'
 const REASON_SKIPPED = 'skipped since it does not have a genesis key'
@@ -231,7 +232,7 @@ export class AccountManager {
       // scheduleNetworkUpdate is set to false, because the ports 50212/50211 are hardcoded in JS SDK that will not work when running locally or in a pipeline
       this._nodeClient = Client.fromConfig({ network: nodes, scheduleNetworkUpdate: false })
       this._nodeClient.setOperator(operatorId, operatorKey)
-      this._nodeClient.setLogger(new Logger(LogLevel.Trace, `${constants.SOLO_LOGS_DIR}/hashgraph-sdk.log`))
+      this._nodeClient.setLogger(new Logger(LogLevel.Trace, path.join(constants.SOLO_LOGS_DIR, 'hashgraph-sdk.log')))
       this._nodeClient.setMaxAttempts(constants.NODE_CLIENT_MAX_ATTEMPTS)
       this._nodeClient.setMinBackoff(constants.NODE_CLIENT_MIN_BACKOFF)
       this._nodeClient.setMaxBackoff(constants.NODE_CLIENT_MAX_BACKOFF)

--- a/src/core/constants.mjs
+++ b/src/core/constants.mjs
@@ -16,21 +16,21 @@
  */
 import { AccountId, FileId } from '@hashgraph/sdk'
 import { color, PRESET_TIMER } from 'listr2'
-import { dirname, normalize } from 'path'
+import path, { dirname, normalize } from 'path'
 import { fileURLToPath } from 'url'
 
 // -------------------- solo related constants ---------------------------------------------------------------------
 export const CUR_FILE_DIR = dirname(fileURLToPath(import.meta.url))
-export const SOLO_HOME_DIR = process.env.SOLO_HOME || `${process.env.HOME}/.solo`
-export const SOLO_LOGS_DIR = `${SOLO_HOME_DIR}/logs`
-export const SOLO_CACHE_DIR = `${SOLO_HOME_DIR}/cache`
-export const SOLO_VALUES_DIR = `${SOLO_CACHE_DIR}/values-files`
+export const SOLO_HOME_DIR = process.env.SOLO_HOME || path.join(process.env.HOME, '.solo')
+export const SOLO_LOGS_DIR = path.join(SOLO_HOME_DIR, 'logs')
+export const SOLO_CACHE_DIR = path.join(SOLO_HOME_DIR, 'cache')
+export const SOLO_VALUES_DIR = path.join(SOLO_CACHE_DIR, 'values-files')
 export const DEFAULT_NAMESPACE = 'default'
 export const HELM = 'helm'
 export const KEYTOOL = 'keytool'
-export const SOLO_CONFIG_FILE = `${SOLO_HOME_DIR}/solo.config`
-export const RESOURCES_DIR = normalize(CUR_FILE_DIR + '/../../resources')
-export const TEMP_DIR = normalize(CUR_FILE_DIR + '/../../temp')
+export const SOLO_CONFIG_FILE = path.join(SOLO_HOME_DIR, 'solo.config')
+export const RESOURCES_DIR = normalize(path.join(CUR_FILE_DIR, '..', '..', 'resources'))
+export const TEMP_DIR = normalize(path.join(CUR_FILE_DIR, '..', '..', 'temp'))
 
 export const ROOT_CONTAINER = 'root-container'
 
@@ -132,7 +132,7 @@ export const PROFILE_TINY = 'tiny'
 export const PROFILE_LOCAL = 'local'
 
 export const ALL_PROFILES = [PROFILE_LOCAL, PROFILE_TINY, PROFILE_SMALL, PROFILE_MEDIUM, PROFILE_LARGE]
-export const DEFAULT_PROFILE_FILE = `${SOLO_CACHE_DIR}/profiles/custom-spec.yaml`
+export const DEFAULT_PROFILE_FILE = path.join(SOLO_CACHE_DIR, 'profiles', 'custom-spec.yaml')
 
 // ------ Hedera SDK Related ------
 export const NODE_CLIENT_MAX_ATTEMPTS = process.env.NODE_CLIENT_MAX_ATTEMPTS || 60

--- a/src/core/helpers.mjs
+++ b/src/core/helpers.mjs
@@ -66,7 +66,7 @@ export function cloneArray (arr) {
  */
 export function loadPackageJSON () {
   try {
-    const raw = fs.readFileSync(`${CUR_FILE_DIR}/../../package.json`)
+    const raw = fs.readFileSync(path.join(CUR_FILE_DIR, '..', '..', 'package.json'))
     return JSON.parse(raw.toString())
   } catch (e) {
     throw new FullstackTestingError('failed to load package.json', e)

--- a/src/core/k8.mjs
+++ b/src/core/k8.mjs
@@ -537,7 +537,7 @@ export class K8 {
 
       const srcFile = path.basename(srcPath)
       const srcDir = path.dirname(srcPath)
-      const destPath = `${destDir}/${srcFile}`
+      const destPath = path.join(destDir, srcFile)
 
       // download the tar file to a temp location
       const tmpFile = this._tempFileFor(srcFile)

--- a/src/core/logging.mjs
+++ b/src/core/logging.mjs
@@ -19,6 +19,7 @@ import { constants } from './index.mjs'
 import { v4 as uuidv4 } from 'uuid'
 import * as util from 'util'
 import chalk from 'chalk'
+import path from 'path'
 
 const customFormat = winston.format.combine(
   winston.format.label({ label: 'SOLO', message: false }),
@@ -77,7 +78,7 @@ export const Logger = class {
         // - Write all logs with importance level of `error` or less to `error.log`
         // - Write all logs with importance level of `info` or less to `solo.log`
         //
-        new winston.transports.File({ filename: `${constants.SOLO_LOGS_DIR}/solo.log` })
+        new winston.transports.File({ filename: path.join(constants.SOLO_LOGS_DIR, 'solo.log') })
         // new winston.transports.File({filename: constants.TMP_DIR + "/logs/error.log", level: 'error'}),
         // new winston.transports.Console({format: customFormat})
       ]

--- a/src/core/platform_installer.mjs
+++ b/src/core/platform_installer.mjs
@@ -154,18 +154,18 @@ export class PlatformInstaller {
       switch (keyFormat) {
         case constants.KEY_FORMAT_PEM:
           // copy private keys for the node
-          srcFiles.push(`${stagingDir}/keys/${Templates.renderGossipPemPrivateKeyFile(constants.SIGNING_KEY_PREFIX, nodeId)}`)
-          srcFiles.push(`${stagingDir}/keys/${Templates.renderGossipPemPrivateKeyFile(constants.AGREEMENT_KEY_PREFIX, nodeId)}`)
+          srcFiles.push(path.join(stagingDir, 'keys', Templates.renderGossipPemPrivateKeyFile(constants.SIGNING_KEY_PREFIX, nodeId)))
+          srcFiles.push(path.join(stagingDir, 'keys', Templates.renderGossipPemPrivateKeyFile(constants.AGREEMENT_KEY_PREFIX, nodeId)))
 
           // copy all public keys for all nodes
           nodeIds.forEach(id => {
-            srcFiles.push(`${stagingDir}/keys/${Templates.renderGossipPemPublicKeyFile(constants.SIGNING_KEY_PREFIX, id)}`)
-            srcFiles.push(`${stagingDir}/keys/${Templates.renderGossipPemPublicKeyFile(constants.AGREEMENT_KEY_PREFIX, id)}`)
+            srcFiles.push(path.join(stagingDir, 'keys', Templates.renderGossipPemPublicKeyFile(constants.SIGNING_KEY_PREFIX, id)))
+            srcFiles.push(path.join(stagingDir, 'keys', Templates.renderGossipPemPublicKeyFile(constants.AGREEMENT_KEY_PREFIX, id)))
           })
           break
         case constants.KEY_FORMAT_PFX:
-          srcFiles.push(`${stagingDir}/keys/${Templates.renderGossipPfxPrivateKeyFile(nodeId)}`)
-          srcFiles.push(`${stagingDir}/keys/${constants.PUBLIC_PFX}`)
+          srcFiles.push(path.join(stagingDir, 'keys', Templates.renderGossipPfxPrivateKeyFile(nodeId)))
+          srcFiles.push(path.join(stagingDir, 'keys', constants.PUBLIC_PFX))
           break
         default:
           throw new FullstackTestingError(`Unsupported key file format ${keyFormat}`)
@@ -215,14 +215,14 @@ export class PlatformInstaller {
       const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), `${nodeId}-tls-keys-`))
 
       // rename files appropriately in the tmp directory
-      fs.cpSync(`${stagingDir}/keys/${Templates.renderTLSPemPrivateKeyFile(nodeId)}`,
-        `${tmpDir}/hedera.key`)
-      fs.cpSync(`${stagingDir}/keys/${Templates.renderTLSPemPublicKeyFile(nodeId)}`,
-        `${tmpDir}/hedera.crt`)
+      fs.cpSync(path.join(stagingDir, 'keys', Templates.renderTLSPemPrivateKeyFile(nodeId)),
+        path.join(tmpDir, 'hedera.key'))
+      fs.cpSync(path.join(stagingDir, 'keys', Templates.renderTLSPemPublicKeyFile(nodeId)),
+        path.join(tmpDir, 'hedera.crt'))
 
       const srcFiles = []
-      srcFiles.push(`${tmpDir}/hedera.key`)
-      srcFiles.push(`${tmpDir}/hedera.crt`)
+      srcFiles.push(path.join(tmpDir, 'hedera.key'))
+      srcFiles.push(path.join(tmpDir, 'hedera.crt'))
 
       return this.copyFiles(podName, srcFiles, constants.HEDERA_HAPI_PATH)
     } catch (e) {

--- a/src/core/templates.mjs
+++ b/src/core/templates.mjs
@@ -141,7 +141,7 @@ export class Templates {
       throw new IllegalArgumentError('releasePrefix cannot be empty')
     }
 
-    return path.resolve(`${cacheDir}/${releasePrefix}/staging/${releaseTag}`)
+    return path.resolve(path.join(cacheDir, releasePrefix, 'staging', releaseTag))
   }
 
   static installationPath (

--- a/test/unit/core/profile_manager.test.mjs
+++ b/test/unit/core/profile_manager.test.mjs
@@ -27,7 +27,7 @@ const configFile = path.join(tmpDir, 'resource-manager.config')
 const configManager = new ConfigManager(testLogger, configFile)
 const profileManager = new ProfileManager(testLogger, configManager, tmpDir)
 configManager.setFlag(flags.nodeIDs, 'node0,node1,node3')
-const testProfileFile = path.resolve('test/data/test-profiles.yaml')
+const testProfileFile = path.join('test', 'data', 'test-profiles.yaml')
 
 describe('ProfileManager', () => {
   afterAll(() => {


### PR DESCRIPTION
## Description

This pull request changes the following:

* use path.join instead of forward slashes to support Windows

### Related Issues

* Closes #490 
