### PR TITLE
chore: update README that v0.32.0+ only supports hedera v0.58.1+

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ An opinionated CLI tool to deploy and manage standalone test networks.
 | 0.29.0       | >= 20.14.0 (lts/hydrogen) | >= v1.29.1 | v0.30.0    | v0.53.0+ | >= v1.27.3 | >= v1.27.3 | v3.14.2 | >= v0.27.4 | Memory >= 8GB, CPU >= 4 |
 | 0.30.0       | >= 20.14.0 (lts/hydrogen) | >= v1.29.1 | v0.30.0    | v0.54.0+ | >= v1.27.3 | >= v1.27.3 | v3.14.2 | >= v0.27.4 | Memory >= 8GB, CPU >= 4 |
 | 0.31.4       | >= 20.18.0 (lts/iron)     | >= v1.29.1 | v0.31.4    | v0.54.0+ | >= v1.27.3 | >= v1.27.3 | v3.14.2 | >= v0.27.4 | Memory >= 8GB, CPU >= 4 |
+| 0.32.0       | >= 20.18.0 (lts/iron)     | >= v1.29.1 | v0.38.2    | v0.58.1+ | >= v1.27.3 | >= v1.27.3 | v3.14.2 | >= v0.27.4 | Memory >= 8GB, CPU >= 4 |
 
 ### Hardware Requirements
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 [![codecov](https://codecov.io/gh/hashgraph/solo/graph/badge.svg?token=hBkQdB1XO5)](https://codecov.io/gh/hashgraph/solo)
 
 > \[!WARNING]
-> SPECIAL NOTICE: Introducing v1.0.0 comes with BREAKING CHANGES.  We have removed caching of the flags in the solo config file.  All commands will need required flags or user will need to answer the prompts.  See more details in our release notes: [release/tag/v1.0.0](https://github.com/hashgraph/solo/releases/tag/v1.0.0)
+> SPECIAL NOTICE: Introducing v0.32.0 comes with BREAKING CHANGES.  We have removed caching of the flags in the solo config file.  All commands will need required flags or user will need to answer the prompts.  See more details in our release notes: [release/tag/v0.32.0](https://github.com/hashgraph/solo/releases/tag/v0.32.0)
 
 An opinionated CLI tool to deploy and manage standalone test networks.
 


### PR DESCRIPTION
## Description

This pull request changes the following:

* Update README that v0.32.0+ only supports hedera v0.58.1+
* update readme about breaking changes in v0.32.0 instead of v1.0.0

### Related Issues

* Closes #1041 
