### PR TITLE
fix: deploy and tag uses commit-hash from readme

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -109,7 +109,6 @@ jobs:
       GH_ACCESS_GPG_KEY: ${{ secrets.GH_ACCESS_GPG_KEY }}
       GH_ACCESS_PASSPHRASE: ${{ secrets.GH_ACCESS_PASSPHRASE }}
 
-
   create-github-release:
     name: Github / Release
     runs-on: solo-linux-medium

--- a/.github/workflows/flow-update-readme.yaml
+++ b/.github/workflows/flow-update-readme.yaml
@@ -40,7 +40,7 @@ on:
     outputs:
       commit-hash:
         description: "The commit hash for the updated README.md commit"
-        value: ${{ jobs.commit-readme.outputs.commit_hash }}
+        value: ${{ jobs.commit-hash.outputs.commit_hash }}
   push:
     paths:
       - '**/*.mjs'
@@ -203,3 +203,8 @@ jobs:
           commit_author: Swirlds Automation <swirlds-eng-automation@swirlds.com>
         env:
           GITHUB_TOKEN: ${{secrets.GH_ACCESS_TOKEN}}
+
+      - name: Set commit hash
+        id: commit-hash
+        run: |
+          echo "commit_hash=${{ jobs.commit-readme.outputs.commit_hash }}" | tee -a ${GITHUB_OUTPUT}


### PR DESCRIPTION
## Description

This pull request changes the following:

* deploy and tag uses commit-hash from readme

### Related Issues

* Closes #594
