### PR TITLE
feat: update genesis-network.json to add roster entries and more

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -2,5 +2,6 @@
   "bracketSpacing": false,
   "singleQuote": true,
   "trailingComma": "all",
-  "arrowParens": "avoid"
+  "arrowParens": "avoid",
+  "printWidth": 120
 }

--- a/Taskfile.helper.yml
+++ b/Taskfile.helper.yml
@@ -14,15 +14,13 @@ vars:
   solo_keys_dir: "{{ .solo_cache_dir }}/keys"
   solo_bin_dir: "{{ .solo_user_dir }}/bin"
   run_build_file:
-    sh: (echo "/tmp/run-build-$(date +%Y%m%d%H%M%S)")
+    sh: (echo "/tmp/${USER}-run-build-$(date +%Y%m%d%H%M%S)")
   var_check_file:
-    sh: (echo "/tmp/var-check-$(date +%Y%m%d%H%M%S)")
+    sh: (echo "/tmp/${USER}-var-check-$(date +%Y%m%d%H%M%S)")
   minio_flag_file:
-    sh: (echo "/tmp/minio-flag-$(date +%Y%m%d%H%M%S)")
-  solo_chart_file:
-    sh: (echo "/tmp/solo-chart-$(date +%Y%m%d%H%M%S)")
-  solo_consensus_file:
-    sh: (echo "/tmp/solo-consensus-$(date +%Y%m%d%H%M%S)")
+    sh: (echo "/tmp/${USER}-minio-flag-$(date +%Y%m%d%H%M%S)")
+  solo_install_file:
+    sh: (echo "/tmp/${USER}-solo-install-$(date +%Y%m%d%H%M%S)")
 
 env:
   SOLO_CLUSTER_SETUP_NAMESPACE: solo-setup
@@ -75,6 +73,8 @@ tasks:
       - echo "LOG4J2_FLAG=${LOG4J2_FLAG}"
       - echo "APPLICATION_PROPERTIES_FLAG=${APPLICATION_PROPERTIES_FLAG}"
       - echo "LOCAL_BUILD_FLAG=${LOCAL_BUILD_FLAG}"
+      - echo "DEBUG_NODE_ALIAS=${DEBUG_NODE_ALIAS}"
+      - echo "SOLO_CHARTS_DIR_FLAG=${SOLO_CHARTS_DIR_FLAG}"
       - touch {{ .var_check_file }}
 
   readme:
@@ -92,10 +92,18 @@ tasks:
       - echo "Use command 'task default-with-relay' to deploy the network with a relay node."
 
   install:solo:
+    silent: true
     internal: true
+    status:
+      - test -f {{ .solo_install_file }}
     cmds:
-      - cd ..
+      - |
+        if [[ "$(ls -1 package.json)" == "" ]]; then
+          cd ..
+        fi
+        pwd
       - npm install
+      - touch {{ .solo_install_file }}
 
   install:kubectl:darwin:
     internal: true
@@ -157,14 +165,16 @@ tasks:
       - task: "init"
     cmds:
       - |
-        unset RELEASE_FLAG
-        if [[ "${LOCAL_BUILD_FLAG}" == "" ]]; then
-          export RELEASE_FLAG='--release-tag {{.CONSENSUS_NODE_VERSION}}'
+        if [[ "${DEBUG_NODE_ALIAS}" != "" ]]; then
+          export DEBUG_NODE_FLAG="--debug-node-alias {{ .DEBUG_NODE_ALIAS }}"
+        fi
+        if [[ "${CONSENSUS_NODE_VERSION}" != "" ]]; then
+          export CONSENSUS_NODE_FLAG='--release-tag {{.CONSENSUS_NODE_VERSION}}'
         fi
         if [[ "${SOLO_CHART_VERSION}" != "" ]]; then
           export SOLO_CHART_FLAG='--solo-chart-version ${SOLO_CHART_VERSION}'
         fi
-        SOLO_HOME_DIR=${SOLO_HOME_DIR} npm run solo -- network deploy --namespace "${SOLO_NAMESPACE}" --node-aliases-unparsed {{.node_identifiers}} ${RELEASE_FLAG} ${SOLO_CHART_FLAG} ${VALUES_FLAG} ${SETTINGS_FLAG} ${LOG4J2_FLAG} ${APPLICATION_PROPERTIES_FLAG} ${GENESIS_THROTTLES_FLAG} -q
+        SOLO_HOME_DIR=${SOLO_HOME_DIR} npm run solo -- network deploy --namespace "${SOLO_NAMESPACE}" --node-aliases-unparsed {{.node_identifiers}} ${CONSENSUS_NODE_FLAG} ${SOLO_CHART_FLAG} ${VALUES_FLAG} ${SETTINGS_FLAG} ${LOG4J2_FLAG} ${APPLICATION_PROPERTIES_FLAG} ${GENESIS_THROTTLES_FLAG} ${DEBUG_NODE_FLAG} ${SOLO_CHARTS_DIR_FLAG} -q
       - |
         if [[ "${CONSENSUS_NODE_VERSION}" != "" ]]; then
           export CONSENSUS_NODE_FLAG='--release-tag ${CONSENSUS_NODE_VERSION}'
@@ -183,7 +193,11 @@ tasks:
     deps:
       - task: "init"
     cmds:
-      - SOLO_HOME_DIR=${SOLO_HOME_DIR} npm run solo -- node start --namespace "${SOLO_NAMESPACE}" --node-aliases-unparsed {{.node_identifiers}} -q {{ .CLI_ARGS }}
+      - |
+        if [[ "${DEBUG_NODE_ALIAS}" != "" ]]; then
+          export DEBUG_NODE_FLAG="--debug-node-alias {{ .DEBUG_NODE_ALIAS }}"
+        fi
+        SOLO_HOME_DIR=${SOLO_HOME_DIR} npm run solo -- node start --namespace "${SOLO_NAMESPACE}" --node-aliases-unparsed {{.node_identifiers}} ${DEBUG_NODE_FLAG} -q {{ .CLI_ARGS }}
       - |
         if [[ "{{ .use_port_forwards }}" == "true" ]];then
           echo "Enable port forwarding for Hedera Node"
@@ -259,7 +273,7 @@ tasks:
     deps:
       - task: "init"
     cmds:
-      - SOLO_HOME_DIR=${SOLO_HOME_DIR} npm run solo -- cluster setup --cluster-setup-namespace "${SOLO_CLUSTER_SETUP_NAMESPACE}" -q
+      - SOLO_HOME_DIR=${SOLO_HOME_DIR} npm run solo -- cluster setup --cluster-setup-namespace "${SOLO_CLUSTER_SETUP_NAMESPACE}" ${SOLO_CHARTS_DIR_FLAG} -q
 
   cluster:destroy:
     cmds:
@@ -409,8 +423,7 @@ tasks:
     silent: true
     cmds:
       - echo "Cleaning up temporary files..."
-      - rm -f /tmp/run-build-*
-      - rm -f /tmp/var-check-*
-      - rm -f /tmp/minio-flag-*
-      - rm -f /tmp/solo-chart-*
-      - rm -f /tmp/solo-consensus-*
+      - rm -f /tmp/${USER}-run-build-* || true
+      - rm -f /tmp/${USER}-var-check-* || true
+      - rm -f /tmp/${USER}-minio-flag-* || true
+      - rm -f /tmp/${USER}-solo-install-* || true

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,6 +8,10 @@ env:
   SOLO_NAMESPACE: solo-e2e
   # SOLO_CHART_VERSION: 0.39.0
   # CONSENSUS_NODE_VERSION: v0.58.0
+  HEDERA_SERVICES_ROOT: "/Users/user/source/hedera-services"
+  # LOCAL_BUILD_FLAG: "--local-build-path {{.HEDERA_SERVICES_ROOT}}/hedera-node/data"
+  # DEBUG_NODE_ALIAS: "node2"
+  # SOLO_CHARTS_DIR_FLAG: "-d /Users/user/source/solo-charts/charts"
 vars:
   use_port_forwards: "true"
 

--- a/examples/custom-network-config/init-containers-values.yaml
+++ b/examples/custom-network-config/init-containers-values.yaml
@@ -9,6 +9,7 @@ hedera:
           mountPath: /data-saved
   nodes:
     - name: node1
+      nodeId: 0
       accountId: 0.0.3
       root:
         resources:
@@ -19,6 +20,7 @@ hedera:
             cpu: 24
             memory: 256Gi
     - name: node2
+      nodeId: 1
       accountId: 0.0.4
       root:
         resources:
@@ -29,6 +31,7 @@ hedera:
             cpu: 24
             memory: 256Gi
     - name: node3
+      nodeId: 2
       accountId: 0.0.5
       root:
         resources:
