### PR TITLE
fix(tests): start Kind cluster on demand if not having a kube config errors

### DIFF
--- a/test/test_util.js
+++ b/test/test_util.js
@@ -370,6 +370,7 @@ async function addKeyHashToMap (k8, nodeId, keyDir, uniqueNodeDestDir, keyHashMa
 export function getK8Instance (configManager) {
   try {
     return new K8(configManager, testLogger)
+    // TODO: return a mock without running the init within constructor after we convert to Mocha, Jest ESModule mocks are broke.
   } catch (e) {
     if (!(e instanceof FullstackTestingError)) {
       throw e

--- a/test/test_util.js
+++ b/test/test_util.js
@@ -51,6 +51,8 @@ import {
 import { ROOT_CONTAINER } from '../src/core/constants.mjs'
 import crypto from 'crypto'
 import { AccountCommand } from '../src/commands/account.mjs'
+import { FullstackTestingError } from '../src/core/errors.mjs'
+import { execSync } from 'child_process'
 
 export const testLogger = logging.NewLogger('debug', true)
 export const TEST_CLUSTER = 'solo-e2e'
@@ -359,4 +361,27 @@ async function addKeyHashToMap (k8, nodeId, keyDir, uniqueNodeDestDir, keyHashMa
   const keyBytes = await fs.readFileSync(path.join(uniqueNodeDestDir, privateKeyFileName))
   const keyString = keyBytes.toString()
   keyHashMap.set(privateKeyFileName, crypto.createHash('sha256').update(keyString).digest('base64'))
+}
+
+/**
+ * @param {ConfigManager} configManager
+ * @returns {K8}
+ */
+export function getK8Instance (configManager) {
+  try {
+    return new K8(configManager, testLogger)
+  } catch (e) {
+    if (!(e instanceof FullstackTestingError)) {
+      throw e
+    }
+
+    // Set envs
+    process.env.SOLO_CLUSTER_NAME = 'solo-e2e'
+    process.env.SOLO_NAMESPACE = 'solo-e2e'
+    process.env.SOLO_CLUSTER_SETUP_NAMESPACE = 'fullstack-setup'
+
+    // Create cluster
+    execSync(`kind create cluster --name "${process.env.SOLO_CLUSTER_NAME}"`, { stdio: 'inherit' })
+    return new K8(configManager, testLogger)
+  }
 }

--- a/test/unit/commands/base.test.mjs
+++ b/test/unit/commands/base.test.mjs
@@ -24,8 +24,8 @@ import {
   constants
 } from '../../../src/core/index.mjs'
 import { BaseCommand } from '../../../src/commands/base.mjs'
-import { K8 } from '../../../src/core/k8.mjs'
 import * as flags from '../../../src/commands/flags.mjs'
+import { getK8Instance } from '../../test_util.js'
 
 const testLogger = logging.NewLogger('debug', true)
 
@@ -40,7 +40,8 @@ describe('BaseCommand', () => {
   const helmDepManager = new HelmDependencyManager(downloader, zippy, testLogger)
   const depManagerMap = new Map().set(constants.HELM, helmDepManager)
   const depManager = new DependencyManager(testLogger, depManagerMap)
-  const k8 = new K8(configManager, testLogger)
+
+  const k8 = getK8Instance(configManager)
 
   const baseCmd = new BaseCommand({
     logger: testLogger,

--- a/test/unit/commands/init.test.mjs
+++ b/test/unit/commands/init.test.mjs
@@ -28,7 +28,7 @@ import {
   KeyManager,
   logging, PackageDownloader, Zippy
 } from '../../../src/core/index.mjs'
-import { K8 } from '../../../src/core/k8.mjs'
+import { getK8Instance } from '../../test_util.js'
 
 const testLogger = logging.NewLogger('debug', true)
 describe('InitCommand', () => {
@@ -47,7 +47,8 @@ describe('InitCommand', () => {
   const configManager = new ConfigManager(testLogger)
 
   const keyManager = new KeyManager(testLogger)
-  const k8 = new K8(configManager, testLogger)
+
+  const k8 = getK8Instance(configManager)
 
   const initCmd = new InitCommand({
     logger: testLogger,

--- a/test/unit/core/platform_installer.test.mjs
+++ b/test/unit/core/platform_installer.test.mjs
@@ -16,7 +16,7 @@
  */
 import { describe, expect, it } from '@jest/globals'
 import * as core from '../../../src/core/index.mjs'
-import { ConfigManager, PlatformInstaller } from '../../../src/core/index.mjs'
+import { ConfigManager, K8, PlatformInstaller } from '../../../src/core/index.mjs'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'
@@ -25,10 +25,13 @@ import {
   MissingArgumentError
 } from '../../../src/core/errors.mjs'
 import { AccountManager } from '../../../src/core/account_manager.mjs'
+import { getK8Instance } from '../../test_util.js'
 describe('PackageInstaller', () => {
   const testLogger = core.logging.NewLogger('debug', true)
   const configManager = new ConfigManager(testLogger)
-  const k8 = new core.K8(configManager, testLogger)
+
+  const k8 = getK8Instance(configManager)
+
   const accountManager = new AccountManager(testLogger, k8)
   const installer = new PlatformInstaller(testLogger, k8, configManager, accountManager)
 

--- a/test/unit/core/platform_installer.test.mjs
+++ b/test/unit/core/platform_installer.test.mjs
@@ -16,7 +16,7 @@
  */
 import { describe, expect, it } from '@jest/globals'
 import * as core from '../../../src/core/index.mjs'
-import { ConfigManager, K8, PlatformInstaller } from '../../../src/core/index.mjs'
+import { ConfigManager, PlatformInstaller } from '../../../src/core/index.mjs'
 import * as fs from 'fs'
 import * as path from 'path'
 import * as os from 'os'


### PR DESCRIPTION
## Description

Start Kind cluster on demand if not having a kube config errors

### Related Issues

* Closes # [359](https://github.com/hashgraph/solo/issues/359)

### Note

This pull request might also render [issue #360](https://github.com/hashgraph/solo/issues/360) obsolete
