### PR TITLE
fix: node add call triggers no prompt found for local-build-path error and exits

### DIFF
--- a/src/commands/flags.mjs
+++ b/src/commands/flags.mjs
@@ -725,6 +725,17 @@ export const allFlags = [
   valuesFile
 ]
 
+/**
+ * Resets the definition.disablePrompt for all flags
+ */
+export function resetDisabledPrompts () {
+  allFlags.forEach(f => {
+    if (f.definition.disablePrompt) {
+      delete f.definition.disablePrompt
+    }
+  })
+}
+
 export const allFlagsMap = new Map(allFlags.map(f => [f.name, f]))
 
 export const nodeConfigFileFlags = new Map([

--- a/src/commands/node.mjs
+++ b/src/commands/node.mjs
@@ -1452,6 +1452,7 @@ export class NodeCommand extends BaseCommand {
             flags.endpointType,
             flags.force,
             flags.fstChartVersion,
+            flags.localBuildPath,
             flags.gossipEndpoints,
             flags.grpcEndpoints
           ])

--- a/src/commands/node.mjs
+++ b/src/commands/node.mjs
@@ -1194,7 +1194,8 @@ export class NodeCommand extends BaseCommand {
           // disable the prompts that we don't want to prompt the user for
           prompts.disablePrompts([
             flags.devMode,
-            flags.force
+            flags.force,
+            flags.localBuildPath
           ])
 
           await prompts.execute(task, self.configManager, NodeCommand.REFRESH_FLAGS_LIST)

--- a/src/commands/prompts.mjs
+++ b/src/commands/prompts.mjs
@@ -20,6 +20,7 @@ import { FullstackTestingError, IllegalArgumentError } from '../core/errors.mjs'
 import { ConfigManager, constants } from '../core/index.mjs'
 import * as flags from './flags.mjs'
 import * as helpers from '../core/helpers.mjs'
+import { resetDisabledPrompts } from './flags.mjs'
 
 async function prompt (type, task, input, defaultValue, promptMessage, emptyCheckMessage, flagName) {
   try {
@@ -531,6 +532,7 @@ export async function execute (task, configManager, flagList = []) {
  * @param {CommandFlag[]} flags list of flags to disable prompts for
  */
 export function disablePrompts (flags) {
+  resetDisabledPrompts()
   for (const flag of flags) {
     if (flag.definition) {
       flag.definition.disablePrompt = true

--- a/test/e2e/commands/node-add.test.mjs
+++ b/test/e2e/commands/node-add.test.mjs
@@ -75,7 +75,7 @@ describe('Node add', () => {
       flags.devMode.constName
     ])
     await nodeCmd.accountManager.close()
-  }, 600000)
+  }, 800000)
 
   balanceQueryShouldSucceed(nodeCmd.accountManager, nodeCmd, namespace)
 


### PR DESCRIPTION
## Description

This pull request changes the following:

* reset the disablePrompt attribute for the definition under each flag
* add local build path to the disabled prompts for node add

### Related Issues

* Closes #514 
