### PR TITLE
fix: downgrade hashgraph/sdk to fix e2e update tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
       ],
       "dependencies": {
         "@eslint/eslintrc": "^3.2.0",
-        "@hashgraph/sdk": "^2.54.0-beta.1",
+        "@hashgraph/sdk": "^2.52.0",
         "@kubernetes/client-node": "^0.22.2",
         "@listr2/prompt-adapter-enquirer": "^2.0.12",
         "@peculiar/x509": "^1.12.3",
@@ -840,9 +840,9 @@
       }
     },
     "node_modules/@hashgraph/sdk": {
-      "version": "2.54.0-beta.1",
-      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.54.0-beta.1.tgz",
-      "integrity": "sha512-rXbwp24fr04LJcOtISabwtKtb0qiRHGa3ltY1KALJ0fEYlUogSEf8DmCeOzNWiZEyy9boCequlRajAkJ+1OF3A==",
+      "version": "2.52.0",
+      "resolved": "https://registry.npmjs.org/@hashgraph/sdk/-/sdk-2.52.0.tgz",
+      "integrity": "sha512-Gv/U9bM744lPGwctKFl27iaQogEq3jWcTRKoGkBC9HYJwsiKnEGxjwGaI4sM/4+Y24tyhDTngLa4nV/QxbjbaA==",
       "dependencies": {
         "@ethersproject/abi": "^5.7.0",
         "@ethersproject/bignumber": "^5.7.0",
@@ -9685,9 +9685,9 @@
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
     "node_modules/pump": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.2.tgz",
+      "integrity": "sha512-tUPXtzlGM8FE3P0ZL6DVs/3P58k9nk8/jZeQCurTJylQA8qFYzHFfhBJkuqyE0FifOsQ0uKWekiZ5g8wtr28cw==",
       "dependencies": {
         "end-of-stream": "^1.1.0",
         "once": "^1.3.1"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "license": "Apache2.0",
   "dependencies": {
     "@eslint/eslintrc": "^3.2.0",
-    "@hashgraph/sdk": "^2.54.0-beta.1",
+    "@hashgraph/sdk": "^2.52.0",
     "@kubernetes/client-node": "^0.22.2",
     "@listr2/prompt-adapter-enquirer": "^2.0.12",
     "@peculiar/x509": "^1.12.3",


### PR DESCRIPTION
## Description

This pull request changes the following:

* downgrade hashgraph/sdk to fix e2e update tests

### Related Issues

* Closes #
