### PR TITLE
c: skip update readme if dependabot due to permission issues

### DIFF
--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -54,6 +54,7 @@ jobs:
 
   update-readme:
     name: "Update README.md"
+    if: ${{ github.actor != 'dependabot[bot]' && !cancelled() && always() }}
     uses: ./.github/workflows/zxc-update-readme.yaml
     with:
       commit-changes: false

--- a/.github/workflows/templates/template.flow-pull-request-checks.yaml
+++ b/.github/workflows/templates/template.flow-pull-request-checks.yaml
@@ -54,6 +54,7 @@ jobs:
 
   update-readme:
     name: "Update README.md"
+    if: ${{ github.actor != 'dependabot[bot]' && !cancelled() && always() }}
     uses: ./.github/workflows/zxc-update-readme.yaml
     with:
       commit-changes: false


### PR DESCRIPTION
## Description

This pull request changes the following:

* Skip update readme flow when ran by dependabot as it doesn't have access

### Related Issues

* Closes #687
