### PR TITLE
fix: jsdoc failed but ci job not failed

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "merge-unit": "nyc merge ./coverage/unit/ .nyc_output/coverage.json",
     "report-coverage": "npm run merge-clean && npm run merge-unit && npm run merge-e2e && nyc report --reporter=json --reporter=html --reporter=lcov",
     "solo": "NODE_OPTIONS=--experimental-vm-modules node --no-deprecation solo.mjs",
-    "check": "rm -rf docs/public/*; remark . --quiet --frail && eslint .; cd docs; jsdoc -c jsdoc.conf.json; cd ..",
+    "check": "rm -rf docs/public/*; remark . --quiet --frail && eslint .; cd docs; jsdoc -c jsdoc.conf.json",
     "format": "remark . --quiet --frail --output && eslint --fix .",
     "test-setup": "./test/e2e/setup-e2e.sh",
     "test-coverage": "npm run test && npm run test-setup && npm run test-e2e-all && npm run report-coverage"


### PR DESCRIPTION
## Description

This pull request changes the following:

* fixing jsdoc failed but ci job not failed

### Related Issues

* Closes #607


---

Now ci job would fail if jsdoc reported errors

https://github.com/hashgraph/solo/actions/runs/10924368487/job/30323236542


<img width="1685" alt="image" src="https://github.com/user-attachments/assets/91a7e2e4-3648-4b06-99d6-eb55bb0f2e28">

