### PR TITLE
ci: use nodejs cached version to avoid downloading issues

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: 20.18.0
+          node-version: 20.17.0
 
       - name: Install Semantic Release
         run: |
@@ -141,7 +141,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: 20.18.0
+          node-version: 20.17.0
 
       - name: Build Production Distribution
         run: |

--- a/.github/workflows/flow-hugo-publish.yaml
+++ b/.github/workflows/flow-hugo-publish.yaml
@@ -79,7 +79,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: 20.18.0
+          node-version: 20.17.0
 
       - name: Setup Pages
         id: pages

--- a/.github/workflows/templates/template.zxc-code-analysis.yaml
+++ b/.github/workflows/templates/template.zxc-code-analysis.yaml
@@ -49,7 +49,7 @@ on:
         description: "NodeJS Version:"
         type: string
         required: false
-        default: "20.18.0"
+        default: "20.17.0"
       custom-job-label:
         description: "Custom Job Label:"
         type: string

--- a/.github/workflows/zxc-code-analysis.yaml
+++ b/.github/workflows/zxc-code-analysis.yaml
@@ -49,7 +49,7 @@ on:
         description: "NodeJS Version:"
         type: string
         required: false
-        default: "20.18.0"
+        default: "20.17.0"
       custom-job-label:
         description: "Custom Job Label:"
         type: string

--- a/.github/workflows/zxc-code-style.yaml
+++ b/.github/workflows/zxc-code-style.yaml
@@ -27,7 +27,7 @@ on:
         description: "NodeJS Version:"
         type: string
         required: false
-        default: "20.18.0"
+        default: "20.17.0"
       custom-job-label:
         description: "Custom Job Label:"
         type: string

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -27,7 +27,7 @@ on:
         description: "NodeJS Version:"
         type: string
         required: false
-        default: "20.18.0"
+        default: "20.17.0"
       custom-job-label:
         description: "Custom Job Label:"
         type: string

--- a/.github/workflows/zxc-unit-test.yaml
+++ b/.github/workflows/zxc-unit-test.yaml
@@ -27,7 +27,7 @@ on:
         description: "NodeJS Version:"
         type: string
         required: false
-        default: "20.18.0"
+        default: "20.17.0"
       custom-job-label:
         description: "Custom Job Label:"
         type: string

--- a/.github/workflows/zxc-update-readme.yaml
+++ b/.github/workflows/zxc-update-readme.yaml
@@ -69,7 +69,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@39370e3970a6d050c480ffad4ff0ed4d3fdee5af # v4.1.0
         with:
-          node-version: 20.18.0
+          node-version: 20.17.0
 
       - name: Install wget
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -480,3 +480,4 @@ deleteme.yaml
 /docs/themes/
 /docs/.hugo_build.lock
 /docs/public/
+/contextDir/

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hashgraph/solo",
-  "version": "0.31.1",
+  "version": "0.99.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hashgraph/solo",
-      "version": "0.31.1",
+      "version": "0.99.0",
       "license": "Apache2.0",
       "os": [
         "darwin",

--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -23,8 +23,7 @@ import * as prompts from './prompts.ts'
 import { constants, type AccountManager } from '../core/index.ts'
 import { type AccountId, AccountInfo, HbarUnit, PrivateKey } from '@hashgraph/sdk'
 import { FREEZE_ADMIN_ACCOUNT } from '../core/constants.ts'
-import type { Opts } from '../types/index.ts'
-
+import { type Opts } from '../types/index.js'
 export class AccountCommand extends BaseCommand {
   private readonly accountManager: AccountManager
   private accountInfo: {
@@ -68,7 +67,7 @@ export class AccountCommand extends BaseCommand {
   }
 
   async createNewAccount (ctx: { config: { ecdsaPrivateKey?: string; ed25519PrivateKey?: string; namespace: string;
-    setAlias: boolean; amount: number}; privateKey: PrivateKey; }) {
+      setAlias: boolean; amount: number}; privateKey: PrivateKey; }) {
     if (ctx.config.ecdsaPrivateKey) {
       ctx.privateKey = PrivateKey.fromStringECDSA(ctx.config.ecdsaPrivateKey)
     } else if (ctx.config.ed25519PrivateKey) {
@@ -78,7 +77,7 @@ export class AccountCommand extends BaseCommand {
     }
 
     return await this.accountManager.createNewAccount(ctx.config.namespace,
-      ctx.privateKey, ctx.config.amount, ctx.config.ecdsaPrivateKey ? ctx.config.setAlias : false)
+        ctx.privateKey, ctx.config.amount, ctx.config.ecdsaPrivateKey ? ctx.config.setAlias : false)
   }
 
   getAccountInfo (ctx: { config: { accountId: string } }) {
@@ -192,8 +191,8 @@ export class AccountCommand extends BaseCommand {
                     title: `Updating accounts [${rangeStr}]`,
                     task: async (ctx: Context) => {
                       ctx.resultTracker = await self.accountManager.updateSpecialAccountsKeys(
-                        ctx.config.namespace, currentSet,
-                        ctx.updateSecrets, ctx.resultTracker)
+                          ctx.config.namespace, currentSet,
+                          ctx.updateSecrets, ctx.resultTracker)
                     }
                   })
                 }
