### PR TITLE
fix: bump solo-charts to 0.42.2 to pull in blockStreams fix

### DIFF
--- a/version.ts
+++ b/version.ts
@@ -20,7 +20,7 @@
  */
 
 export const HELM_VERSION = 'v3.14.2';
-export const SOLO_CHART_VERSION = '0.42.0';
+export const SOLO_CHART_VERSION = '0.42.2';
 export const HEDERA_PLATFORM_VERSION = 'v0.58.1';
 export const MIRROR_NODE_VERSION = '0.118.1';
 export const HEDERA_EXPLORER_VERSION = '0.2.1';


### PR DESCRIPTION
## Description

This pull request changes the following:

* bump solo-charts to 0.42.2 to pull in blockStreams fix

### Related Issues

* Closes #
