### PR TITLE
fix: flag check of node logs command and incorrect download source

### DIFF
--- a/src/commands/node/configs.ts
+++ b/src/commands/node/configs.ts
@@ -235,7 +235,7 @@ export const addConfigBuilder = async function (argv, ctx, task) {
 }
 
 export const logsConfigBuilder = function (argv, ctx, task) {
-    /** @type {{namespace: string, nodeAliases: NodeAliases}} */
+    /** @type {{namespace: string, nodeAliases: NodeAliases, nodeAliasesUnparsed: string}} */
     const config = {
         namespace: this.configManager.getFlag(flags.namespace),
         nodeAliases: helpers.parseNodeAliases(this.configManager.getFlag(flags.nodeAliasesUnparsed)),

--- a/src/commands/node/configs.ts
+++ b/src/commands/node/configs.ts
@@ -238,7 +238,8 @@ export const logsConfigBuilder = function (argv, ctx, task) {
     /** @type {{namespace: string, nodeAliases: NodeAliases}} */
     const config = {
         namespace: this.configManager.getFlag(flags.namespace),
-        nodeAliases: helpers.parseNodeAliases(this.configManager.getFlag(flags.nodeAliasesUnparsed))
+        nodeAliases: helpers.parseNodeAliases(this.configManager.getFlag(flags.nodeAliasesUnparsed)),
+        nodeAliasesUnparsed: this.configManager.getFlag(flags.nodeAliasesUnparsed)
     }
     ctx.config = config
     return config

--- a/src/commands/node/flags.ts
+++ b/src/commands/node/flags.ts
@@ -179,7 +179,7 @@ export const ADD_EXECUTE_FLAGS = {
 }
 
 export const LOGS_FLAGS = {
-    requiredFlags: [flags.nodeAliasesUnparsed],
+    requiredFlags: [flags.namespace, flags.nodeAliasesUnparsed],
     requiredFlagsWithDisabledPrompt: [],
     optionalFlags: []
 }

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -92,6 +92,8 @@ export const POD_CONDITION_STATUS_TRUE = 'True'
 export const EXPLORER_VALUES_FILE = path.join('resources', 'hedera-explorer-values.yaml')
 export const MIRROR_NODE_VALUES_FILE = path.join('resources', 'mirror-node-values.yaml')
 
+export const NODE_LOG_FAILURE_MSG = 'failed to download logs from pod'
+
 /**
  * Listr related
  * @return a object that defines the default color options

--- a/src/core/helpers.ts
+++ b/src/core/helpers.ts
@@ -210,7 +210,7 @@ async function getNodeLog (pod: V1Pod, namespace: string, timeString: string, k8
   } catch (e: Error | any) {
     // not throw error here, so we can continue to finish downloading logs from other pods
     // and also delete namespace in the end
-    k8.logger.error(`failed to download logs from pod ${podName}`, e)
+    k8.logger.error(`${constants.NODE_LOG_FAILURE_MSG} ${podName}`, e)
   }
   k8.logger.debug(`getNodeLogs(${pod.metadata.name}): ...end`)
 }

--- a/src/core/helpers.ts
+++ b/src/core/helpers.ts
@@ -206,7 +206,7 @@ async function getNodeLog (pod: V1Pod, namespace: string, timeString: string, k8
     await k8.copyTo(podName, ROOT_CONTAINER, sourcePath, `${HEDERA_HAPI_PATH}`)
     await k8.execContainer(podName, ROOT_CONTAINER, `chmod 0755 ${HEDERA_HAPI_PATH}/${scriptName}`)
     await k8.execContainer(podName, ROOT_CONTAINER, `${HEDERA_HAPI_PATH}/${scriptName}`)
-    await k8.copyFrom(podName, ROOT_CONTAINER, `${HEDERA_HAPI_PATH}/${podName}.zip`, targetDir)
+    await k8.copyFrom(podName, ROOT_CONTAINER, `${HEDERA_HAPI_PATH}/data/${podName}.zip`, targetDir)
   } catch (e: Error | any) {
     // not throw error here, so we can continue to finish downloading logs from other pods
     // and also delete namespace in the end

--- a/test/test_util.ts
+++ b/test/test_util.ts
@@ -52,7 +52,7 @@ import {
   AccountCreateTransaction, Hbar, HbarUnit,
   PrivateKey
 } from '@hashgraph/sdk'
-import { MINUTES, ROOT_CONTAINER, SECONDS, SOLO_LOGS_DIR } from '../src/core/constants.ts'
+import { MINUTES, NODE_LOG_FAILURE_MSG, ROOT_CONTAINER, SECONDS, SOLO_LOGS_DIR } from '../src/core/constants.ts'
 import crypto from 'crypto'
 import { AccountCommand } from '../src/commands/account.ts'
 import { SoloError } from '../src/core/errors.ts'
@@ -300,7 +300,7 @@ export function e2eTestSuite (
             const soloLogPath = path.join(SOLO_LOGS_DIR, 'solo.log')
             const soloLog = fs.readFileSync(soloLogPath, 'utf8')
 
-            expect(soloLog).to.not.contain('failed to download logs')
+            expect(soloLog).to.not.contain(NODE_LOG_FAILURE_MSG)
           } catch (e) {
             nodeCmd.logger.showUserError(e)
             expect.fail()

--- a/test/test_util.ts
+++ b/test/test_util.ts
@@ -52,7 +52,7 @@ import {
   AccountCreateTransaction, Hbar, HbarUnit,
   PrivateKey
 } from '@hashgraph/sdk'
-import { MINUTES, ROOT_CONTAINER, SECONDS } from '../src/core/constants.ts'
+import { MINUTES, ROOT_CONTAINER, SECONDS, SOLO_LOGS_DIR } from '../src/core/constants.ts'
 import crypto from 'crypto'
 import { AccountCommand } from '../src/commands/account.ts'
 import { SoloError } from '../src/core/errors.ts'
@@ -287,6 +287,20 @@ export function e2eTestSuite (
         it('should succeed with node start command', async () => {
           try {
             await expect(nodeCmd.handlers.start(argv)).to.eventually.be.ok
+          } catch (e) {
+            nodeCmd.logger.showUserError(e)
+            expect.fail()
+          }
+        }).timeout(30 * MINUTES)
+
+        it('node log command should work', async () => {
+          try {
+            await expect(nodeCmd.handlers.logs(argv)).to.eventually.be.ok
+
+            const soloLogPath = path.join(SOLO_LOGS_DIR, 'solo.log')
+            const soloLog = fs.readFileSync(soloLogPath, 'utf8')
+
+            expect(soloLog).to.not.contain('failed to download logs')
           } catch (e) {
             nodeCmd.logger.showUserError(e)
             expect.fail()


### PR DESCRIPTION
## Description

This pull request changes the following:

* Fixed unparsed node alias node assigned error
* Fixed the incorrect log download source directory
* Added a unit check to check if download is working

### Related Issues

* Closes #847 
