### PR TITLE
fix: solo deployment create should use email address in local config if it is already there instead of prompting the user for it

### DIFF
--- a/src/commands/deployment.ts
+++ b/src/commands/deployment.ts
@@ -60,7 +60,11 @@ export class DeploymentCommand extends BaseCommand {
             self.configManager.update(argv);
             self.logger.debug('Updated config with argv', {config: self.configManager.config});
 
-            await self.configManager.executePrompt(task, DeploymentCommand.DEPLOY_FLAGS_LIST);
+            await self.configManager.executePrompt(task, [
+              flags.contextClusterUnparsed,
+              flags.namespace,
+              flags.deploymentClusters,
+            ]);
 
             ctx.config = {
               contextClusterUnparsed: self.configManager.getFlag<string>(flags.contextClusterUnparsed),

--- a/src/core/config/local_config.ts
+++ b/src/core/config/local_config.ts
@@ -15,7 +15,6 @@
  *
  */
 import {IsEmail, IsNotEmpty, IsObject, IsString, validateSync} from 'class-validator';
-import type {ListrTask, ListrTaskWrapper} from 'listr2';
 import fs from 'fs';
 import * as yaml from 'yaml';
 import {Flags as flags} from '../../commands/flags.js';
@@ -35,6 +34,7 @@ import {type K8} from '../k8.js';
 import {splitFlagInput} from '../helpers.js';
 import {inject, injectable} from 'tsyringe-neo';
 import {patchInject} from '../container_helper.js';
+import type {SoloListrTask, SoloListrTaskWrapper} from '../../types/index.js';
 
 @injectable()
 export class LocalConfig implements LocalConfigData {
@@ -162,13 +162,17 @@ export class LocalConfig implements LocalConfigData {
     this.logger.info(`Wrote local config to ${this.filePath}: ${yamlContent}`);
   }
 
-  public promptLocalConfigTask(k8: K8): ListrTask<any, any, any> {
+  public promptLocalConfigTask(k8: K8): SoloListrTask<any> {
     const self = this;
 
     return {
       title: 'Prompt local configuration',
       skip: this.skipPromptTask,
-      task: async (_: any, task: ListrTaskWrapper<any, any, any>): Promise<void> => {
+      task: async (_: any, task: SoloListrTaskWrapper<any>): Promise<void> => {
+        if (self.configFileExists) {
+          self.configManager.setFlag(flags.userEmailAddress, self.userEmailAddress);
+        }
+
         const isQuiet = self.configManager.getFlag<boolean>(flags.quiet);
         const contexts = self.configManager.getFlag<string>(flags.context);
         const deploymentName = self.configManager.getFlag<Namespace>(flags.namespace);


### PR DESCRIPTION
## Description

* made localconfig set the user email address if's already present.
* removed flags from execute prompt inside `deployment create` that prevent getting the existing email address from localconfig.

### Related Issues

* Closes [#975](https://github.com/hashgraph/solo/issues/975)
