### PR TITLE
fix: node id should start from `1`

### DIFF
--- a/examples/custom-network-config/Taskfile.yml
+++ b/examples/custom-network-config/Taskfile.yml
@@ -1,6 +1,6 @@
 version: 3
 includes:
-  helper: ../HelperTasks.yml
+  helper: ../../HelperTasks.yml
 dotenv:
   - .env
 
@@ -20,7 +20,7 @@ vars:
   ip_list_template_file: "{{.ROOT_DIR}}/list-external-ips.gotemplate"
   nodes:
     ref: until (env "SOLO_NETWORK_SIZE" | default .SOLO_NETWORK_SIZE | int)
-  node_list_internal: "{{range $idx, $n := .nodes }}node{{$n}},{{end}}"
+  node_list_internal: "{{range $idx, $n := .nodes }}node{{add $n 1}},{{end}}"
   node_identifiers: "{{ .node_list_internal | trimSuffix \",\" }}"
   solo_user_dir: "{{ env \"HOME\" }}/.solo"
   solo_cache_dir: "{{ .solo_user_dir }}/cache"

--- a/examples/custom-network-config/Taskfile.yml
+++ b/examples/custom-network-config/Taskfile.yml
@@ -41,7 +41,7 @@ tasks:
     cmds:
       - task: "helper:solo:init"
       - task: "helper:solo:keys"
-      - task: "helper:solo:network:deploy"
+      - task: "solo:network:deploy"
 
   start:
     cmds:
@@ -53,7 +53,7 @@ tasks:
 
   show:ips:
     cmds:
-      - task: "helper:solo:node:addresses"
+      - task: "solo:node:addresses"
 
   destroy:
     cmds:
@@ -73,3 +73,18 @@ tasks:
   clean:logs:
     cmds:
       - task: "helper:solo:logs:remove"
+
+  # Do not use network:deploy from HelperTasks.yml since custom network need extra settings and values files
+  solo:network:deploy:
+    internal: true
+    cmds:
+      - npm run build
+      - solo network deploy --namespace "${SOLO_NAMESPACE}" --node-aliases-unparsed {{.node_identifiers}} --release-tag "${CONSENSUS_NODE_VERSION}" --solo-chart-version "${SOLO_CHART_VERSION}" --values-file {{ .solo_values_file }} --settings-txt {{ .solo_settings_file }}
+      - solo node setup --namespace "${SOLO_NAMESPACE}" --node-aliases-unparsed {{.node_identifiers}} --release-tag "${CONSENSUS_NODE_VERSION}"
+
+  # Do not use node:addresses from HelperTasks.yml since we need to output the list of external IPs
+  solo:node:addresses:
+    internal: true
+    cmds:
+      - kubectl get svc -n "${SOLO_NAMESPACE}" -l "solo.hedera.com/type=network-node-svc" --output=go-template-file={{ .ip_list_template_file }}
+

--- a/examples/custom-network-config/Taskfile.yml
+++ b/examples/custom-network-config/Taskfile.yml
@@ -82,7 +82,7 @@ tasks:
       - solo network deploy --namespace "${SOLO_NAMESPACE}" --node-aliases-unparsed {{.node_identifiers}} --release-tag "${CONSENSUS_NODE_VERSION}" --solo-chart-version "${SOLO_CHART_VERSION}" --values-file {{ .solo_values_file }} --settings-txt {{ .solo_settings_file }}
       - solo node setup --namespace "${SOLO_NAMESPACE}" --node-aliases-unparsed {{.node_identifiers}} --release-tag "${CONSENSUS_NODE_VERSION}"
 
-  # Do not use node:addresses from HelperTasks.yml since we need to output the list of external IPs
+  # Do not use node:addresses from HelperTasks.yml since we need to use template file to get output the list of IPs
   solo:node:addresses:
     internal: true
     cmds:

--- a/examples/custom-network-config/init-containers-values.yaml
+++ b/examples/custom-network-config/init-containers-values.yaml
@@ -8,7 +8,7 @@ hedera:
         - name: hgcapp-data-saved
           mountPath: /data-saved
   nodes:
-    - name: node0
+    - name: node1
       accountId: 0.0.3
       root:
         resources:
@@ -18,7 +18,7 @@ hedera:
           limits:
             cpu: 24
             memory: 256Gi
-    - name: node1
+    - name: node2
       accountId: 0.0.4
       root:
         resources:
@@ -28,7 +28,7 @@ hedera:
           limits:
             cpu: 24
             memory: 256Gi
-    - name: node2
+    - name: node3
       accountId: 0.0.5
       root:
         resources:
@@ -38,7 +38,7 @@ hedera:
           limits:
             cpu: 24
             memory: 256Gi
-    - name: node3
+    - name: node4
       accountId: 0.0.6
       root:
         resources:
@@ -48,7 +48,7 @@ hedera:
           limits:
             cpu: 24
             memory: 256Gi
-    - name: node4
+    - name: node5
       accountId: 0.0.7
       root:
         resources:
@@ -58,7 +58,7 @@ hedera:
           limits:
             cpu: 24000m
             memory: 64000Mi
-    - name: node5
+    - name: node6
       accountId: 0.0.8
       root:
         resources:
@@ -68,7 +68,7 @@ hedera:
           limits:
             cpu: 24
             memory: 256Gi
-    - name: node6
+    - name: node7
       accountId: 0.0.9
       root:
         resources:


### PR DESCRIPTION
## Description

This pull request changes the following:

* Fixed the example task file incorrect path to helper file and node id still starts from 0

### Related Issues

* Closes #878


To test the custom Taskfile, run the following command

```bash
task helper:cluster:create
task helper:cluster:setup
cd examples/custom-network-config
task default 
task show:ips
task clean
```
