### PR TITLE
ci: update release rc to treat breaking changes for minor version bump instead of major

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -5,11 +5,14 @@
       "@semantic-release/release-notes-generator",
       {
         "preset": "conventionalcommits"
-      }
+      },
     ],
     "@semantic-release/npm",
     "@semantic-release/git",
     "@semantic-release/github"
+  ],
+  "releaseRules": [
+    { "breaking": "true", "release": "minor"}
   ],
   "verifyRelease": [
     [


### PR DESCRIPTION
## Description

This pull request changes the following:

* update release rc to treat breaking changes for minor version bump instead of major

### Related Issues

* Closes #1035
