### PR TITLE
fix: jsdoc errors due to unrecognized format

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,6 +30,7 @@
         "ip": "^2.0.1",
         "js-base64": "^3.7.7",
         "js-yaml": "^4.1.0",
+        "jsdoc": "^4.0.3",
         "listr2": "^8.2.4",
         "semver": "^7.6.3",
         "stream-buffers": "^3.0.3",
@@ -416,7 +417,6 @@
       "version": "7.24.7",
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.7.tgz",
       "integrity": "sha512-9uUYRm6OqQrCqQdG1iCBwBPZgN8ciDBro2nIOFaiRz1/BCxaI7CNvQbDHvsArAC7Tw9Hda/B3U+6ui9u4HWXPw==",
-      "dev": true,
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -2054,6 +2054,17 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@jsdoc/salty": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@jsdoc/salty/-/salty-0.2.8.tgz",
+      "integrity": "sha512-5e+SFVavj1ORKlKaKr2BmTOekmXbelU7dC0cDkQLqag7xfuTPuGMUFx7KWJuv4bYZrTsoL2Z18VVCOKYxzoHcg==",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      },
+      "engines": {
+        "node": ">=v12.0.0"
+      }
+    },
     "node_modules/@kubernetes/client-node": {
       "version": "0.21.0",
       "resolved": "https://registry.npmjs.org/@kubernetes/client-node/-/client-node-0.21.0.tgz",
@@ -2611,6 +2622,20 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
     },
+    "node_modules/@types/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-sVDA58zAw4eWAffKOaQH5/5j3XeayukzDk+ewSsnv3p4yJEZHCCzMDiZM8e0OUrRvmpGZ85jf4yDHkHsgBNr9Q=="
+    },
+    "node_modules/@types/markdown-it": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/@types/markdown-it/-/markdown-it-14.1.2.tgz",
+      "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
+      "dependencies": {
+        "@types/linkify-it": "^5",
+        "@types/mdurl": "^2"
+      }
+    },
     "node_modules/@types/mdast": {
       "version": "4.0.3",
       "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.3.tgz",
@@ -2619,6 +2644,11 @@
       "dependencies": {
         "@types/unist": "*"
       }
+    },
+    "node_modules/@types/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@types/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-RGdgjQUZba5p6QEFAVx2OGb8rQDL/cPRG7GiedRzMcJ1tYnUANBncjbSB1NRGwbvjcPeikRABz2nshyPk1bhWg=="
     },
     "node_modules/@types/ms": {
       "version": "0.7.34",
@@ -3286,6 +3316,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/bluebird": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg=="
+    },
     "node_modules/bn.js": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
@@ -3579,6 +3614,17 @@
       "version": "0.12.0",
       "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
       "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
+    },
+    "node_modules/catharsis": {
+      "version": "0.9.0",
+      "resolved": "https://registry.npmjs.org/catharsis/-/catharsis-0.9.0.tgz",
+      "integrity": "sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==",
+      "dependencies": {
+        "lodash": "^4.17.15"
+      },
+      "engines": {
+        "node": ">= 10"
+      }
     },
     "node_modules/chalk": {
       "version": "5.3.0",
@@ -4459,6 +4505,17 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/environment": {
@@ -5792,8 +5849,7 @@
     "node_modules/graceful-fs": {
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="
     },
     "node_modules/graphemer": {
       "version": "1.4.0",
@@ -7615,10 +7671,54 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/js2xmlparser": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/js2xmlparser/-/js2xmlparser-4.0.2.tgz",
+      "integrity": "sha512-6n4D8gLlLf1n5mNLQPRfViYzu9RATblzPEtm1SthMX1Pjao0r9YI9nw7ZIfRxQMERS87mcswrg+r/OYrPRX6jA==",
+      "dependencies": {
+        "xmlcreate": "^2.0.4"
+      }
+    },
     "node_modules/jsbn": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
       "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg=="
+    },
+    "node_modules/jsdoc": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/jsdoc/-/jsdoc-4.0.3.tgz",
+      "integrity": "sha512-Nu7Sf35kXJ1MWDZIMAuATRQTg1iIPdzh7tqJ6jjvaU/GfDf+qi5UV8zJR3Mo+/pYFvm8mzay4+6O5EWigaQBQw==",
+      "dependencies": {
+        "@babel/parser": "^7.20.15",
+        "@jsdoc/salty": "^0.2.1",
+        "@types/markdown-it": "^14.1.1",
+        "bluebird": "^3.7.2",
+        "catharsis": "^0.9.0",
+        "escape-string-regexp": "^2.0.0",
+        "js2xmlparser": "^4.0.2",
+        "klaw": "^3.0.0",
+        "markdown-it": "^14.1.0",
+        "markdown-it-anchor": "^8.6.7",
+        "marked": "^4.0.10",
+        "mkdirp": "^1.0.4",
+        "requizzle": "^0.2.3",
+        "strip-json-comments": "^3.1.0",
+        "underscore": "~1.13.2"
+      },
+      "bin": {
+        "jsdoc": "jsdoc.js"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/jsdoc/node_modules/escape-string-regexp": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+      "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==",
+      "engines": {
+        "node": ">=8"
+      }
     },
     "node_modules/jsesc": {
       "version": "2.5.2",
@@ -7710,6 +7810,14 @@
         "json-buffer": "3.0.1"
       }
     },
