### PR TITLE
fix: remote config validation not working

### DIFF
--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -776,8 +776,8 @@ export class NetworkCommand extends BaseCommand {
             );
 
             remoteConfig.components.add(
-              `envoy-${nodeAlias}`,
-              new EnvoyProxyComponent(`envoy-${nodeAlias}`, cluster, namespace),
+              `envoy-proxy-${nodeAlias}`,
+              new EnvoyProxyComponent(`envoy-proxy-${nodeAlias}`, cluster, namespace),
             );
 
             remoteConfig.components.add(

--- a/src/core/config/remote/remote_config_validator.ts
+++ b/src/core/config/remote/remote_config_validator.ts
@@ -60,10 +60,10 @@ export class RemoteConfigValidator {
   private static validateHaProxies(components: ComponentsDataWrapper, k8: K8): Promise<void>[] {
     return Object.values(components.haProxies).map(async component => {
       try {
-        const pod = await k8.getPodByName(component.name);
+        const pods = await k8.getPodsByLabel([`app=${component.name}`]);
 
         // to return the generic error message
-        if (!pod) throw new Error('Pod not found');
+        if (!pods.length) throw new Error('Pod not found');
       } catch (e) {
         RemoteConfigValidator.throwValidationError('HaProxy', component, e);
       }
@@ -86,10 +86,10 @@ export class RemoteConfigValidator {
   private static validateEnvoyProxies(components: ComponentsDataWrapper, k8: K8): Promise<void>[] {
     return Object.values(components.envoyProxies).map(async component => {
       try {
-        const pod = await k8.getPodByName(component.name);
+        const pods = await k8.getPodsByLabel([`app=${component.name}`]);
 
         // to return the generic error message
-        if (!pod) throw new Error('Pod not found');
+        if (!pods.length) throw new Error('Pod not found');
       } catch (e) {
         RemoteConfigValidator.throwValidationError('Envoy proxy', component, e);
       }
@@ -99,10 +99,10 @@ export class RemoteConfigValidator {
   private static validateConsensusNodes(components: ComponentsDataWrapper, k8: K8): Promise<void>[] {
     return Object.values(components.consensusNodes).map(async component => {
       try {
-        const pod = await k8.getPodByName(component.name);
+        const pods = await k8.getPodsByLabel([`app=network-${component.name}`]);
 
         // to return the generic error message
-        if (!pod) throw new Error('Pod not found');
+        if (!pods.length) throw new Error('Pod not found');
       } catch (e) {
         RemoteConfigValidator.throwValidationError('Consensus node', component, e);
       }

--- a/test/e2e/integration/core/remote_config_validator.test.ts
+++ b/test/e2e/integration/core/remote_config_validator.test.ts
@@ -133,7 +133,7 @@ describe('RemoteConfigValidator', () => {
     });
 
     it('should succeed if component is present', async () => {
-      await createPod(haProxyName, {});
+      await createPod(haProxyName, {app: haProxyName});
 
       // @ts-ignore
       await Promise.all(RemoteConfigValidator.validateHaProxies(components, k8));
@@ -173,7 +173,7 @@ describe('RemoteConfigValidator', () => {
     });
 
     it('should succeed if component is present', async () => {
-      await createPod(envoyProxyName, {});
+      await createPod(envoyProxyName, {app: envoyProxyName});
 
       // @ts-ignore
       await Promise.all(RemoteConfigValidator.validateEnvoyProxies(components, k8));
@@ -192,7 +192,7 @@ describe('RemoteConfigValidator', () => {
     });
 
     it('should succeed if component is present', async () => {
-      await createPod(nodeAlias, {});
+      await createPod(nodeAlias, {app: `network-${nodeAlias}`});
 
       // @ts-ignore
       await Promise.all(RemoteConfigValidator.validateConsensusNodes(components, k8));


### PR DESCRIPTION
## Description

Fixes the failing validation by selecting the `node`, `enovy` and `haproxy` by their labels instead of names

* Closes [#947](https://github.com/hashgraph/solo/issues/947)