@@ -221,14 +220,6 @@ export class AccountCommand extends BaseCommand {
                 }
               }
             },
-            {
-              title: 'Trigger the handler by writing some transactions',
-              task: async (ctx) => {
-                // create two accounts to force the handler to trigger
-                await self.create({})
-                await self.create({})
-              }
-            },
           ], {
             concurrent: false,
             rendererOptions: {
@@ -248,6 +239,9 @@ export class AccountCommand extends BaseCommand {
       throw new SoloError(`Error in creating account: ${e.message}`, e)
     } finally {
       await this.closeConnections()
+      // create two accounts to force the handler to trigger
+      await self.create({})
+      await self.create({})
     }
 
     return true

--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -220,7 +220,15 @@ export class AccountCommand extends BaseCommand {
                   throw new SoloError(`Account keys updates failed for ${ctx.resultTracker.rejectedCount} accounts.`)
                 }
               }
-            }
+            },
+            {
+              title: 'Trigger the handler by writing some transactions',
+              task: async (ctx) => {
+                // create two accounts to force the handler to trigger
+                await self.create({})
+                await self.create({})
+              }
+            },
           ], {
             concurrent: false,
             rendererOptions: {

--- a/src/core/k8.ts
+++ b/src/core/k8.ts
@@ -73,14 +73,14 @@ export class K8 {
     this.kubeConfig = new k8s.KubeConfig()
     this.kubeConfig.loadFromDefault()
 
-    if (!this.kubeConfig.getCurrentCluster()) {
-      throw new SoloError('No active kubernetes cluster found. ' +
-        'Please create a cluster and set current context.')
-    }
-
     if (!this.kubeConfig.getCurrentContext()) {
       throw new SoloError('No active kubernetes context found. ' +
         'Please set current kubernetes context.')
+    }
+
+    if (!this.kubeConfig.getCurrentCluster()) {
+      throw new SoloError('No active kubernetes cluster found. ' +
+          'Please create a cluster and set current context.')
     }
 
     this.kubeClient = this.kubeConfig.makeApiClient(k8s.CoreV1Api)

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,7 +22,7 @@ import * as commands from './commands/index.ts'
 import { HelmDependencyManager, DependencyManager } from './core/dependency_managers/index.ts'
 import {
   ChartManager, ConfigManager, PackageDownloader, PlatformInstaller, Helm, logging,
-  KeyManager, Zippy, constants, ProfileManager, AccountManager, LeaseManager, CertificateManager
+  KeyManager, Zippy, constants, ProfileManager, AccountManager, LeaseManager, CertificateManager, helpers
 } from './core/index.ts'
 import 'dotenv/config'
 import { K8 } from './core/k8.ts'
@@ -33,6 +33,12 @@ import { type Opts } from './types/index.ts'
 export function main (argv: any) {
   const logger = logging.NewLogger('debug')
   constants.LISTR_DEFAULT_RENDERER_OPTION.logger = new ListrLogger({ processOutput: new CustomProcessOutput(logger) })
+  if (argv.length >= 3 && ['-version', '--version', '-v', '--v'].includes(argv[2])) {
+    logger.showUser(chalk.cyan('\n******************************* Solo *********************************************'))
+    logger.showUser(chalk.cyan('Version\t\t\t:'), chalk.yellow(helpers.packageVersion()))
+    logger.showUser(chalk.cyan('**********************************************************************************'))
+    process.exit(0)
+  }
 
   try {
     // prepare dependency manger registry


### PR DESCRIPTION
## Description

This pull request changes the following:

* use nodejs cached version to avoid downloading issues
* add a couple of account creates after account init to trigger the handler
* update version check to work in case no cluster is found

### Related Issues

* Closes #
