### PR TITLE
fix: Error in `node update` separate commands when new admin key is not supplied

### DIFF
--- a/src/commands/node/handlers.ts
+++ b/src/commands/node/handlers.ts
@@ -196,13 +196,13 @@ export class NodeCommandHandlers {
     return [
       this.tasks.sendNodeUpdateTransaction(),
       this.tasks.sendPrepareUpgradeTransaction(),
-      this.tasks.downloadNodeGeneratedFiles(),
       this.tasks.sendFreezeUpgradeTransaction(),
     ]
   }
 
   updateExecuteTasks (argv) {
     return [
+      this.tasks.downloadNodeGeneratedFiles(),
       this.tasks.prepareStagingDirectory('allNodeAliases'),
       this.tasks.copyNodeKeysToSecrets(),
       this.tasks.checkAllNodesAreFrozen('existingNodeAliases'),
@@ -319,7 +319,6 @@ export class NodeCommandHandlers {
     const action = helpers.commandActionBuilder([
       this.tasks.initialize(argv, updateConfigBuilder.bind(this), lease),
       this.tasks.loadContextData(argv, NodeCommandHandlers.UPDATE_CONTEXT_FILE, helpers.updateLoadContextParser),
-      this.tasks.loadAdminKey(),
         ...this.updateSubmitTransactionsTasks(argv)
     ], {
         concurrent: false,

--- a/src/core/helpers.ts
+++ b/src/core/helpers.ts
@@ -384,6 +384,7 @@ export function updateSaveContextParser (ctx: { config: NodeUpdateConfigClass, u
   const exportedCtx: any = {}
 
   const config = /** @type {NodeUpdateConfigClass} **/ ctx.config
+  exportedCtx.adminKey = config.adminKey.toString()
   exportedCtx.newAdminKey = config.newAdminKey.toString()
   exportedCtx.freezeAdminPrivateKey = config.freezeAdminPrivateKey.toString()
   exportedCtx.treasuryKey = config.treasuryKey.toString()
@@ -409,9 +410,14 @@ export function updateSaveContextParser (ctx: { config: NodeUpdateConfigClass, u
  */
 export function updateLoadContextParser (ctx: { config: NodeUpdateConfigClass, upgradeZipHash: any }, ctxData: any) {
   const config = ctx.config
-  config.newAdminKey = PrivateKey.fromStringED25519(ctxData.newAdminKey)
+
+  if (ctxData.newAdminKey && ctxData.newAdminKey.length) {
+    config.newAdminKey = PrivateKey.fromStringED25519(ctxData.newAdminKey)
+  }
+
   config.freezeAdminPrivateKey = PrivateKey.fromStringED25519(ctxData.freezeAdminPrivateKey)
   config.treasuryKey = PrivateKey.fromStringED25519(ctxData.treasuryKey)
+  config.adminKey = PrivateKey.fromStringED25519(ctxData.adminKey)
   config.existingNodeAliases = ctxData.existingNodeAliases
   config.nodeAlias = ctxData.nodeAlias
   config.newAccountNumber = ctxData.newAccountNumber


### PR DESCRIPTION
## Description

This pull request changes the following:

* TBD

### Related Issues

* Closes #