@@ -39,6 +42,7 @@ hedera:
             cpu: 24
             memory: 256Gi
     - name: node4
+      nodeId: 3
       accountId: 0.0.6
       root:
         resources:
@@ -49,6 +53,7 @@ hedera:
             cpu: 24
             memory: 256Gi
     - name: node5
+      nodeId: 4
       accountId: 0.0.7
       root:
         resources:
@@ -59,6 +64,7 @@ hedera:
             cpu: 24
             memory: 256Gi
     - name: node6
+      nodeId: 5
       accountId: 0.0.8
       root:
         resources:
@@ -69,6 +75,7 @@ hedera:
             cpu: 24
             memory: 256Gi
     - name: node7
+      nodeId: 6
       accountId: 0.0.9
       root:
         resources:
@@ -79,6 +86,7 @@ hedera:
             cpu: 24
             memory: 256Gi
     - name: node8
+      nodeId: 7
       accountId: 0.0.10
       root:
         resources:
@@ -89,6 +97,7 @@ hedera:
             cpu: 24
             memory: 256Gi
     - name: node9
+      nodeId: 8
       accountId: 0.0.11
       root:
         resources:
@@ -99,6 +108,7 @@ hedera:
             cpu: 24
             memory: 256Gi
     - name: node10
+      nodeId: 9
       accountId: 0.0.12
       root:
         resources:
@@ -109,8 +119,6 @@ hedera:
             cpu: 24
             memory: 256Gi
 defaults:
-  envoyProxy:
-    loadBalancerEnabled: true
   sidecars:
     recordStreamUploader:
       resources:

--- a/examples/performance-tuning/latitude/init-containers-values.yaml
+++ b/examples/performance-tuning/latitude/init-containers-values.yaml
@@ -9,6 +9,7 @@ hedera:
           mountPath: /data-saved
   nodes:
     - name: node1
+      nodeId: 0
       accountId: 0.0.3
       root:
         resources:
@@ -19,6 +20,7 @@ hedera:
             cpu: 24
             memory: 256Gi
     - name: node2
+      nodeId: 1
       accountId: 0.0.4
       root:
         resources:
@@ -29,6 +31,7 @@ hedera:
             cpu: 24
             memory: 256Gi
     - name: node3
+      nodeId: 2
       accountId: 0.0.5
       root:
         resources:
@@ -39,6 +42,7 @@ hedera:
             cpu: 24
             memory: 256Gi
     - name: node4
+      nodeId: 3
       accountId: 0.0.6
       root:
         resources:
@@ -49,6 +53,7 @@ hedera:
             cpu: 24
             memory: 256Gi
     - name: node5
+      nodeId: 4
       accountId: 0.0.7
       root:
         resources:
@@ -59,6 +64,7 @@ hedera:
             cpu: 24
             memory: 256Gi
     - name: node6
+      nodeId: 5
       accountId: 0.0.8
       root:
         resources:
@@ -69,6 +75,7 @@ hedera:
             cpu: 24
             memory: 256Gi
     - name: node7
+      nodeId: 6
       accountId: 0.0.9
       root:
         resources:
@@ -79,6 +86,7 @@ hedera:
             cpu: 24
             memory: 256Gi
     - name: node8
+      nodeId: 7
       accountId: 0.0.10
       root:
         resources:
@@ -89,6 +97,7 @@ hedera:
             cpu: 24
             memory: 256Gi
     - name: node9
+      nodeId: 8
       accountId: 0.0.11
       root:
         resources:
@@ -99,6 +108,7 @@ hedera:
             cpu: 24
             memory: 256Gi
     - name: node10
+      nodeId: 9
       accountId: 0.0.12
       root:
         resources:
@@ -111,8 +121,6 @@ hedera:
 defaults:
   haproxy:
     serviceType: NodePort
-  envoyProxy:
-    loadBalancerEnabled: true
   sidecars:
     recordStreamUploader:
       resources:

--- a/examples/performance-tuning/solo-perf-test/init-containers-values.yaml
+++ b/examples/performance-tuning/solo-perf-test/init-containers-values.yaml
@@ -9,6 +9,7 @@ hedera:
           mountPath: /data-saved
   nodes:
     - name: node0
+      nodeId: 0
       accountId: 0.0.3
       root:
         resources:
@@ -19,6 +20,7 @@ hedera:
             cpu: 4
             memory: 31Gi
     - name: node1
+      nodeId: 1
       accountId: 0.0.4
       root:
         resources:
@@ -29,6 +31,7 @@ hedera:
             cpu: 4
             memory: 31Gi
     - name: node2
+      nodeId: 2
       accountId: 0.0.5
       root:
         resources:
@@ -39,6 +42,7 @@ hedera:
             cpu: 4
             memory: 31Gi
     - name: node3
+      nodeId: 3
       accountId: 0.0.6
       root:
         resources:
@@ -49,6 +53,7 @@ hedera:
             cpu: 4
             memory: 31Gi
     - name: node4
+      nodeId: 4
       accountId: 0.0.7
       root:
         resources:
@@ -59,6 +64,7 @@ hedera:
             cpu: 4
             memory: 31Gi
     - name: node5
+      nodeId: 5
       accountId: 0.0.8
       root:
         resources:
@@ -69,6 +75,7 @@ hedera:
             cpu: 4
             memory: 31Gi
     - name: node6
+      nodeId: 6
       accountId: 0.0.9
       root:
         resources:
@@ -79,8 +86,6 @@ hedera:
             cpu: 4
             memory: 31Gi
 defaults:
-  envoyProxy:
-    loadBalancerEnabled: true
   sidecars:
     recordStreamUploader:
       resources:

--- a/examples/solo-gke-test/Taskfile.yml
+++ b/examples/solo-gke-test/Taskfile.yml
@@ -18,3 +18,4 @@ env:
   HEDERA_SERVICES_ROOT: "/Users/user/source/hedera-services"
   LOCAL_BUILD_FLAG: "--local-build-path {{.HEDERA_SERVICES_ROOT}}/hedera-node/data"
   GENESIS_THROTTLES_FLAG: "--genesis-throttles-file {{.USER_WORKING_DIR}}/throttles.json"
+  # SOLO_CHARTS_DIR_FLAG: "-d /Users/user/source/solo-charts/charts"

--- a/examples/solo-gke-test/init-containers-values.yaml
+++ b/examples/solo-gke-test/init-containers-values.yaml
@@ -9,6 +9,7 @@ hedera:
           mountPath: /data-saved
   nodes:
     - name: node1
+      nodeId: 0
       accountId: 0.0.3
       root:
         resources:
@@ -19,6 +20,7 @@ hedera:
             cpu: 4
             memory: 31Gi
     - name: node2
+      nodeId: 1
       accountId: 0.0.4
       root:
         resources:
@@ -29,6 +31,7 @@ hedera:
             cpu: 4
             memory: 31Gi
     - name: node3
+      nodeId: 2
       accountId: 0.0.5
       root:
         resources:
@@ -39,6 +42,7 @@ hedera:
             cpu: 4
             memory: 31Gi
     - name: node4
+      nodeId: 3
       accountId: 0.0.6
       root:
         resources:
@@ -49,6 +53,7 @@ hedera:
             cpu: 4
             memory: 31Gi
     - name: node5
+      nodeId: 4
       accountId: 0.0.7
       root:
         resources:
@@ -59,8 +64,6 @@ hedera:
             cpu: 4
             memory: 31Gi
 defaults:
-  envoyProxy:
-    loadBalancerEnabled: true
   sidecars:
     recordStreamUploader:
       resources:

--- a/resources/templates/application.properties
+++ b/resources/templates/application.properties
@@ -16,4 +16,5 @@ staking.periodMins=1
 nodes.updateAccountIdAllowed=true
 # TODO: remove once we have the uploader enabled, required for current p0 deadline
 blockStream.streamMode=RECORDS
+# TODO: uncomment this when we are ready to use genesis-network.json
 #addressBook.useRosterLifecycle=true

--- a/resources/templates/application.properties
+++ b/resources/templates/application.properties
@@ -16,3 +16,4 @@ staking.periodMins=1
 nodes.updateAccountIdAllowed=true
 # TODO: remove once we have the uploader enabled, required for current p0 deadline
 blockStream.streamMode=RECORDS
+addressBook.useRosterLifecycle=true

--- a/resources/templates/application.properties
+++ b/resources/templates/application.properties
@@ -16,4 +16,4 @@ staking.periodMins=1
 nodes.updateAccountIdAllowed=true
 # TODO: remove once we have the uploader enabled, required for current p0 deadline
 blockStream.streamMode=RECORDS
-addressBook.useRosterLifecycle=true
+#addressBook.useRosterLifecycle=true

