### PR TITLE
fix: should run `npm install` before build

### DIFF
--- a/.github/workflows/flow-task-test.yaml
+++ b/.github/workflows/flow-task-test.yaml
@@ -63,13 +63,6 @@ jobs:
           verbosity: 3
           wait: 120s
 
-      - name: Install Dependencies
-        id: npm-deps
-        run: npm ci
-
-      - name: Compile Project
-        run: npm run build
-
       - name: Run Example Task File Test
         run: |
           task default-with-relay

--- a/Taskfile.helper.yml
+++ b/Taskfile.helper.yml
@@ -31,10 +31,9 @@ env:
   MIRROR_RELEASE_NAME: mirror
 
 tasks:
-  deps:
-    - task: "install:solo"
   init:
     cmds:
+      - task: "install:solo"
       - task: "var:check"
       - task: "run:build"
 

--- a/Taskfile.helper.yml
+++ b/Taskfile.helper.yml
@@ -31,6 +31,8 @@ env:
   MIRROR_RELEASE_NAME: mirror
 
 tasks:
+  deps:
+    - task: "install:solo"
   init:
     cmds:
       - task: "var:check"

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -21,7 +21,6 @@ tasks:
       - echo "This command is meant to deploy a Solo network to a Kind cluster on your local machine, "
       - echo "ctrl-c if this is not what you want to do."
       - sleep 5
-      - task: "install:solo"
       - task: "install"
       - task: "start"
 

--- a/examples/Taskfile.examples.yml
+++ b/examples/Taskfile.examples.yml
@@ -11,7 +11,6 @@ tasks:
     cmds:
       - task: "install:kubectl:darwin"
       - task: "install:kubectl:linux"
-      - task: "install:solo"
       - task: "install"
       - task: "start"
 


### PR DESCRIPTION
## Description

This pull request changes the following:

* should run npm install before build

### Related Issues

* Closes #1116
