### PR TITLE
fix: resolve node delete test failures

### DIFF
--- a/resources/profiles/custom-spec.yaml
+++ b/resources/profiles/custom-spec.yaml
@@ -5,9 +5,9 @@ local: # 3 nodes, ~850 TPS (Docker Desktop 8 cores, 16 GB RAM)
         - name: JAVA_HEAP_MIN
           value: 1g
         - name: JAVA_HEAP_MAX
-          value: 6g
+          value: 4g
         - name: JAVA_OPTS
-          value: "-XX:+UnlockExperimentalVMOptions -XX:+UseZGC -XX:ZAllocationSpikeTolerance=2 -XX:ConcGCThreads=2 -XX:ZMarkStackSpaceLimit=1g -XX:MaxDirectMemorySize=2g -XX:MetaspaceSize=100M -Xlog:gc*:gc.log --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED -Dio.netty.tryReflectionSetAccessible=true"
+          value: "-XX:+UnlockExperimentalVMOptions -XX:+UseZGC -XX:ZAllocationSpikeTolerance=2 -XX:ConcGCThreads=2 -XX:ZMarkStackSpaceLimit=1g -XX:MaxDirectMemorySize=1500m -XX:MetaspaceSize=100M -Xlog:gc*:gc.log --add-opens java.base/jdk.internal.misc=ALL-UNNAMED --add-opens java.base/java.nio=ALL-UNNAMED -Dio.netty.tryReflectionSetAccessible=true"
   haproxy: # use chart defaults
   envoyProxy: # use chart defaults
   rpcRelay:

--- a/src/core/account_manager.ts
+++ b/src/core/account_manager.ts
@@ -219,17 +219,19 @@ export class AccountManager {
     try {
       let localPort = constants.LOCAL_NODE_START_PORT
 
-      if (useSecondNodeOnly && networkNodeServicesMap.size > 1) {
-        const networkNodeService = networkNodeServicesMap.get(networkNodeServicesMap.keys()[1]) as NetworkNodeServices
+      let iteration = 0
+      for (const networkNodeService of networkNodeServicesMap.values()) {
+        if (useSecondNodeOnly && networkNodeServicesMap.size > 1 && (iteration < 1 || iteration > 1)) {
+          continue
+        }
+
         const addlNode = await this.configureNodeAccess(networkNodeService, localPort, networkNodeServicesMap.size)
         nodes = { ...nodes, ...addlNode }
-      } else {
-        for (const networkNodeService of networkNodeServicesMap.values()) {
-          const addlNode = await this.configureNodeAccess(networkNodeService, localPort, networkNodeServicesMap.size)
-          nodes = { ...nodes, ...addlNode }
-          localPort++
-        }
+
+        localPort++
+        iteration++
       }
+
 
       this.logger.debug(`creating client from network configuration: ${JSON.stringify(nodes)}`)
       // scheduleNetworkUpdate is set to false, because the ports 50212/50211 are hardcoded in JS SDK that will not work when running locally or in a pipeline

--- a/src/core/account_manager.ts
+++ b/src/core/account_manager.ts
@@ -214,18 +214,20 @@ export class AccountManager {
    * @returns a node client that can be used to call transactions
    */
   async _getNodeClient (namespace: string, networkNodeServicesMap: Map<string, NetworkNodeServices>, operatorId: string,
-    operatorKey: string, useFirstNodeOnly = true) {
+    operatorKey: string, useSecondNodeOnly = true) {
     let nodes = {}
     try {
       let localPort = constants.LOCAL_NODE_START_PORT
 
-      for (const networkNodeService of networkNodeServicesMap.values()) {
+      if (useSecondNodeOnly && networkNodeServicesMap.size > 1) {
+        const networkNodeService = networkNodeServicesMap.get(networkNodeServicesMap.keys()[1]) as NetworkNodeServices
         const addlNode = await this.configureNodeAccess(networkNodeService, localPort, networkNodeServicesMap.size)
         nodes = { ...nodes, ...addlNode }
-        localPort++
-
-        if (useFirstNodeOnly) {
-          break
+      } else {
+        for (const networkNodeService of networkNodeServicesMap.values()) {
+          const addlNode = await this.configureNodeAccess(networkNodeService, localPort, networkNodeServicesMap.size)
+          nodes = { ...nodes, ...addlNode }
+          localPort++
         }
       }
 


### PR DESCRIPTION
## Description

This pull request changes the following:

* Changes the `_getNodeClient` method to use the second node only by default.

### Related Issues

* Closes #864 