--- a/resources/templates/settings.txt
+++ b/resources/templates/settings.txt
@@ -1,16 +1,2 @@
-checkSignedStateFromDisk,                      1
-csvFileName,                                   MainNetStats
-doUpnp,                                        false
-loadKeysFromPfxFiles,                          0
-maxOutgoingSyncs,                              1
-reconnect.active,                              1
-reconnect.reconnectWindowSeconds,              -1
-showInternalStats,                             1
-state.saveStatePeriod,                         900
-useLoopbackIp,                                 false
-waitAtStartup,                                 false
 state.mainClassNameOverride,                   com.hedera.services.ServicesMain
-maxEventQueueForCons,                          1000
-merkleDb.hashesRamToDiskThreshold,             8388608
-event.creation.maxCreationRate,                20
-virtualMap.familyThrottleThreshold,            6000000000
+state.saveStatePeriod, 60

--- a/src/commands/flags.ts
+++ b/src/commands/flags.ts
@@ -1675,6 +1675,17 @@ export class Flags {
     prompt: undefined,
   };
 
+  static readonly loadBalancerEnabled: CommandFlag = {
+    constName: 'loadBalancerEnabled',
+    name: 'load-balancer',
+    definition: {
+      describe: 'Enable load balancer for network node proxies',
+      defaultValue: false,
+      type: 'boolean',
+    },
+    prompt: undefined,
+  };
+
   static readonly allFlags: CommandFlag[] = [
     Flags.accountId,
     Flags.amount,
@@ -1727,6 +1738,7 @@ export class Flags {
     Flags.hederaExplorerTlsLoadBalancerIp,
     Flags.hederaExplorerVersion,
     Flags.inputDir,
+    Flags.loadBalancerEnabled,
     Flags.localBuildPath,
     Flags.log4j2Xml,
     Flags.mirrorNodeVersion,

--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -808,7 +808,11 @@ export class NetworkCommand extends BaseCommand {
         {
           title: 'Waiting for network pods to be running',
           task: async () => {
-            await this.k8.waitForPods([constants.POD_PHASE_RUNNING], ['solo.hedera.com/type=network-node'], 1);
+            await this.k8.waitForPods(
+              [constants.POD_PHASE_RUNNING],
+              ['solo.hedera.com/type=network-node', 'solo.hedera.com/type=network-node'],
+              1,
+            );
           },
         },
       ],

--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -38,7 +38,6 @@ import {ConsensusNodeComponent} from '../core/config/remote/components/consensus
 import {ConsensusNodeStates} from '../core/config/remote/enumerations.js';
 import {EnvoyProxyComponent} from '../core/config/remote/components/envoy_proxy_component.js';
 import {HaProxyComponent} from '../core/config/remote/components/ha_proxy_component.js';
-import {GenesisNetworkDataConstructor} from '../core/genesis_network_models/genesis_network_data_constructor.js';
 import {v4 as uuidv4} from 'uuid';
 import * as Base64 from 'js-base64';
 
@@ -47,6 +46,7 @@ export interface NetworkDeployConfigClass {
   cacheDir: string;
   chartDirectory: string;
   enablePrometheusSvcMonitor: boolean;
+  loadBalancerEnabled: boolean;
   soloChartVersion: string;
   namespace: string;
   nodeAliasesUnparsed: string;
@@ -64,7 +64,6 @@ export interface NetworkDeployConfigClass {
   grpcWebTlsCertificatePath: string;
   grpcTlsKeyPath: string;
   grpcWebTlsKeyPath: string;
-  genesisNetworkData: GenesisNetworkDataConstructor;
   genesisThrottlesFile: string;
   resolvedThrottlesFile: string;
   getUnusedConfigs: () => string[];
@@ -123,6 +122,7 @@ export class NetworkCommand extends BaseCommand {
       flags.enablePrometheusSvcMonitor,
       flags.soloChartVersion,
       flags.debugNodeAlias,
+      flags.loadBalancerEnabled,
       flags.log4j2Xml,
       flags.namespace,
       flags.nodeAliasesUnparsed,
@@ -225,13 +225,13 @@ export class NetworkCommand extends BaseCommand {
     valuesFile?: string;
     haproxyIpsParsed?: Record<NodeAlias, IP>;
     envoyIpsParsed?: Record<NodeAlias, IP>;
-    genesisNetworkData: GenesisNetworkDataConstructor;
     storageType: constants.StorageType;
     resolvedThrottlesFile: string;
     storageAccessKey: string;
     storageSecrets: string;
     storageEndpoint: string;
     storageBucket: string;
+    loadBalancerEnabled: boolean;
   }) {
     let valuesArg = config.chartDirectory
       ? `-f ${path.join(config.chartDirectory, 'solo-deployment', 'values.yaml')}`
@@ -280,15 +280,11 @@ export class NetworkCommand extends BaseCommand {
       valuesArg += ` --set minio-server.tenant.buckets[0].name=${config.storageBucket}`;
     }
     const profileName = this.configManager.getFlag<string>(flags.profileName) as string;
-    this.profileValuesFile = await this.profileManager.prepareValuesForSoloChart(
-      profileName,
-      config.genesisNetworkData,
-    );
+    this.profileValuesFile = await this.profileManager.prepareValuesForSoloChart(profileName);
     if (this.profileValuesFile) {
       valuesArg += this.prepareValuesFiles(this.profileValuesFile);
     }
 
-    // do not deploy mirror node until after we have the updated address book
     valuesArg += ` --set "telemetry.prometheus.svcMonitor.enabled=${config.enablePrometheusSvcMonitor}"`;
 
     valuesArg += ` --set "defaults.volumeClaims.enabled=${config.persistentVolumeClaims}"`;
@@ -315,6 +311,11 @@ export class NetworkCommand extends BaseCommand {
       valuesArg += ` --set-file "hedera.configMaps.genesisThrottlesJson=${config.resolvedThrottlesFile}"`;
     }
 
+    if (config.loadBalancerEnabled) {
+      valuesArg += ' --set "defaults.haproxy.serviceType=LoadBalancer"';
+      valuesArg += ' --set "defaults.envoyProxy.serviceType=LoadBalancer"';
+    }
+
     if (config.valuesFile) {
       valuesArg += this.prepareValuesFiles(config.valuesFile);
     }
@@ -339,6 +340,7 @@ export class NetworkCommand extends BaseCommand {
       flags.chainId,
       flags.chartDirectory,
       flags.debugNodeAlias,
+      flags.loadBalancerEnabled,
       flags.log4j2Xml,
       flags.persistentVolumeClaims,
       flags.profileName,
@@ -391,12 +393,6 @@ export class NetworkCommand extends BaseCommand {
     config.keysDir = path.join(validatePath(config.cacheDir), 'keys');
     config.stagingDir = Templates.renderStagingDir(config.cacheDir, config.releaseTag);
     config.stagingKeysDir = path.join(validatePath(config.stagingDir), 'keys');
-
-    config.genesisNetworkData = await GenesisNetworkDataConstructor.initialize(
-      config.nodeAliases,
-      this.keyManager,
-      config.keysDir,
-    );
 
     config.resolvedThrottlesFile = resolveValidJsonFilePath(
       config.genesisThrottlesFile,

--- a/src/commands/node/handlers.ts
+++ b/src/commands/node/handlers.ts
@@ -744,7 +744,7 @@ export class NodeCommandHandlers implements CommandHandlers {
         }),
         this.tasks.identifyNetworkPods(),
         this.tasks.fetchPlatformSoftware('nodeAliases'),
-        this.tasks.setupNetworkNodes('nodeAliases'),
+        this.tasks.setupNetworkNodes('nodeAliases', true),
         this.changeAllNodeStates(ConsensusNodeStates.SETUP),
       ],
       {

--- a/src/commands/node/handlers.ts
+++ b/src/commands/node/handlers.ts
@@ -744,7 +744,8 @@ export class NodeCommandHandlers implements CommandHandlers {
         }),
         this.tasks.identifyNetworkPods(),
         this.tasks.fetchPlatformSoftware('nodeAliases'),
-        this.tasks.setupNetworkNodes('nodeAliases', true),
+        // TODO: change to isGenesis: true once we are ready to use genesis-network.json: this.tasks.setupNetworkNodes('nodeAliases', true),
+        this.tasks.setupNetworkNodes('nodeAliases', false),
         this.changeAllNodeStates(ConsensusNodeStates.SETUP),
       ],
       {

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -1036,6 +1036,7 @@ export class NodeCommandTasks {
       );
       await sleep(Duration.ofSeconds(60));
       const accountMap = getNodeAccountMap(config.allNodeAliases);
+      let skipNodeAlias: NodeAlias;
 
       switch (transactionType) {
         case NodeSubcommandType.ADD:
@@ -1044,18 +1045,17 @@ export class NodeCommandTasks {
           if (config.newAccountNumber) {
             // update map with current account ids
             accountMap.set(config.nodeAlias, config.newAccountNumber);
-
-            // update _nodeClient with the new service map since one of the account number has changed
-            await self.accountManager.refreshNodeClient(config.namespace);
+            skipNodeAlias = config.nodeAlias;
           }
           break;
         case NodeSubcommandType.DELETE:
           if (config.nodeAlias) {
             accountMap.delete(config.nodeAlias);
+            skipNodeAlias = config.nodeAlias;
           }
       }
 
-      config.nodeClient = await self.accountManager.loadNodeClient(config.namespace);
+      config.nodeClient = await self.accountManager.refreshNodeClient(config.namespace, skipNodeAlias);
 
       // send some write transactions to invoke the handler that will trigger the stake weight recalculate
       for (const nodeAlias of accountMap.keys()) {

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -870,21 +870,23 @@ export class NodeCommandTasks {
     });
   }
 
-  setupNetworkNodes(nodeAliasesProperty: string) {
+  setupNetworkNodes(nodeAliasesProperty: string, isGenesis: boolean = false) {
     return new Task('Setup network nodes', async (ctx: any, task: ListrTaskWrapper<any, any, any>) => {
-      await this.generateGenesisNetworkJson(
-        ctx.config.namespace,
-        ctx.config.nodeAliases,
-        ctx.config.keysDir,
-        ctx.config.stagingDir,
-      );
+      if (isGenesis) {
+        await this.generateGenesisNetworkJson(
+          ctx.config.namespace,
+          ctx.config.nodeAliases,
+          ctx.config.keysDir,
+          ctx.config.stagingDir,
+        );
+      }
 
       const subTasks = [];
       for (const nodeAlias of ctx.config[nodeAliasesProperty]) {
         const podName = ctx.config.podNames[nodeAlias];
         subTasks.push({
           title: `Node: ${chalk.yellow(nodeAlias)}`,
-          task: () => this.platformInstaller.taskSetup(podName, ctx.config.stagingDir),
+          task: () => this.platformInstaller.taskSetup(podName, ctx.config.stagingDir, isGenesis),
         });
       }
 

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -1201,6 +1201,7 @@ export class NodeCommandTasks {
         values.hedera.nodes.push({
           accountId: networkNodeServices.accountId,
           name: networkNodeServices.nodeAlias,
+          nodeId: networkNodeServices.nodeId,
         });
         maxNum =
           maxNum > AccountId.fromString(networkNodeServices.accountId).num
@@ -1408,31 +1409,32 @@ export class NodeCommandTasks {
           config.serviceMap = await self.accountManager.getNodeServiceMap(config.namespace);
         }
 
-        const index = config.existingNodeAliases.length;
         let maxNodeId = 0;
         for (const nodeAlias of config.existingNodeAliases) {
           const nodeId = config.serviceMap.get(nodeAlias).nodeId;
           maxNodeId = Math.max(nodeId, maxNodeId);
         }
+
         const nodeId = maxNodeId + 1;
+        const index = config.existingNodeAliases.length;
 
         let valuesArg = '';
         for (let i = 0; i < index; i++) {
           if (transactionType === NodeSubcommandType.UPDATE && config.newAccountNumber && i === nodeId) {
             // for the case of updating node
             // use new account number for this node id
-            valuesArg += ` --set "hedera.nodes[${i}].accountId=${config.newAccountNumber}" --set "hedera.nodes[${i}].name=${config.existingNodeAliases[i]}"--set "hedera.nodes[${i}].node-id=${nodeId}" `;
+            valuesArg += ` --set "hedera.nodes[${i}].accountId=${config.newAccountNumber}" --set "hedera.nodes[${i}].name=${config.existingNodeAliases[i]}" --set "hedera.nodes[${i}].nodeId=${i}" `;
           } else if (transactionType !== NodeSubcommandType.DELETE || i !== nodeId) {
             // for the case of deleting node
-            valuesArg += ` --set "hedera.nodes[${i}].accountId=${config.serviceMap.get(config.existingNodeAliases[i]).accountId}" --set "hedera.nodes[${i}].name=${config.existingNodeAliases[i]}"`;
+            valuesArg += ` --set "hedera.nodes[${i}].accountId=${config.serviceMap.get(config.existingNodeAliases[i]).accountId}" --set "hedera.nodes[${i}].name=${config.existingNodeAliases[i]}" --set "hedera.nodes[${i}].nodeId=${i}" `;
           } else if (transactionType === NodeSubcommandType.DELETE && i === nodeId) {
-            valuesArg += ` --set "hedera.nodes[${i}].accountId=${IGNORED_NODE_ACCOUNT_ID}" --set "hedera.nodes[${i}].name=${config.existingNodeAliases[i]}"`;
+            valuesArg += ` --set "hedera.nodes[${i}].accountId=${IGNORED_NODE_ACCOUNT_ID}" --set "hedera.nodes[${i}].name=${config.existingNodeAliases[i]}" --set "hedera.nodes[${i}].nodeId=${i}" `;
           }
         }
 
         // for the case of adding a new node
         if (transactionType === NodeSubcommandType.ADD && ctx.newNode && ctx.newNode.accountId) {
-          valuesArg += ` --set "hedera.nodes[${index}].accountId=${ctx.newNode.accountId}" --set "hedera.nodes[${index}].name=${ctx.newNode.name}"`;
+          valuesArg += ` --set "hedera.nodes[${index}].accountId=${ctx.newNode.accountId}" --set "hedera.nodes[${index}].name=${ctx.newNode.name}" --set "hedera.nodes[${index}].nodeId=${nodeId}" `;
 
           if (config.haproxyIps) {
             config.haproxyIpsParsed = Templates.parseNodeAliasToIpMapping(config.haproxyIps);

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -24,8 +24,6 @@ import {type ChartManager} from '../../core/chart_manager.js';
 import {type CertificateManager} from '../../core/certificate_manager.js';
 import {Zippy} from '../../core/zippy.js';
 import * as constants from '../../core/constants.js';
-import {Templates} from '../../core/templates.js';
-import {Task} from '../../core/task.js';
 import {
   DEFAULT_NETWORK_NODE_NAME,
   FREEZE_ADMIN_ACCOUNT,
@@ -33,6 +31,8 @@ import {
   IGNORED_NODE_ACCOUNT_ID,
   TREASURY_ACCOUNT_ID,
 } from '../../core/constants.js';
+import {Templates} from '../../core/templates.js';
+import {Task} from '../../core/task.js';
 import {
   AccountBalanceQuery,
   AccountId,
@@ -42,10 +42,10 @@ import {
   FreezeTransaction,
   FreezeType,
   Long,
-  PrivateKey,
   NodeCreateTransaction,
   NodeDeleteTransaction,
   NodeUpdateTransaction,
+  PrivateKey,
   Timestamp,
 } from '@hashgraph/sdk';
 import {IllegalArgumentError, MissingArgumentError, SoloError} from '../../core/errors.js';
@@ -68,18 +68,17 @@ import {
   type ConfigBuilder,
   type NodeAlias,
   type NodeAliases,
-  type NodeId,
   type PodName,
   type SkipCheck,
 } from '../../types/aliases.js';
 import {NodeStatusCodes, NodeStatusEnums, NodeSubcommandType} from '../../core/enumerations.js';
-import * as x509 from '@peculiar/x509';
 import type {NodeDeleteConfigClass, NodeRefreshConfigClass, NodeUpdateConfigClass} from './configs.js';
 import {type Lease} from '../../core/lease/lease.js';
 import {ListrLease} from '../../core/lease/listr_lease.js';
 import {Duration} from '../../core/time/duration.js';
 import {type BaseCommand} from '../base.js';
 import {type NodeAddConfigClass} from './node_add_config.js';
+import {GenesisNetworkDataConstructor} from '../../core/genesis_network_models/genesis_network_data_constructor.js';
 
 export class NodeCommandTasks {
   private readonly accountManager: AccountManager;
@@ -305,16 +304,21 @@ export class NodeCommandTasks {
       config: {namespace},
     } = ctx;
 
+    const enableDebugger = ctx.config.debugNodeAlias && status !== NodeStatusCodes.FREEZE_COMPLETE;
+
     const subTasks = nodeAliases.map((nodeAlias, i) => {
       const reminder =
         'debugNodeAlias' in ctx.config &&
         ctx.config.debugNodeAlias === nodeAlias &&
         status !== NodeStatusCodes.FREEZE_COMPLETE
-          ? 'Please attach JVM debugger now.'
+          ? 'Please attach JVM debugger now.  Sleeping for 1 hour, hit ctrl-c once debugging is complete.'
           : '';
       const title = `Check network pod: ${chalk.yellow(nodeAlias)} ${chalk.red(reminder)}`;
 
       const subTask = async (ctx: any, task: ListrTaskWrapper<any, any, any>) => {
+        if (enableDebugger) {
+          await sleep(Duration.ofHours(1));
+        }
         ctx.config.podNames[nodeAlias] = await this._checkNetworkNodeActiveness(
           namespace,
           nodeAlias,
@@ -511,15 +515,6 @@ export class NodeCommandTasks {
     );
   }
 
-  _loadPermCertificate(certFullPath: string) {
-    const certPem = fs.readFileSync(certFullPath).toString();
-    const decodedDers = x509.PemConverter.decode(certPem);
-    if (!decodedDers || decodedDers.length === 0) {
-      throw new SoloError('unable to load perm key: ' + certFullPath);
-    }
-    return new Uint8Array(decodedDers[0]);
-  }
-
   async _addStake(
     namespace: string,
     accountId: string,
@@ -547,7 +542,7 @@ export class NodeCommandTasks {
       // Create the transaction
       const transaction = new AccountUpdateTransaction()
         .setAccountId(accountId)
-        .setStakedNodeId(Templates.nodeIdFromNodeAlias(nodeAlias) - 1)
+        .setStakedNodeId(Templates.nodeIdFromNodeAlias(nodeAlias))
         .freezeWith(client);
 
       // Sign the transaction with the account's private key
@@ -876,13 +871,20 @@ export class NodeCommandTasks {
   }
 
   setupNetworkNodes(nodeAliasesProperty: string) {
-    return new Task('Setup network nodes', (ctx: any, task: ListrTaskWrapper<any, any, any>) => {
+    return new Task('Setup network nodes', async (ctx: any, task: ListrTaskWrapper<any, any, any>) => {
+      await this.generateGenesisNetworkJson(
+        ctx.config.namespace,
+        ctx.config.nodeAliases,
+        ctx.config.keysDir,
+        ctx.config.stagingDir,
+      );
+
       const subTasks = [];
       for (const nodeAlias of ctx.config[nodeAliasesProperty]) {
         const podName = ctx.config.podNames[nodeAlias];
         subTasks.push({
           title: `Node: ${chalk.yellow(nodeAlias)}`,
-          task: () => this.platformInstaller.taskSetup(podName),
+          task: () => this.platformInstaller.taskSetup(podName, ctx.config.stagingDir),
         });
       }
 
@@ -892,6 +894,33 @@ export class NodeCommandTasks {
         rendererOptions: constants.LISTR_DEFAULT_RENDERER_OPTION,
       });
     });
+  }
+
+  /**
+   * Generate genesis network json file
+   * @private
+   * @param namespace - namespace
+   * @param nodeAliases - node aliases
+   * @param keysDir - keys directory
+   * @param stagingDir - staging directory
+   */
+  private async generateGenesisNetworkJson(
+    namespace: string,
+    nodeAliases: NodeAliases,
+    keysDir: string,
+    stagingDir: string,
+  ) {
+    const networkNodeServiceMap = await this.accountManager.getNodeServiceMap(namespace);
+
+    const genesisNetworkData = await GenesisNetworkDataConstructor.initialize(
+      nodeAliases,
+      this.keyManager,
+      keysDir,
+      networkNodeServiceMap,
+    );
+
+    const genesisNetworkJson = path.join(stagingDir, 'genesis-network.json');
+    fs.writeFileSync(genesisNetworkJson, genesisNetworkData.toJSON());
   }
 
   prepareStagingDirectory(nodeAliasesProperty: any) {
@@ -1215,7 +1244,7 @@ export class NodeCommandTasks {
       const config = ctx.config;
       const signingCertFile = Templates.renderGossipPemPublicKeyFile(config.nodeAlias);
       const signingCertFullPath = path.join(config.keysDir, signingCertFile);
-      ctx.signingCertDer = this._loadPermCertificate(signingCertFullPath);
+      ctx.signingCertDer = this.keyManager.getDerFromPemCertificate(signingCertFullPath);
     });
   }
 
@@ -1224,7 +1253,7 @@ export class NodeCommandTasks {
       const config = ctx.config;
       const tlsCertFile = Templates.renderTLSPemPublicKeyFile(config.nodeAlias);
       const tlsCertFullPath = path.join(config.keysDir, tlsCertFile);
-      const tlsCertDer = this._loadPermCertificate(tlsCertFullPath);
+      const tlsCertDer = this.keyManager.getDerFromPemCertificate(tlsCertFullPath);
       ctx.tlsCertHash = crypto.createHash('sha384').update(tlsCertDer).digest();
     });
   }
@@ -1292,7 +1321,7 @@ export class NodeCommandTasks {
     return new Task('Send node update transaction', async (ctx: any, task: ListrTaskWrapper<any, any, any>) => {
       const config: NodeUpdateConfigClass = ctx.config;
 
-      const nodeId = Templates.nodeIdFromNodeAlias(config.nodeAlias) - 1;
+      const nodeId = Templates.nodeIdFromNodeAlias(config.nodeAlias);
       self.logger.info(`nodeId: ${nodeId}, config.newAccountNumber: ${config.newAccountNumber}`);
 
       if (config.existingNodeAliases.length > 1) {
@@ -1305,7 +1334,7 @@ export class NodeCommandTasks {
 
         if (config.tlsPublicKey && config.tlsPrivateKey) {
           self.logger.info(`config.tlsPublicKey: ${config.tlsPublicKey}`);
-          const tlsCertDer = self._loadPermCertificate(config.tlsPublicKey);
+          const tlsCertDer = self.keyManager.getDerFromPemCertificate(config.tlsPublicKey);
           const tlsCertHash = crypto.createHash('sha384').update(tlsCertDer).digest();
           nodeUpdateTx = nodeUpdateTx.setCertificateHash(tlsCertHash);
 
@@ -1317,7 +1346,7 @@ export class NodeCommandTasks {
 
         if (config.gossipPublicKey && config.gossipPrivateKey) {
           self.logger.info(`config.gossipPublicKey: ${config.gossipPublicKey}`);
-          const signingCertDer = self._loadPermCertificate(config.gossipPublicKey);
+          const signingCertDer = self.keyManager.getDerFromPemCertificate(config.gossipPublicKey);
           nodeUpdateTx = nodeUpdateTx.setGossipCaCertificate(signingCertDer);
 
           const publicKeyFile = Templates.renderGossipPemPublicKeyFile(config.nodeAlias);
@@ -1378,14 +1407,19 @@ export class NodeCommandTasks {
         }
 
         const index = config.existingNodeAliases.length;
-        const nodeId = Templates.nodeIdFromNodeAlias(config.nodeAlias) - 1;
+        let maxNodeId = 0;
+        for (const nodeAlias of config.existingNodeAliases) {
+          const nodeId = config.serviceMap.get(nodeAlias).nodeId;
+          maxNodeId = Math.max(nodeId, maxNodeId);
+        }
+        const nodeId = maxNodeId + 1;
 
         let valuesArg = '';
         for (let i = 0; i < index; i++) {
           if (transactionType === NodeSubcommandType.UPDATE && config.newAccountNumber && i === nodeId) {
             // for the case of updating node
             // use new account number for this node id
-            valuesArg += ` --set "hedera.nodes[${i}].accountId=${config.newAccountNumber}" --set "hedera.nodes[${i}].name=${config.existingNodeAliases[i]}"`;
+            valuesArg += ` --set "hedera.nodes[${i}].accountId=${config.newAccountNumber}" --set "hedera.nodes[${i}].name=${config.existingNodeAliases[i]}"--set "hedera.nodes[${i}].node-id=${nodeId}" `;
           } else if (transactionType !== NodeSubcommandType.DELETE || i !== nodeId) {
             // for the case of deleting node
             valuesArg += ` --set "hedera.nodes[${i}].accountId=${config.serviceMap.get(config.existingNodeAliases[i]).accountId}" --set "hedera.nodes[${i}].name=${config.existingNodeAliases[i]}"`;
@@ -1407,8 +1441,7 @@ export class NodeCommandTasks {
           }
 
           const nodeAlias: NodeAlias = config.nodeAlias;
-          const nodeId: NodeId = Templates.nodeIdFromNodeAlias(nodeAlias);
-          const nodeIndexInValues = nodeId - 1;
+          const nodeIndexInValues = Templates.nodeIdFromNodeAlias(nodeAlias);
 
           // Set static IPs for HAProxy
           if (config.haproxyIpsParsed) {
@@ -1569,7 +1602,7 @@ export class NodeCommandTasks {
       async (ctx: any, task: ListrTaskWrapper<any, any, any>) => {
         const config = ctx.config;
         const newNodeFullyQualifiedPodName = Templates.renderNetworkPodName(config.nodeAlias);
-        const nodeId = Templates.nodeIdFromNodeAlias(config.nodeAlias) - 1;
+        const nodeId = Templates.nodeIdFromNodeAlias(config.nodeAlias);
         const savedStateDir = config.lastStateZipPath.match(/\/(\d+)\.zip$/)[1];
         const savedStatePath = `${constants.HEDERA_HAPI_PATH}/data/saved/com.hedera.services.ServicesMain/${nodeId}/123/${savedStateDir}`;
         await this.k8.execContainer(newNodeFullyQualifiedPodName, constants.ROOT_CONTAINER, [
@@ -1601,7 +1634,7 @@ export class NodeCommandTasks {
         const accountMap = getNodeAccountMap(config.existingNodeAliases);
         const deleteAccountId = accountMap.get(config.nodeAlias);
         this.logger.debug(`Deleting node: ${config.nodeAlias} with account: ${deleteAccountId}`);
-        const nodeId = Templates.nodeIdFromNodeAlias(config.nodeAlias) - 1;
+        const nodeId = Templates.nodeIdFromNodeAlias(config.nodeAlias);
         const nodeDeleteTx = new NodeDeleteTransaction().setNodeId(nodeId).freezeWith(config.nodeClient);
 
         const signedTx = await nodeDeleteTx.sign(config.adminKey);

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -1328,8 +1328,7 @@ export class NodeCommandTasks {
       self.logger.info(`nodeId: ${nodeId}, config.newAccountNumber: ${config.newAccountNumber}`);
 
       if (config.existingNodeAliases.length > 1) {
-        await self.accountManager.refreshNodeClient(config.namespace, config.nodeAlias);
-        config.nodeClient = await this.accountManager.loadNodeClient(config.namespace);
+        config.nodeClient = await self.accountManager.refreshNodeClient(config.namespace, config.nodeAlias);
       }
 
       try {

--- a/src/core/account_manager.ts
+++ b/src/core/account_manager.ts
@@ -194,6 +194,7 @@ export class AccountManager {
       treasuryAccountInfo.privateKey,
       skipNodeAlias,
     );
+    return this._nodeClient;
   }
 
   /**

--- a/src/core/genesis_network_models/genesis_network_data_wrapper.ts
+++ b/src/core/genesis_network_models/genesis_network_data_wrapper.ts
@@ -1,0 +1,34 @@
+/**
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the ""License"");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an ""AS IS"" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import type {NodeId} from '../../types/aliases.js';
+import type {ServiceEndpoint} from '../../types/index.js';
+
+export abstract class GenesisNetworkDataWrapper {
+  public gossipEndpoint: ServiceEndpoint[] = [];
+  public weight: number;
+  public gossipCaCertificate: string;
+
+  protected constructor(public readonly nodeId: NodeId) {}
+
+  /**
+   * @param domainName - a fully qualified domain name
+   * @param port
+   */
+  public addGossipEndpoint(domainName: string, port: number): void {
+    this.gossipEndpoint.push({domainName, port, ipAddressV4: ''});
+  }
+}

--- a/src/core/genesis_network_models/genesis_network_node_data_wrapper.ts
+++ b/src/core/genesis_network_models/genesis_network_node_data_wrapper.ts
@@ -15,24 +15,25 @@
  *
  */
 import type {AccountId, PublicKey} from '@hashgraph/sdk';
-import type {GenesisNetworkNodeStructure, ServiceEndpoint, ToObject} from '../../types/index.js';
+import type {GenesisNetworkNodeStructure, NodeAccountId, ServiceEndpoint, ToObject} from '../../types/index.js';
+import {GenesisNetworkDataWrapper} from './genesis_network_data_wrapper.js';
 
 export class GenesisNetworkNodeDataWrapper
-  implements GenesisNetworkNodeStructure, ToObject<{node: GenesisNetworkNodeStructure}>
+  extends GenesisNetworkDataWrapper
+  implements ToObject<GenesisNetworkNodeStructure>
 {
   public accountId: AccountId;
-  public gossipEndpoint: ServiceEndpoint[] = [];
   public serviceEndpoint: ServiceEndpoint[] = [];
-  public gossipCaCertificate: string;
   public grpcCertificateHash: string;
-  public weight: number;
   public readonly deleted = false;
 
   constructor(
     public readonly nodeId: number,
     public readonly adminKey: PublicKey,
     public readonly description: string,
-  ) {}
+  ) {
+    super(nodeId);
+  }
 
   /**
    * @param domainName - a fully qualified domain name
@@ -42,28 +43,18 @@ export class GenesisNetworkNodeDataWrapper
     this.serviceEndpoint.push({domainName, port, ipAddressV4: ''});
   }
 
-  /**
-   * @param domainName - a fully qualified domain name
-   * @param port
-   */
-  public addGossipEndpoint(domainName: string, port: number): void {
-    this.gossipEndpoint.push({domainName, port, ipAddressV4: ''});
-  }
-
   public toObject() {
     return {
-      node: {
-        nodeId: this.nodeId,
-        accountId: this.accountId,
-        description: this.description,
-        gossipEndpoint: this.gossipEndpoint,
-        serviceEndpoint: this.serviceEndpoint,
-        gossipCaCertificate: this.gossipCaCertificate,
-        grpcCertificateHash: this.grpcCertificateHash,
-        weight: this.weight,
-        deleted: this.deleted,
-        adminKey: this.adminKey,
-      },
+      nodeId: this.nodeId,
+      accountId: {accountNum: `${this.accountId.num}`} as unknown as NodeAccountId,
+      description: this.description,
+      gossipEndpoint: this.gossipEndpoint,
+      serviceEndpoint: this.serviceEndpoint,
+      gossipCaCertificate: this.gossipCaCertificate,
+      grpcCertificateHash: this.grpcCertificateHash,
+      weight: this.weight,
+      deleted: this.deleted,
+      adminKey: this.adminKey,
     };
   }
 }

--- a/src/core/genesis_network_models/genesis_network_roster_entry_data_wrapper.ts
+++ b/src/core/genesis_network_models/genesis_network_roster_entry_data_wrapper.ts
@@ -1,0 +1,37 @@
+/**
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the ""License"");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an ""AS IS"" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import {GenesisNetworkDataWrapper} from './genesis_network_data_wrapper.js';
+import type {NodeId} from '../../types/aliases.js';
+import type {GenesisNetworkRosterStructure, ToObject} from '../../types/index.js';
+
+export class GenesisNetworkRosterEntryDataWrapper
+  extends GenesisNetworkDataWrapper
+  implements GenesisNetworkRosterStructure, ToObject<GenesisNetworkRosterStructure>
+{
+  constructor(public readonly nodeId: NodeId) {
+    super(nodeId);
+  }
+
+  public toObject() {
+    return {
+      nodeId: this.nodeId,
+      gossipEndpoint: this.gossipEndpoint,
+      gossipCaCertificate: this.gossipCaCertificate,
+      weight: this.weight,
+    };
+  }
+}

--- a/src/core/helpers.ts
+++ b/src/core/helpers.ts
@@ -226,7 +226,7 @@ export function renameAndCopyFile(srcFilePath: string, expectedBaseName: string,
  */
 export function addDebugOptions(valuesArg: string, debugNodeAlias: NodeAlias, index = 0) {
   if (debugNodeAlias) {
-    const nodeId = Templates.nodeIdFromNodeAlias(debugNodeAlias) - 1;
+    const nodeId = Templates.nodeIdFromNodeAlias(debugNodeAlias);
     valuesArg += ` --set "hedera.nodes[${nodeId}].root.extraEnv[${index}].name=JAVA_OPTS"`;
     valuesArg += ` --set "hedera.nodes[${nodeId}].root.extraEnv[${index}].value=-agentlib:jdwp=transport=dt_socket\\,server=y\\,suspend=y\\,address=*:${constants.JVM_DEBUG_PORT}"`;
   }

--- a/src/core/k8.ts
+++ b/src/core/k8.ts
@@ -1696,7 +1696,11 @@ export class K8 {
    * @returns a promise that resolves when the state files are downloaded
    */
   async getNodeStatesFromPod(namespace: string, nodeAlias: string) {
-    const pods = await this.getPodsByLabel([`solo.hedera.com/node-name=${nodeAlias}`]);
+    const pods = await this.getPodsByLabel([
+      `solo.hedera.com/node-name=${nodeAlias}`,
+      'solo.hedera.com/type=network-node',
+    ]);
+
     // get length of pods
     const promises = [];
     for (const pod of pods) {

--- a/src/core/key_manager.ts
+++ b/src/core/key_manager.ts
@@ -509,4 +509,17 @@ export class KeyManager {
 
     return subTasks;
   }
+
+  /**
+   * Given the path to the PEM certificate (Base64 ASCII), will return the DER (raw binary) bytes
+   * @param pemCertFullPath
+   */
+  getDerFromPemCertificate(pemCertFullPath: string) {
+    const certPem = fs.readFileSync(pemCertFullPath).toString();
+    const decodedDers = x509.PemConverter.decode(certPem);
+    if (!decodedDers || decodedDers.length === 0) {
+      throw new SoloError('unable to load perm key: ' + pemCertFullPath);
+    }
+    return new Uint8Array(decodedDers[0]);
+  }
 }

--- a/src/core/network_node_services.ts
+++ b/src/core/network_node_services.ts
@@ -19,6 +19,8 @@ import type {NodeAlias, PodName} from '../types/aliases.js';
 
 export class NetworkNodeServices {
   public readonly nodeAlias: NodeAlias;
+  public readonly namespace: string;
+  public readonly nodeId: string | number;
   public readonly nodePodName?: PodName;
   public readonly haProxyName?: string;
   public readonly haProxyLoadBalancerIp?: string;
@@ -41,6 +43,8 @@ export class NetworkNodeServices {
 
   constructor(builder: NetworkNodeServicesBuilder) {
     this.nodeAlias = builder.nodeAlias;
+    this.namespace = builder.namespace;
+    this.nodeId = builder.nodeId;
     this.nodePodName = builder.nodePodName;
     this.haProxyName = builder.haProxyName;
     this.haProxyLoadBalancerIp = builder.haProxyLoadBalancerIp;
@@ -68,6 +72,8 @@ export class NetworkNodeServices {
 }
 
 export class NetworkNodeServicesBuilder {
+  public namespace?: string;
+  public nodeId?: string | number;
   public haProxyName?: string;
   public accountId?: string;
   public haProxyClusterIp!: string;
@@ -90,6 +96,16 @@ export class NetworkNodeServicesBuilder {
   public nodePodName?: PodName;
 
   constructor(public readonly nodeAlias: NodeAlias) {}
+
+  withNamespace(namespace: string) {
+    this.namespace = namespace;
+    return this;
+  }
+
+  withNodeId(nodeId: string | number) {
+    this.nodeId = nodeId;
+    return this;
+  }
 
   withAccountId(accountId: string) {
     this.accountId = accountId;

--- a/src/core/platform_installer.ts
+++ b/src/core/platform_installer.ts
@@ -278,10 +278,16 @@ export class PlatformInstaller {
   }
 
   /** Return a list of task to perform node directory setup */
-  taskSetup(podName: PodName) {
+  taskSetup(podName: PodName, stagingDir: string) {
     const self = this;
     return new Listr(
       [
+        {
+          title: 'Copy configuration files',
+          task: async () => {
+            await this.copyConfigurationFiles(stagingDir, podName);
+          },
+        },
         {
           title: 'Set file permissions',
           task: async () => await self.setPlatformDirPermissions(podName),
@@ -294,6 +300,17 @@ export class PlatformInstaller {
         },
       },
     );
+  }
+
+  /**
+   * Copy configuration files to the network consensus node pod
+   * @param stagingDir - staging directory path
+   * @param podName - network consensus node pod name
+   * @private
+   */
+  private async copyConfigurationFiles(stagingDir: string, podName: `network-node${number}-0`) {
+    const genesisNetworkJson = [path.join(stagingDir, 'genesis-network.json')];
+    await this.copyFiles(podName, genesisNetworkJson, `${constants.HEDERA_HAPI_PATH}/data/config`);
   }
 
   /**

--- a/src/core/platform_installer.ts
+++ b/src/core/platform_installer.ts
@@ -278,14 +278,14 @@ export class PlatformInstaller {
   }
 
   /** Return a list of task to perform node directory setup */
-  taskSetup(podName: PodName, stagingDir: string) {
+  taskSetup(podName: PodName, stagingDir: string, isGenesis: boolean) {
     const self = this;
     return new Listr(
       [
         {
           title: 'Copy configuration files',
           task: async () => {
-            await this.copyConfigurationFiles(stagingDir, podName);
+            await this.copyConfigurationFiles(stagingDir, podName, isGenesis);
           },
         },
         {
@@ -306,11 +306,14 @@ export class PlatformInstaller {
    * Copy configuration files to the network consensus node pod
    * @param stagingDir - staging directory path
    * @param podName - network consensus node pod name
+   * @param isGenesis - true if this is `solo node setup` and we are at genesis
    * @private
    */
-  private async copyConfigurationFiles(stagingDir: string, podName: `network-node${number}-0`) {
-    const genesisNetworkJson = [path.join(stagingDir, 'genesis-network.json')];
-    await this.copyFiles(podName, genesisNetworkJson, `${constants.HEDERA_HAPI_PATH}/data/config`);
+  private async copyConfigurationFiles(stagingDir: string, podName: `network-node${number}-0`, isGenesis: boolean) {
+    if (isGenesis) {
+      const genesisNetworkJson = [path.join(stagingDir, 'genesis-network.json')];
+      await this.copyFiles(podName, genesisNetworkJson, `${constants.HEDERA_HAPI_PATH}/data/config`);
+    }
   }
 
   /**

--- a/src/core/platform_installer.ts
+++ b/src/core/platform_installer.ts
@@ -284,9 +284,7 @@ export class PlatformInstaller {
       [
         {
           title: 'Copy configuration files',
-          task: async () => {
-            await this.copyConfigurationFiles(stagingDir, podName, isGenesis);
-          },
+          task: async () => await self.copyConfigurationFiles(stagingDir, podName, isGenesis),
         },
         {
           title: 'Set file permissions',

--- a/src/core/profile_manager.ts
+++ b/src/core/profile_manager.ts
@@ -200,7 +200,7 @@ export class ProfileManager {
     // set consensus pod level resources
     for (let nodeIndex = 0; nodeIndex < nodeAliases.length; nodeIndex++) {
       this._setValue(`hedera.nodes.${nodeIndex}.name`, nodeAliases[nodeIndex], yamlRoot);
-      this._setValue(`hedera.nodes.${nodeIndex}.nodeId`, nodeIndex, yamlRoot);
+      this._setValue(`hedera.nodes.${nodeIndex}.nodeId`, `${nodeIndex}`, yamlRoot);
       this._setValue(`hedera.nodes.${nodeIndex}.accountId`, accountMap.get(nodeAliases[nodeIndex]), yamlRoot);
     }
 

--- a/src/core/templates.ts
+++ b/src/core/templates.ts
@@ -173,7 +173,7 @@ export class Templates {
     for (let i = nodeAlias.length - 1; i > 0; i--) {
       // @ts-ignore
       if (isNaN(nodeAlias[i])) {
-        return parseInt(nodeAlias.substring(i + 1, nodeAlias.length));
+        return parseInt(nodeAlias.substring(i + 1, nodeAlias.length)) - 1;
       }
     }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -103,9 +103,15 @@ export interface ServiceEndpoint {
   domainName: string;
 }
 
+export interface NodeAccountId {
+  accountId: {
+    accountNum: string;
+  };
+}
+
 export interface GenesisNetworkNodeStructure {
   nodeId: number;
-  accountId: AccountId;
+  accountId: NodeAccountId;
   description: string;
   gossipEndpoint: ServiceEndpoint[];
   serviceEndpoint: ServiceEndpoint[];
@@ -114,4 +120,11 @@ export interface GenesisNetworkNodeStructure {
   weight: number;
   deleted: boolean;
   adminKey: PublicKey;
+}
+
+export interface GenesisNetworkRosterStructure {
+  nodeId: number;
+  weight: number;
+  gossipEndpoint: ServiceEndpoint[];
+  gossipCaCertificate: string;
 }

--- a/test/e2e/commands/node_delete.test.ts
+++ b/test/e2e/commands/node_delete.test.ts
@@ -33,10 +33,10 @@ import * as NodeCommandConfigs from '../../../src/commands/node/configs.js';
 import {Duration} from '../../../src/core/time/duration.js';
 
 const namespace = 'node-delete';
-const nodeAlias = 'node1';
+const deleteNodeAlias = 'node1';
 const argv = getDefaultArgv();
 argv[flags.nodeAliasesUnparsed.name] = 'node1,node2';
-argv[flags.nodeAlias.name] = nodeAlias;
+argv[flags.nodeAlias.name] = deleteNodeAlias;
 argv[flags.stakeAmounts.name] = '1,1000';
 argv[flags.generateGossipKeys.name] = true;
 argv[flags.generateTlsKeys.name] = true;
@@ -74,9 +74,9 @@ e2eTestSuite(namespace, argv, undefined, undefined, undefined, undefined, undefi
       await bootstrapResp.opts.accountManager.close();
     }).timeout(Duration.ofMinutes(10).toMillis());
 
-    balanceQueryShouldSucceed(bootstrapResp.opts.accountManager, nodeCmd, namespace);
+    balanceQueryShouldSucceed(bootstrapResp.opts.accountManager, nodeCmd, namespace, deleteNodeAlias);
 
-    accountCreationShouldSucceed(bootstrapResp.opts.accountManager, nodeCmd, namespace);
+    accountCreationShouldSucceed(bootstrapResp.opts.accountManager, nodeCmd, namespace, deleteNodeAlias);
 
     it('config.txt should no longer contain removed node alias name', async () => {
       // read config.txt file from first node, read config.txt line by line, it should not contain value of nodeAlias
@@ -86,7 +86,7 @@ e2eTestSuite(namespace, argv, undefined, undefined, undefined, undefined, undefi
       await k8.copyFrom(podName, ROOT_CONTAINER, `${HEDERA_HAPI_PATH}/config.txt`, tmpDir);
       const configTxt = fs.readFileSync(`${tmpDir}/config.txt`, 'utf8');
       console.log('config.txt:', configTxt);
-      expect(configTxt).not.to.contain(nodeAlias);
+      expect(configTxt).not.to.contain(deleteNodeAlias);
     }).timeout(Duration.ofMinutes(10).toMillis());
   });
 });

--- a/test/e2e/commands/node_local_hedera.test.ts
+++ b/test/e2e/commands/node_local_hedera.test.ts
@@ -110,8 +110,8 @@ e2eTestSuite(
 
       it('get the logs and delete the namespace', async () => {
         await accountManager.close();
-        // await hederaK8.getNodeLogs(LOCAL_HEDERA);
-        // await hederaK8.deleteNamespace(LOCAL_HEDERA);
+        await hederaK8.getNodeLogs(LOCAL_HEDERA);
+        await hederaK8.deleteNamespace(LOCAL_HEDERA);
       }).timeout(Duration.ofMinutes(10).toMillis());
     });
   },

--- a/test/e2e/commands/node_local_hedera.test.ts
+++ b/test/e2e/commands/node_local_hedera.test.ts
@@ -110,8 +110,8 @@ e2eTestSuite(
 
       it('get the logs and delete the namespace', async () => {
         await accountManager.close();
-        await hederaK8.getNodeLogs(LOCAL_HEDERA);
-        await hederaK8.deleteNamespace(LOCAL_HEDERA);
+        // await hederaK8.getNodeLogs(LOCAL_HEDERA);
+        // await hederaK8.deleteNamespace(LOCAL_HEDERA);
       }).timeout(Duration.ofMinutes(10).toMillis());
     });
   },

--- a/test/e2e/commands/node_update.test.ts
+++ b/test/e2e/commands/node_update.test.ts
@@ -115,9 +115,9 @@ e2eTestSuite(namespace, argv, undefined, undefined, undefined, undefined, undefi
       await bootstrapResp.opts.accountManager.close();
     }).timeout(Duration.ofMinutes(30).toMillis());
 
-    balanceQueryShouldSucceed(bootstrapResp.opts.accountManager, nodeCmd, namespace);
+    balanceQueryShouldSucceed(bootstrapResp.opts.accountManager, nodeCmd, namespace, updateNodeId);
 
-    accountCreationShouldSucceed(bootstrapResp.opts.accountManager, nodeCmd, namespace);
+    accountCreationShouldSucceed(bootstrapResp.opts.accountManager, nodeCmd, namespace, updateNodeId);
 
     it('signing key and tls key should not match previous one', async () => {
       const currentNodeIdsPrivateKeysHash = await getNodeAliasesPrivateKeysHash(

--- a/test/e2e/commands/separate_node_delete.test.ts
+++ b/test/e2e/commands/separate_node_delete.test.ts
@@ -86,9 +86,9 @@ e2eTestSuite(namespace, argv, undefined, undefined, undefined, undefined, undefi
       await bootstrapResp.opts.accountManager.close();
     }).timeout(Duration.ofMinutes(10).toMillis());
 
-    balanceQueryShouldSucceed(bootstrapResp.opts.accountManager, nodeCmd, namespace);
+    balanceQueryShouldSucceed(bootstrapResp.opts.accountManager, nodeCmd, namespace, nodeAlias);
 
-    accountCreationShouldSucceed(bootstrapResp.opts.accountManager, nodeCmd, namespace);
+    accountCreationShouldSucceed(bootstrapResp.opts.accountManager, nodeCmd, namespace, nodeAlias);
 
     it('config.txt should no longer contain removed nodeAlias', async () => {
       // read config.txt file from first node, read config.txt line by line, it should not contain value of nodeAlias

--- a/test/e2e/commands/separate_node_update.test.ts
+++ b/test/e2e/commands/separate_node_update.test.ts
@@ -126,9 +126,9 @@ e2eTestSuite(namespace, argv, undefined, undefined, undefined, undefined, undefi
       await bootstrapResp.opts.accountManager.close();
     }).timeout(Duration.ofMinutes(30).toMillis());
 
-    balanceQueryShouldSucceed(bootstrapResp.opts.accountManager, nodeCmd, namespace);
+    balanceQueryShouldSucceed(bootstrapResp.opts.accountManager, nodeCmd, namespace, updateNodeId);
 
-    accountCreationShouldSucceed(bootstrapResp.opts.accountManager, nodeCmd, namespace);
+    accountCreationShouldSucceed(bootstrapResp.opts.accountManager, nodeCmd, namespace, updateNodeId);
 
     it('signing key and tls key should not match previous one', async () => {
       const currentNodeIdsPrivateKeysHash = await getNodeAliasesPrivateKeysHash(

--- a/test/test_util.ts
+++ b/test/test_util.ts
@@ -336,11 +336,16 @@ export function e2eTestSuite(
   });
 }
 
-export function balanceQueryShouldSucceed(accountManager: AccountManager, cmd: BaseCommand, namespace: string) {
+export function balanceQueryShouldSucceed(
+  accountManager: AccountManager,
+  cmd: BaseCommand,
+  namespace: string,
+  skipNodeAlias?: NodeAlias,
+) {
   it('Balance query should succeed', async () => {
     try {
       expect(accountManager._nodeClient).to.be.null;
-      await accountManager.loadNodeClient(namespace);
+      await accountManager.refreshNodeClient(namespace, skipNodeAlias);
       expect(accountManager._nodeClient).not.to.be.null;
 
       const balance = await new AccountBalanceQuery()
@@ -356,10 +361,15 @@ export function balanceQueryShouldSucceed(accountManager: AccountManager, cmd: B
   }).timeout(Duration.ofMinutes(2).toMillis());
 }
 
-export function accountCreationShouldSucceed(accountManager: AccountManager, nodeCmd: BaseCommand, namespace: string) {
+export function accountCreationShouldSucceed(
+  accountManager: AccountManager,
+  nodeCmd: BaseCommand,
+  namespace: string,
+  skipNodeAlias?: NodeAlias,
+) {
   it('Account creation should succeed', async () => {
     try {
-      await accountManager.loadNodeClient(namespace);
+      await accountManager.refreshNodeClient(namespace, skipNodeAlias);
       expect(accountManager._nodeClient).not.to.be.null;
       const privateKey = PrivateKey.generate();
       const amount = 100;

--- a/version.ts
+++ b/version.ts
@@ -20,7 +20,7 @@
  */
 
 export const HELM_VERSION = 'v3.14.2';
-export const SOLO_CHART_VERSION = '0.40.0';
+export const SOLO_CHART_VERSION = '0.41.0';
 export const HEDERA_PLATFORM_VERSION = 'v0.58.1';
 export const MIRROR_NODE_VERSION = '0.118.1';
 export const HEDERA_EXPLORER_VERSION = '0.2.1';


### PR DESCRIPTION
## Description

This pull request changes the following:

* update genesis-network.json to add roster entries
* updated prettier to set print width to 120
* pass the node ID to the solo-chart to set the labels and env vars
* update genesis-network.json to use node IDs from network consensus pods
* fixed Templates.nodeIdFromNodeAlias(config.nodeAlias) - 1 issue
* fixed taskfile issue for removing files that might belong to another user
* added debug node alias setting to taskfile
* added solo charts dir setting to taskfile
* fixed taskfile issue that cause solo npm install multiple times and to the wrong directory if ran from repo root directory
* added `--load-balancer` enabled flag to `solo network deploy` because solo-charts now defaults to ClusterIP
* moved genesis network json creation and copying into `solo node setup`
* added more sleep time for when debug is enabled to give time to debug
* added node ID and namespace to NetworkNodeServiceBuilder
* bumped solo-chart to v0.41.0
* disabled `addressBook.useRosterLifecycle=true` as the `genesis-network.json` pathway does not work when the network comes back up after being stopped due to invalid signature errors

### Related Issues

* Closes #1031 
* Closes #943 
* Closes #1057 
* Closes #1059 
* Closes #1107
