### PR TITLE
ci: Change peaceiris/actions-hugo action to a step-security maintained version

### DIFF
--- a/.github/workflows/flow-hugo-publish.yaml
+++ b/.github/workflows/flow-hugo-publish.yaml
@@ -67,7 +67,7 @@ jobs:
           egress-policy: audit
 
       - name: Setup Hugo
-        uses: peaceiris/actions-hugo@75d2e84710de30f6ff7268e08f310b60ef14033f # v3.0.0
+        uses: step-security/actions-hugo@8b2a237efc0653848b74551acf66bb9ddd5fa02e # v3.0.0
         with:
           hugo-version: '0.124.1'
 


### PR DESCRIPTION

## Description

This pull request changes the following:

Change peaceiris/actions-hugo action to a step-security maintained version

### Related Issues

* Closes #887 
