### PR TITLE
fix: undefined log output of namespace

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -96,7 +96,9 @@ export function main (argv: any) {
       logger.showUser(chalk.cyan('Version\t\t\t:'), chalk.yellow(configManager.getVersion()))
       logger.showUser(chalk.cyan('Kubernetes Context\t:'), chalk.yellow(context.name))
       logger.showUser(chalk.cyan('Kubernetes Cluster\t:'), chalk.yellow(configManager.getFlag(flags.clusterName)))
-      logger.showUser(chalk.cyan('Kubernetes Namespace\t:'), chalk.yellow(configManager.getFlag(flags.namespace)))
+      if (configManager.getFlag(flags.namespace) !== undefined) {
+        logger.showUser(chalk.cyan('Kubernetes Namespace\t:'), chalk.yellow(configManager.getFlag(flags.namespace)))
+      }
       logger.showUser(chalk.cyan('**********************************************************************************'))
 
       return argv


### PR DESCRIPTION
## Description

This pull request changes the following:

* Check namespace before logging 

### Related Issues

* Closes #721 


Output result
```
******************************* Solo *********************************************
Version			: 0.31.1
Kubernetes Context	: kind-solo-e2e
Kubernetes Cluster	: kind-solo-e2e
**********************************************************************************
✔ Setup home directory and cache
✔ Check dependencies

```