### PR TITLE
docs(SDK): Fix incorrect command and fix typos

### DIFF
--- a/docs/content/User/SDK.md
+++ b/docs/content/User/SDK.md
@@ -8,7 +8,7 @@ Then we start with launching a local Solo network with the following commands:
 
 ```bash
 # launch a local Solo network with mirror node and hedera explorer
-task default-with-mirror-node
+task default-with-mirror
 ```
 
 Then create a new test account with the following command:
@@ -60,7 +60,7 @@ OPERATOR_KEY="302a300506032b65700321001d8978e647aca1195c54a4d3d5dc469b95666de14e
 HEDERA_NETWORK="local-node"
 ```
 
-Make sure to assign the value of accountId to `OPERATOR\_ID` and the value of privateKey to `OPERATOR\_KEY`.
+Make sure to assign the value of accountId to `OPERATOR_ID` and the value of privateKey to `OPERATOR_KEY`.
 
 Then try the following command to run the test
 


### PR DESCRIPTION
## Description

This pull request changes the following:
- Replaced `task default-with-mirror-node` to `task default-with-mirror` Since the `task default-with-mirror-node` does not work anymore and also to ensure synchronicity with [Use the Task tool to launch Solo](https://github.com/hashgraph/solo/blob/main/docs/content/User/TaskTool.md ).
- Fixed typos for `OPERATOR_ID` and `OPERATOR_KEY` to remove incorrect escape character. 
