### PR TITLE
fix(functionality): removed the 'z' from the 'tar' command on the K8.copyFrom

### DIFF
--- a/src/core/k8.mjs
+++ b/src/core/k8.mjs
@@ -571,7 +571,7 @@ export class K8 {
       const self = this
       return new Promise((resolve, reject) => {
         const execInstance = new k8s.Exec(this.kubeConfig)
-        const command = ['tar', 'zcf', '-', '-C', srcDir, srcFile]
+        const command = ['tar', 'cf', '-', '-C', srcDir, srcFile]
         const writerStream = fs.createWriteStream(tmpFile)
         const errStream = new sb.WritableStreamBuffer()
 


### PR DESCRIPTION
## Description

Removed the 'z' from the 'tar' command on the K8.copyFrom method in order to disable the compression

### Related Issues

* Closes # [57](https://github.com/hashgraph/solo/issues/57)

