### PR TITLE
chore: add eslint config @typescript-eslint/consistent-type-imports

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -147,6 +147,13 @@ export default [
       '@typescript-eslint/explicit-module-boundary-types': 'off',
       '@typescript-eslint/ban-types': 'off',
       '@typescript-eslint/camelcase': 'off',
+      '@typescript-eslint/consistent-type-imports': [
+        // optional: assists in reducing circular dependencies
+        'error',
+        {
+          fixStyle: 'inline-type-imports',
+        },
+      ],
       '@typescript-eslint/no-explicit-any': 'warn', // TODO remove (771 errors)
       '@typescript-eslint/no-this-alias': [
         'error',

--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -24,7 +24,7 @@ import {type AccountId, AccountInfo, HbarUnit, PrivateKey} from '@hashgraph/sdk'
 import {FREEZE_ADMIN_ACCOUNT} from '../core/constants.js';
 import {type Opts} from '../types/index.js';
 import {ListrLease} from '../core/lease/listr_lease.js';
-import {CommandBuilder} from '../types/aliases.js';
+import {type CommandBuilder} from '../types/aliases.js';
 
 export class AccountCommand extends BaseCommand {
   private readonly accountManager: AccountManager;

--- a/src/commands/cluster.ts
+++ b/src/commands/cluster.ts
@@ -23,7 +23,7 @@ import chalk from 'chalk';
 import {constants} from '../core/index.js';
 import path from 'path';
 import {ListrLease} from '../core/lease/listr_lease.js';
-import {CommandBuilder} from '../types/aliases.js';
+import {type CommandBuilder} from '../types/aliases.js';
 
 /**
  * Define the core functionalities of 'cluster' command

--- a/src/commands/deployment.ts
+++ b/src/commands/deployment.ts
@@ -24,7 +24,7 @@ import {RemoteConfigTasks} from '../core/config/remote/remote_config_tasks.js';
 import {ListrLease} from '../core/lease/listr_lease.js';
 import type {Namespace} from '../core/config/remote/types.js';
 import type {CommandFlag, ContextClusterStructure} from '../types/index.js';
-import {CommandBuilder} from '../types/aliases.js';
+import {type CommandBuilder} from '../types/aliases.js';
 
 export class DeploymentCommand extends BaseCommand {
   private static get DEPLOY_FLAGS_LIST(): CommandFlag[] {

--- a/src/commands/flags.ts
+++ b/src/commands/flags.ts
@@ -19,7 +19,7 @@ import * as core from '../core/index.js';
 import * as version from '../../version.js';
 import path from 'path';
 import type {CommandFlag} from '../types/index.js';
-import {ListrTaskWrapper} from 'listr2';
+import {type ListrTaskWrapper} from 'listr2';
 import fs from 'fs';
 import {IllegalArgumentError, SoloError} from '../core/errors.js';
 import {ListrEnquirerPromptAdapter} from '@listr2/prompt-adapter-enquirer';

--- a/src/commands/mirror_node.ts
+++ b/src/commands/mirror_node.ts
@@ -22,7 +22,7 @@ import {BaseCommand} from './base.js';
 import {flags} from './index.js';
 import {getFileContents, getEnvValue} from '../core/helpers.js';
 import {RemoteConfigTasks} from '../core/config/remote/remote_config_tasks.js';
-import {CommandBuilder, type PodName} from '../types/aliases.js';
+import {type CommandBuilder, type PodName} from '../types/aliases.js';
 import type {Opts} from '../types/index.js';
 import {ListrLease} from '../core/lease/listr_lease.js';
 

--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -27,7 +27,7 @@ import {addDebugOptions, validatePath} from '../core/helpers.js';
 import fs from 'fs';
 import {RemoteConfigTasks} from '../core/config/remote/remote_config_tasks.js';
 import type {CertificateManager, KeyManager, PlatformInstaller, ProfileManager} from '../core/index.js';
-import {CommandBuilder, NodeAlias, NodeAliases} from '../types/aliases.js';
+import {type CommandBuilder, type NodeAlias, type NodeAliases} from '../types/aliases.js';
 import type {Opts} from '../types/index.js';
 import {ListrLease} from '../core/lease/listr_lease.js';
 

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -69,7 +69,13 @@ import chalk from 'chalk';
 import {flags} from '../index.js';
 import {type SoloLogger} from '../../core/logging.js';
 import type {Listr, ListrTaskWrapper} from 'listr2';
-import {ConfigBuilder, type NodeAlias, type NodeAliases, type PodName, SkipCheck} from '../../types/aliases.js';
+import {
+  type ConfigBuilder,
+  type NodeAlias,
+  type NodeAliases,
+  type PodName,
+  type SkipCheck,
+} from '../../types/aliases.js';
 import {NodeStatusCodes, NodeStatusEnums, NodeSubcommandType} from '../../core/enumerations.js';
 import * as x509 from '@peculiar/x509';
 import {type NodeCommand} from './index.js';

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -23,7 +23,7 @@ import {BaseCommand} from './base.js';
 import {flags} from './index.js';
 import {getNodeAccountMap} from '../core/helpers.js';
 import {RemoteConfigTasks} from '../core/config/remote/remote_config_tasks.js';
-import {CommandBuilder, type NodeAliases} from '../types/aliases.js';
+import {type CommandBuilder, type NodeAliases} from '../types/aliases.js';
 import {type Opts} from '../types/index.js';
 import {ListrLease} from '../core/lease/listr_lease.js';
 

--- a/src/core/config/local_config.ts
+++ b/src/core/config/local_config.ts
@@ -19,7 +19,7 @@ import type {ListrTask, ListrTaskWrapper} from 'listr2';
 import fs from 'fs';
 import * as yaml from 'yaml';
 import {flags} from '../../commands/index.js';
-import {type Deployments, DeploymentStructure, type LocalConfigData} from './local_config_data.js';
+import {type Deployments, type DeploymentStructure, type LocalConfigData} from './local_config_data.js';
 import {MissingArgumentError, SoloError} from '../errors.js';
 import {type SoloLogger} from '../logging.js';
 import {IsDeployments} from '../validator_decorators.js';

--- a/src/core/config/remote/remote_config_tasks.ts
+++ b/src/core/config/remote/remote_config_tasks.ts
@@ -34,7 +34,7 @@ import type {DeploymentCommand} from '../../../commands/deployment.js';
 import type {MirrorNodeCommand} from '../../../commands/mirror_node.js';
 import type {NodeCommandHandlers} from '../../../commands/node/handlers.js';
 import type {Optional} from '../../../types/index.js';
-import {ComponentsDataWrapper} from './components_data_wrapper.js';
+import {type ComponentsDataWrapper} from './components_data_wrapper.js';
 
 /**
  * Static class that handles all tasks related to remote config used by other commands.

--- a/src/core/k8.ts
+++ b/src/core/k8.ts
@@ -30,7 +30,7 @@ import * as stream from 'node:stream';
 
 import {type SoloLogger} from './logging.js';
 import type * as WebSocket from 'ws';
-import {PodName, TarCreateFilter} from '../types/aliases.js';
+import {type PodName, type TarCreateFilter} from '../types/aliases.js';
 import type {ExtendedNetServer, LocalContextObject} from '../types/index.js';
 import type * as http from 'node:http';
 import {MINUTES} from './constants.js';

--- a/src/core/task.ts
+++ b/src/core/task.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  *
  */
-import {SkipCheck, TaskFunction} from '../types/aliases.js';
+import {type SkipCheck, type TaskFunction} from '../types/aliases.js';
 
 /**
  * Copyright (C) 2024 Hedera Hashgraph, LLC

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -37,7 +37,7 @@ import type {
 } from '../core/index.js';
 import type {Cluster, Context} from '../core/config/remote/types.js';
 import {type BaseCommand} from '../commands/base.js';
-import {PromptFunction} from './aliases.js';
+import {type PromptFunction} from './aliases.js';
 
 export interface NodeKeyObject {
   privateKey: crypto.webcrypto.CryptoKey;

--- a/test/unit/commands/context.test.ts
+++ b/test/unit/commands/context.test.ts
@@ -43,7 +43,7 @@ import {type Opts} from '../../../src/types/index.js';
 import fs from 'fs';
 import {stringify} from 'yaml';
 import {type Cluster, KubeConfig} from '@kubernetes/client-node';
-import {ListrTaskWrapper} from 'listr2';
+import {type ListrTaskWrapper} from 'listr2';
 
 describe('ContextCommandTasks unit tests', () => {
   const filePath = `${getTestCacheDir('ContextCommandTasks')}/localConfig.yaml`;


### PR DESCRIPTION
## Description

This pull request changes the following:

* add eslint config @typescript-eslint/consistent-type-imports to reduce chances of circular dependencies

### Related Issues

* Relates to #928 
