### PR TITLE
fix: file size empty error when throttle file is provided on command line

### DIFF
--- a/src/core/helpers.ts
+++ b/src/core/helpers.ts
@@ -366,7 +366,7 @@ export function resolveValidJsonFilePath(filePath: string, defaultPath?: string)
   const throttleInfo = fs.statSync(resolvedFilePath);
   if (throttleInfo.size === 0 && defaultPath) {
     return resolveValidJsonFilePath(defaultPath, null);
-  } else if (!defaultPath) {
+  } else if (throttleInfo.size === 0) {
     throw new SoloError(`File is empty: ${filePath}`);
   }
 


### PR DESCRIPTION
## Description

This pull request changes the following:

* fix file size empty error when throttle file is provided on command line

### Related Issues

* Closes #1139 