+    "node_modules/klaw": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/klaw/-/klaw-3.0.0.tgz",
+      "integrity": "sha512-0Fo5oir+O9jnXu5EefYbVK+mHMBeEVEy2cmctR1O1NECcCkPRreJKrS6Qt/j3KC2C148Dfo9i3pCmCMsdqGr0g==",
+      "dependencies": {
+        "graceful-fs": "^4.1.9"
+      }
+    },
     "node_modules/kleur": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/kleur/-/kleur-3.0.3.tgz",
@@ -7751,6 +7859,14 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
       "dev": true
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.0.tgz",
+      "integrity": "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
     },
     "node_modules/listr2": {
       "version": "8.2.4",
@@ -7866,6 +7982,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/lodash": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
     },
     "node_modules/lodash.camelcase": {
       "version": "4.3.0",
@@ -8105,6 +8226,42 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-it": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.0.tgz",
+      "integrity": "sha512-a54IwgWPaeBCAAsv13YgmALOF1elABB08FxO9i+r4VFk5Vl4pKokRPeX8u5TCgSsPi6ec1otfLjdOpVcgbpshg==",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.4.0",
+        "linkify-it": "^5.0.0",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
+      }
+    },
+    "node_modules/markdown-it-anchor": {
+      "version": "8.6.7",
+      "resolved": "https://registry.npmjs.org/markdown-it-anchor/-/markdown-it-anchor-8.6.7.tgz",
+      "integrity": "sha512-FlCHFwNnutLgVTflOYHPW2pPcl2AACqVzExlkGQNsi4CJgqOHN7YTgDd4LuhgN1BFO3TS0vLAruV1Td6dwWPJA==",
+      "peerDependencies": {
+        "@types/markdown-it": "*",
+        "markdown-it": "*"
+      }
+    },
+    "node_modules/marked": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+      "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 12"
+      }
+    },
     "node_modules/mdast-comment-marker": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/mdast-comment-marker/-/mdast-comment-marker-3.0.0.tgz",
@@ -8255,6 +8412,11 @@
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
       }
