### PR TITLE
fix: check if setup chart installed or not before network deploy

### DIFF
--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -231,6 +231,15 @@ export class NetworkCommand extends BaseCommand {
         }
       },
       {
+        title: 'Check if cluster setup chart is installed',
+        task: async (ctx, task) => {
+          const isChartInstalled = await this.chartManager.isChartInstalled('', constants.SOLO_CLUSTER_SETUP_CHART)
+          if (!isChartInstalled) {
+            throw new SoloError(`Chart ${constants.SOLO_CLUSTER_SETUP_CHART} is not installed. Run 'solo cluster setup'`)
+          }
+        }
+      },
+      {
         title: 'Prepare staging directory',
         task: (_, parentTask) => {
           return parentTask.newListr([
@@ -547,7 +556,7 @@ export class NetworkCommand extends BaseCommand {
         return yargs
           .command({
             command: 'deploy',
-            desc: 'Deploy solo network',
+            desc: "Deploy solo network.  Requires the chart `solo-cluster-setup` to have been installed in the cluster.  If it hasn't the following command can be ran: `solo cluster setup`",
             builder: (y: any) => flags.setCommandFlags(y, ...NetworkCommand.DEPLOY_FLAGS_LIST),
             handler: (argv: any) => {
               networkCmd.logger.debug('==== Running \'network deploy\' ===')

--- a/src/core/chart_manager.ts
+++ b/src/core/chart_manager.ts
@@ -58,6 +58,9 @@ export class ChartManager {
   /** List available clusters */
   async getInstalledCharts (namespaceName: string) {
     try {
+      if (!namespaceName) {
+        return await this.helm.list('--all-namespaces --no-headers | awk \'{print $1 " [" $9"]"}\'')
+      }
       return await this.helm.list(`-n ${namespaceName}`, '--no-headers | awk \'{print $1 " [" $9"]"}\'')
     } catch (e: Error | any) {
       this.logger.showUserError(e)


### PR DESCRIPTION
## Description

This pull request changes the following:

* added logic to check if cluster setup chart installed or not before network deploy

### Related Issues

* Closes #782


Test output

```
✔ Initialize
  ✔ Acquire lease - namespace not created, skipping lease acquire
✔ Generate gossip keys [0.4s]
  ✔ Backup old files
  ✔ Gossip key for node: node1 [0.4s]
✔ Generate gRPC TLS Keys [0.8s]
  ✔ Backup old files
  ✔ TLS key for node: node1 [0.7s]
✔ Finalize
      ✔ generate key files (1329ms)
✔ Initialize
  ✔ Acquire lease - lease acquired successfully, attempt: 1/10
✖ Chart solo-cluster-setup is not installed. Run 'solo cluster setup'
◼ Prepare staging directory
◼ Copy node keys to secrets
◼ Install chart 'solo-deployment'
◼ Check node pods are running
◼ Check proxy pods are running
◼ Check auxiliary pods are ready

```