### PR TITLE
test: remove test that is causing timeouts

### DIFF
--- a/test/unit/core/dependency_managers/dependency_manager.test.ts
+++ b/test/unit/core/dependency_managers/dependency_manager.test.ts
@@ -35,9 +35,5 @@ describe('DependencyManager', () => {
     it('should fail during invalid dependency check', async () => {
       await expect(depManager.checkDependency('INVALID_PROGRAM')).to.be.rejectedWith("Dependency 'INVALID_PROGRAM' is not found")
     })
-
-    it('should succeed during helm dependency check', async () => {
-      await expect(depManager.checkDependency(constants.HELM)).to.eventually.equal(true)
-    }).timeout(60 * SECONDS)
   })
 })


### PR DESCRIPTION
## Description

Remove test since it was causing timeout's and is already covered in other tests

Test:
* DependencyManager
   * checkDependency
      * should succeed during helm dependency check

### Related Issues

* Closes # [#783](https://github.com/hashgraph/solo/issues/783)
