### PR TITLE
feat: Updating solo to leverage changes after moving acme-cluster-issuer and haproxy-ingress out of mirror-node-explorer

### DIFF
--- a/src/commands/mirror_node.ts
+++ b/src/commands/mirror_node.ts
@@ -290,6 +290,7 @@ export class MirrorNodeCommand extends BaseCommand {
                       soloChartSetupValuesArg,
                     );
                   },
+                  skip: ctx => !ctx.config.enableHederaExplorerTls,
                 },
                 {
                   title: 'Deploy hedera-explorer',

--- a/src/commands/mirror_node.ts
+++ b/src/commands/mirror_node.ts
@@ -98,7 +98,7 @@ export class MirrorNodeCommand extends BaseCommand {
     ];
   }
 
-  async prepareHederaExplorerValuesArg(config: any) {
+  async prepareHederaExplorerValuesArg(config: {valuesFile: string}) {
     let valuesArg = '';
 
     const profileName = this.configManager.getFlag<string>(flags.profileName) as string;
@@ -163,7 +163,7 @@ export class MirrorNodeCommand extends BaseCommand {
     return valuesArg;
   }
 
-  async prepareValuesArg(config: any) {
+  async prepareValuesArg(config: {valuesFile: string}) {
     let valuesArg = '';
 
     const profileName = this.configManager.getFlag<string>(flags.profileName) as string;
@@ -466,7 +466,7 @@ export class MirrorNodeCommand extends BaseCommand {
     try {
       await tasks.run();
       self.logger.debug('mirror node depolyment has completed');
-    } catch (e: Error | any) {
+    } catch (e) {
       throw new SoloError(`Error deploying node: ${e.message}`, e);
     } finally {
       await lease.release();
@@ -563,7 +563,7 @@ export class MirrorNodeCommand extends BaseCommand {
     try {
       await tasks.run();
       self.logger.debug('mirror node destruction has completed');
-    } catch (e: Error | any) {
+    } catch (e) {
       throw new SoloError(`Error destrong mirror node: ${e.message}`, e);
     } finally {
       await lease.release();
@@ -579,13 +579,13 @@ export class MirrorNodeCommand extends BaseCommand {
     return {
       command: 'mirror-node',
       desc: 'Manage Hedera Mirror Node in solo network',
-      builder: (yargs: any) => {
+      builder: yargs => {
         return yargs
           .command({
             command: 'deploy',
             desc: 'Deploy mirror-node and its components',
-            builder: (y: any) => flags.setCommandFlags(y, ...MirrorNodeCommand.DEPLOY_FLAGS_LIST),
-            handler: (argv: any) => {
+            builder: y => flags.setCommandFlags(y, ...MirrorNodeCommand.DEPLOY_FLAGS_LIST),
+            handler: argv => {
               self.logger.debug("==== Running 'mirror-node deploy' ===");
               self.logger.debug(argv);
 
@@ -604,8 +604,8 @@ export class MirrorNodeCommand extends BaseCommand {
           .command({
             command: 'destroy',
             desc: 'Destroy mirror-node components and database',
-            builder: (y: any) => flags.setCommandFlags(y, flags.chartDirectory, flags.force, flags.namespace),
-            handler: (argv: any) => {
+            builder: y => flags.setCommandFlags(y, flags.chartDirectory, flags.force, flags.namespace),
+            handler: argv => {
               self.logger.debug("==== Running 'mirror-node destroy' ===");
               self.logger.debug(argv);
 

--- a/src/commands/mirror_node.ts
+++ b/src/commands/mirror_node.ts
@@ -94,7 +94,6 @@ export class MirrorNodeCommand extends BaseCommand {
       flags.mirrorNodeVersion,
       flags.pinger,
       flags.clusterSetupNamespace,
-      flags.chartDirectory,
       flags.soloChartVersion,
     ];
   }
@@ -193,7 +192,6 @@ export class MirrorNodeCommand extends BaseCommand {
 
             // disable the prompts that we don't want to prompt the user for
             flags.disablePrompts([
-              flags.chartDirectory,
               flags.deployHederaExplorer,
               flags.enableHederaExplorerTls,
               flags.hederaExplorerTlsHostName,

--- a/test/e2e/commands/mirror_node.test.ts
+++ b/test/e2e/commands/mirror_node.test.ts
@@ -92,7 +92,6 @@ e2eTestSuite(testName, argv, undefined, undefined, undefined, undefined, undefin
       }
 
       expect(mirrorNodeCmd.getUnusedConfigs(MirrorNodeCommand.DEPLOY_CONFIGS_NAME)).to.deep.equal([
-        flags.chartDirectory.constName,
         flags.hederaExplorerTlsHostName.constName,
         flags.hederaExplorerTlsLoadBalancerIp.constName,
         flags.profileFile.constName,

--- a/test/e2e/commands/mirror_node.test.ts
+++ b/test/e2e/commands/mirror_node.test.ts
@@ -92,12 +92,15 @@ e2eTestSuite(testName, argv, undefined, undefined, undefined, undefined, undefin
       }
 
       expect(mirrorNodeCmd.getUnusedConfigs(MirrorNodeCommand.DEPLOY_CONFIGS_NAME)).to.deep.equal([
+        flags.chartDirectory.constName,
         flags.hederaExplorerTlsHostName.constName,
         flags.hederaExplorerTlsLoadBalancerIp.constName,
         flags.profileFile.constName,
         flags.profileName.constName,
         flags.quiet.constName,
         flags.tlsClusterIssuerType.constName,
+        flags.clusterSetupNamespace.constName,
+        flags.soloChartVersion.constName,
       ]);
     }).timeout(Duration.ofMinutes(10).toMillis());
 


### PR DESCRIPTION
## Description

Added new step to the deploy process for the mirror node to upgrade the solo-charts with the appropriate values.

### Related Issues

* Closes [#58](https://github.com/hashgraph/solo-charts/issues/58)
