### PR TITLE
fix: Bug when running `solo cluster connect` after fresh install

### DIFF
--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -31,6 +31,8 @@ import {type CommandFlag} from '../types/flag_types.js';
 import {type Lease} from '../core/lease/lease.js';
 import {Listr} from 'listr2';
 import path from 'path';
+import * as constants from '../core/constants.js';
+import fs from 'fs';
 
 export interface CommandHandlers {
   parent: BaseCommand;
@@ -219,5 +221,34 @@ export abstract class BaseCommand extends ShellRunner {
         await Promise.all(promises);
       }
     };
+  }
+
+  /**
+   * Setup home directories
+   * @param dirs a list of directories that need to be created in sequence
+   */
+  setupHomeDirectory(
+    dirs: string[] = [
+      constants.SOLO_HOME_DIR,
+      constants.SOLO_LOGS_DIR,
+      constants.SOLO_CACHE_DIR,
+      constants.SOLO_VALUES_DIR,
+    ],
+  ) {
+    const self = this;
+
+    try {
+      dirs.forEach(dirPath => {
+        if (!fs.existsSync(dirPath)) {
+          fs.mkdirSync(dirPath, {recursive: true});
+        }
+        self.logger.debug(`OK: setup directory: ${dirPath}`);
+      });
+    } catch (e: Error | any) {
+      this.logger.error(e);
+      throw new SoloError(`failed to create directory: ${e.message}`, e);
+    }
+
+    return dirs;
   }
 }

--- a/src/commands/cluster/handlers.ts
+++ b/src/commands/cluster/handlers.ts
@@ -43,6 +43,7 @@ export class ClusterCommandHandlers implements CommandHandlers {
     const action = this.parent.commandActionBuilder(
       [
         this.tasks.initialize(argv, connectConfigBuilder.bind(this)),
+        this.tasks.setupHomeDirectory(),
         this.parent.getLocalConfig().promptLocalConfigTask(this.parent.getK8()),
         this.tasks.selectContext(argv),
         RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),

--- a/src/commands/cluster/tasks.ts
+++ b/src/commands/cluster/tasks.ts
@@ -331,4 +331,10 @@ export class ClusterCommandTasks {
       ctx => !ctx.isChartInstalled,
     );
   }
+
+  setupHomeDirectory() {
+    return new Task('Setup home directory', async () => {
+      this.parent.setupHomeDirectory();
+    });
+  }
 }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -27,35 +27,6 @@ import chalk from 'chalk';
  * Defines the core functionalities of 'init' command
  */
 export class InitCommand extends BaseCommand {
-  /**
-   * Setup home directories
-   * @param dirs a list of directories that need to be created in sequence
-   */
-  setupHomeDirectory(
-    dirs: string[] = [
-      constants.SOLO_HOME_DIR,
-      constants.SOLO_LOGS_DIR,
-      constants.SOLO_CACHE_DIR,
-      constants.SOLO_VALUES_DIR,
-    ],
-  ) {
-    const self = this;
-
-    try {
-      dirs.forEach(dirPath => {
-        if (!fs.existsSync(dirPath)) {
-          fs.mkdirSync(dirPath, {recursive: true});
-        }
-        self.logger.debug(`OK: setup directory: ${dirPath}`);
-      });
-    } catch (e: Error | any) {
-      this.logger.error(e);
-      throw new SoloError(`failed to create directory: ${e.message}`, e);
-    }
-
-    return dirs;
-  }
-
   /** Executes the init CLI command */
   async init(argv: any) {
     const self = this;


### PR DESCRIPTION
## Description

Adds a new task to `solo cluster connect` for creating all home directories in case any of them are missing.

### Related Issues

* Closes #1121
