### PR TITLE
fix: external link rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,4 +63,4 @@ expected to uphold this code of conduct.
 
 ## License
 
-[Apache License 2.0](LICENSE)
+[Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)

--- a/docs/content/User/SDK.md
+++ b/docs/content/User/SDK.md
@@ -1,8 +1,8 @@
 # Using Solo with Hedera JavaScript SDK
 
 First, please follow solo repository README to install solo and Docker Desktop.
-You also need to install the Taskfile tool following the instructions here:
-https://taskfile.dev/installation/
+You also need to install the Taskfile tool following the instructions [here](https://taskfile.dev/installation/).
+
 
 Then we start with launching a local Solo network with the following commands:
 

--- a/docs/layouts/_default/_markup/render-link.html
+++ b/docs/layouts/_default/_markup/render-link.html
@@ -1,2 +1,6 @@
+{{ $destination := .Destination }}
+{{ if strings.HasPrefix $destination "http" }}
+<a href="{{ $destination | safeURL }}"{{ with .Title }} title="{{ .Title }}"{{ end }} target="_blank" rel="noopener noreferrer">{{ .Text | safeHTML }}</a>
+{{ else }}
 <a href="{{ (.Page.GetPage .Destination).RelPermalink | safeURL }}">{{ .Text | safeHTML }}</a>
-
+{{ end }}


### PR DESCRIPTION
## Description

This pull request changes the following:

* Fixed the default html link hood rendering template, it was incorrectly replacing external link to empty string

### Related Issues

* Closes #1114
