### PR TITLE
feat: solo network destroy should update remote-config

### DIFF
--- a/src/core/config/local_config.ts
+++ b/src/core/config/local_config.ts
@@ -169,7 +169,7 @@ export class LocalConfig implements LocalConfigData {
       title: 'Prompt local configuration',
       skip: this.skipPromptTask,
       task: async (_: any, task: SoloListrTaskWrapper<any>): Promise<void> => {
-        if (self.configFileExists) {
+        if (self.configFileExists()) {
           self.configManager.setFlag(flags.userEmailAddress, self.userEmailAddress);
         }
 

--- a/src/core/config/remote/remote_config_manager.ts
+++ b/src/core/config/remote/remote_config_manager.ts
@@ -221,6 +221,13 @@ export class RemoteConfigManager {
 
   /* ---------- Utilities ---------- */
 
+  /** Empties the component data inside the remote config */
+  public async deleteComponents() {
+    await this.modify(async remoteConfig => {
+      remoteConfig.components = ComponentsDataWrapper.initializeEmpty();
+    });
+  }
+
   public isLoaded(): boolean {
     return !!this.remoteConfig;
   }


### PR DESCRIPTION
## Description

When `network destroy` is called and the namespace will be emptied but not deleted, remote config's components data will be emptied. 

### Related Issues

* Closes [#965](https://github.com/hashgraph/solo/issues/965)
