### PR TITLE
fix: update readme workflow to use version from semantic-release

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -22,12 +22,7 @@ on:
         description: "Perform Dry Run"
         type: boolean
         required: false
-        default: true
-  pull_request:
-    types:
-      - opened
-      - reopened
-      - synchronize
+        default: false
 
 env:
   REGISTRY: ghcr.io

--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -22,7 +22,12 @@ on:
         description: "Perform Dry Run"
         type: boolean
         required: false
-        default: false
+        default: true
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
 
 env:
   REGISTRY: ghcr.io
@@ -73,13 +78,17 @@ jobs:
           GIT_AUTHOR_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
           GIT_COMMITTER_NAME: ${{ secrets.GIT_USER_NAME }}
           GIT_COMMITTER_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
-        run: npx semantic-release --dry-run
+        run: |
+          npx semantic-release --dry-run
+          ls -al
+          cat VERSION
 
       - name: Extract Version
         id: tag
         run: |
+          cat VERSION
           [[ "${{ github.event.inputs.dry-run-enabled }}" == true && ! -f VERSION ]] && echo -n "0.0.0-latest" > VERSION
-          echo "version=$(cat VERSION | tr -d '[:space:]')" >> ${GITHUB_OUTPUT}
+          echo "version=$(cat VERSION | tr -d '[:space:]')" | tee -a ${GITHUB_OUTPUT}
 
   update-readme:
     name: "Update README.md"


### PR DESCRIPTION
## Description

This pull request changes the following:

* update readme workflow to use version from semantic-release

### Related Issues

* Closes #593 