+    },
+    "node_modules/mdurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+      "integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w=="
     },
     "node_modules/merge-stream": {
       "version": "2.0.0",
@@ -8880,7 +9042,6 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
       "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
-      "dev": true,
       "bin": {
         "mkdirp": "bin/cmd.js"
       },
@@ -9826,6 +9987,14 @@
         "node": ">=6"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pure-rand": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.0.4.tgz",
@@ -10709,6 +10878,14 @@
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-2.0.0.tgz",
       "integrity": "sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==",
       "dev": true
+    },
+    "node_modules/requizzle": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/requizzle/-/requizzle-0.2.4.tgz",
+      "integrity": "sha512-JRrFk1D4OQ4SqovXOgdav+K8EAhSB/LJZqCz8tbX0KObcdeM15Ss59ozWMBWmmINMagCwmqn4ZNryUGpBsl6Jw==",
+      "dependencies": {
+        "lodash": "^4.17.21"
+      }
     },
     "node_modules/resolve": {
       "version": "1.22.8",
@@ -11821,6 +11998,11 @@
         "is-typedarray": "^1.0.0"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -11835,6 +12017,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/underscore": {
+      "version": "1.13.7",
+      "resolved": "https://registry.npmjs.org/underscore/-/underscore-1.13.7.tgz",
+      "integrity": "sha512-GMXzWtsc57XAtguZgaQViUOzs0KTkk8ojr3/xAxXLITqf/3EMwxC0inyETfDFjH/Krbhuep0HNbbjI9i/q3F3g=="
     },
     "node_modules/undici-types": {
       "version": "5.26.5",
@@ -12570,6 +12757,11 @@
       "resolved": "https://registry.npmjs.org/xml/-/xml-1.0.1.tgz",
       "integrity": "sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==",
       "dev": true
+    },
+    "node_modules/xmlcreate": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/xmlcreate/-/xmlcreate-2.0.4.tgz",
+      "integrity": "sha512-nquOebG4sngPmGPICTS5EnxqhKbCmz5Ox5hsszI2T6U5qdrJizBc+0ilYSEjTSzU0yZcmvppztXe/5Al5fUwdg=="
     },
     "node_modules/y18n": {
       "version": "5.0.8",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "merge-unit": "nyc merge ./coverage/unit/ .nyc_output/coverage.json",
     "report-coverage": "npm run merge-clean && npm run merge-unit && npm run merge-e2e && nyc report --reporter=json --reporter=html --reporter=lcov",
     "solo": "NODE_OPTIONS=--experimental-vm-modules node --no-deprecation solo.mjs",
-    "check": "remark . --quiet --frail && eslint .",
+    "check": "remark . --quiet --frail && eslint .; cd docs; jsdoc -c jsdoc.conf.json; cd ..",
     "format": "remark . --quiet --frail --output && eslint --fix .",
     "test-setup": "./test/e2e/setup-e2e.sh",
     "test-coverage": "npm run test && npm run test-setup && npm run test-e2e-all && npm run report-coverage"
@@ -54,6 +54,7 @@
     "got": "^14.4.2",
     "inquirer": "^10.2.0",
     "ip": "^2.0.1",
+    "jsdoc": "^4.0.3",
     "js-base64": "^3.7.7",
     "js-yaml": "^4.1.0",
     "listr2": "^8.2.4",

--- a/src/commands/index.mjs
+++ b/src/commands/index.mjs
@@ -27,7 +27,7 @@ import * as flags from './flags.mjs'
 /**
  * Return a list of Yargs command builder to be exposed through CLI
  * @param {Object} opts it is an Options object containing logger
- * @returns {Array<{command: string, desc: string, builder: Function, handler?: Function}[]>}
+ * @returns {Array} an array of Yargs command builder
  */
 function Initialize (opts) {
   const initCmd = new InitCommand(opts)

--- a/src/commands/init.mjs
+++ b/src/commands/init.mjs
@@ -145,7 +145,7 @@ export class InitCommand extends BaseCommand {
   /**
    * Return Yargs command definition for 'init' command
    * @param {InitCommand} initCmd - an instance of InitCommand
-   * @returns {{command: string, desc: string, builder: Function, handler: (argv: Object) => void}}
+   * @returns A object representing the Yargs command definition
    */
   static getCommandDefinition (initCmd) {
     if (!initCmd || !(initCmd instanceof InitCommand)) {

--- a/src/commands/node.mjs
+++ b/src/commands/node.mjs
@@ -382,7 +382,7 @@ export class NodeCommand extends BaseCommand {
   /**
    * Return task for checking for all network node pods
    * @param {any} ctx
-   * @param {typeof import('listr2').TaskWrapper} task
+   * @param {TaskWrapper} task
    * @param {string[]} nodeIds
    * @returns {*}
    */
@@ -439,7 +439,7 @@ export class NodeCommand extends BaseCommand {
   /**
    * @param {string[]} nodeIds
    * @param {Object} podNames
-   * @param {typeof import('listr2').TaskWrapper} task
+   * @param {TaskWrapper} task
    * @param {string} localBuildPath
    * @returns {Listr<*, *, *>}
    */
@@ -499,7 +499,7 @@ export class NodeCommand extends BaseCommand {
    * @param {string[]} nodeIds
    * @param {Object} podNames
    * @param {string} releaseTag
-   * @param {typeof import('listr2').TaskWrapper} task
+   * @param {TaskWrapper} task
    * @param {string} localBuildPath
    * @returns {Listr<*, *, *>}
    */
@@ -516,7 +516,7 @@ export class NodeCommand extends BaseCommand {
    * @param {string[]} nodeIds
    * @param {Object} podNames
    * @param {string} releaseTag
-   * @param {typeof import('listr2').TaskWrapper} task
+   * @param {TaskWrapper} task
    * @param {PlatformInstaller} platformInstaller
    * @returns {Listr<any, any, any>}
    */
@@ -1981,7 +1981,7 @@ export class NodeCommand extends BaseCommand {
   /**
    * @param {PrivateKey|string} freezeAdminPrivateKey
    * @param {Uint8Array|string} upgradeZipHash
-   * @param {Client<import('../channel/Channel.js').default,import('../channel/MirrorChannel.js').default>} client
+   * @param {NodeClient} client
    * @returns {Promise<void>}
    */
   async prepareUpgradeNetworkNodes (freezeAdminPrivateKey, upgradeZipHash, client) {
@@ -2020,7 +2020,7 @@ export class NodeCommand extends BaseCommand {
   /**
    * @param {PrivateKey|string} freezeAdminPrivateKey
    * @param {Uint8Array|string} upgradeZipHash
-   * @param {Client<import('../channel/Channel.js').default,import('../channel/MirrorChannel.js').default>} client
+   * @param {NodeClient} client
    * @returns {Promise<void>}
    */
   async freezeUpgradeNetworkNodes (freezeAdminPrivateKey, upgradeZipHash, client) {
@@ -2052,7 +2052,7 @@ export class NodeCommand extends BaseCommand {
   /**
    * @param {Object} podNames
    * @param {string} nodeIds
-   * @param {{title: string, task: () => Promise<void>}[]} subTasks
+   * @param {Object[]} subTasks
    */
   startNodes (podNames, nodeIds, subTasks) {
     for (const nodeId of nodeIds) {

--- a/src/commands/relay.mjs
+++ b/src/commands/relay.mjs
@@ -26,7 +26,7 @@ import { getNodeAccountMap } from '../core/helpers.mjs'
 
 export class RelayCommand extends BaseCommand {
   /**
-   * @param {{profileManager: ProfileManager, accountManager?: AccountManager, logger: Logger, helm: Helm, k8: K8,
+   * @param {{profileManager: ProfileManager, accountManager: AccountManager, logger: Logger, helm: Helm, k8: K8,
    * chartManager: ChartManager, configManager: ConfigManager, depManager: DependencyManager,
    * downloader: PackageDownloader}} opts
    */

--- a/src/core/constants.mjs
+++ b/src/core/constants.mjs
@@ -95,7 +95,7 @@ export const POD_CONDITION_STATUS_TRUE = 'True'
 
 /**
  * Listr related
- * @type {LoggerFieldFn<[number]> & {condition: (duration: number) => boolean, format: (duration: number) => Color}}
+ * @return a object that defines the default color options
  */
 export const LISTR_DEFAULT_RENDERER_TIMER_OPTION = {
   ...PRESET_TIMER,

--- a/src/core/dependency_managers/dependency_manager.mjs
+++ b/src/core/dependency_managers/dependency_manager.mjs
@@ -55,10 +55,10 @@ export class DependencyManager extends ShellRunner {
   }
 
   /**
-   * @param {*[]} [deps]
-   * @returns {{title: string, task: () => Promise<void>}[]}
+   * @param {String[]} deps
+   * @param {Object[]} subTasks
    */
-  taskCheckDependencies (deps = []) {
+  taskCheckDependencies (deps) {
     const subTasks = []
     deps.forEach(dep => {
       subTasks.push({

--- a/src/core/k8.mjs
+++ b/src/core/k8.mjs
@@ -212,7 +212,7 @@ export class K8 {
   /**
    * Get pods by labels
    * @param {string[]} labels - list of labels
-   * @returns {Promise<Array<import('@kubernetes/client-node').V1Pod>>}
+   * @returns {Promise<Array<V1Pod>>}
    */
   async getPodsByLabel (labels = []) {
     const ns = this._getNamespace()
@@ -342,7 +342,7 @@ export class K8 {
    * @param {string} containerName
    * @param {string} destPath - path inside the container
    * @param {number} [timeout] - timeout in ms
-   * @returns {Promise<{owner: string, size: number, modifiedAt: string, name: string, directory: boolean, group: string}[]>}
+   * @returns {Promise<{owner: string, size: number, modifiedAt: string, name: string, directory: boolean, group: string}>}
    * array of directory entries, custom object
    */
   async listDir (podName, containerName, destPath, timeout = 5000) {

--- a/src/core/platform_installer.mjs
+++ b/src/core/platform_installer.mjs
@@ -305,7 +305,7 @@ export class PlatformInstaller {
    *
    * @param stagingDir staging directory path
    * @param nodeIds list of node ids
-   * @returns {Listr<ListrContext, ListrPrimaryRendererValue, ListrSecondaryRendererValue>[]}
+   * @returns {Listr<ListrContext, ListrPrimaryRendererValue, ListrSecondaryRendererValue>}
    */
   copyNodeKeys (stagingDir, nodeIds) {
     const self = this


### PR DESCRIPTION
## Description

Fixed some jsdoc errors because it did not support some auto generated mjs documentation styles.
Also run jsdoc when doing syntax format check so we do not need separate jsdoc check from ci flow as mentioned in #544



### Related Issues

* Closes #543
* Closes #544 