### PR TITLE
feat: Update solo to load remote config near entry point

### DIFF
--- a/src/commands/mirror_node.ts
+++ b/src/commands/mirror_node.ts
@@ -278,7 +278,6 @@ export class MirrorNodeCommand extends BaseCommand {
             return ListrLease.newAcquireLeaseTask(lease, task);
           },
         },
-        RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),
         {
           title: 'Enable mirror-node',
           task: (_, parentTask) => {
@@ -597,7 +596,6 @@ export class MirrorNodeCommand extends BaseCommand {
             return ListrLease.newAcquireLeaseTask(lease, task);
           },
         },
-        RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),
         {
           title: 'Destroy mirror-node',
           task: async ctx => {

--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -509,7 +509,6 @@ export class NetworkCommand extends BaseCommand {
             return ListrLease.newAcquireLeaseTask(lease, task);
           },
         },
-        RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),
         {
           title: 'Copy gRPC TLS Certificates',
           task: (ctx, parentTask) =>

--- a/src/commands/node/handlers.ts
+++ b/src/commands/node/handlers.ts
@@ -685,10 +685,7 @@ export class NodeCommandHandlers implements CommandHandlers {
   async logs(argv: any) {
     argv = helpers.addFlagsToArgv(argv, NodeFlags.LOGS_FLAGS);
     const action = this.parent.commandActionBuilder(
-      [
-        this.tasks.initialize(argv, logsConfigBuilder.bind(this), null),
-        this.tasks.getNodeLogsAndConfigs(),
-      ],
+      [this.tasks.initialize(argv, logsConfigBuilder.bind(this), null), this.tasks.getNodeLogsAndConfigs()],
       {
         concurrent: false,
         rendererOptions: constants.LISTR_DEFAULT_RENDERER_OPTION,

--- a/src/commands/node/handlers.ts
+++ b/src/commands/node/handlers.ts
@@ -104,7 +104,6 @@ export class NodeCommandHandlers implements CommandHandlers {
   deletePrepareTaskList(argv: any, lease: Lease) {
     return [
       this.tasks.initialize(argv, deleteConfigBuilder.bind(this), lease),
-      RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),
       this.validateSingleNodeState({excludedStates: []}),
       this.tasks.identifyExistingNodes(),
       this.tasks.loadAdminKey(),
@@ -148,7 +147,6 @@ export class NodeCommandHandlers implements CommandHandlers {
   addPrepareTasks(argv: any, lease: Lease) {
     return [
       this.tasks.initialize(argv, addConfigBuilder.bind(this), lease),
-      RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),
       this.validateSingleNodeState({excludedStates: []}),
       this.tasks.checkPVCsEnabled(),
       this.tasks.identifyExistingNodes(),
@@ -201,7 +199,6 @@ export class NodeCommandHandlers implements CommandHandlers {
   updatePrepareTasks(argv, lease: Lease) {
     return [
       this.tasks.initialize(argv, updateConfigBuilder.bind(this), lease),
-      RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),
       this.validateSingleNodeState({excludedStates: []}),
       this.tasks.identifyExistingNodes(),
       this.tasks.loadAdminKey(),
@@ -246,7 +243,6 @@ export class NodeCommandHandlers implements CommandHandlers {
   upgradePrepareTasks(argv, lease: Lease) {
     return [
       this.tasks.initialize(argv, upgradeConfigBuilder.bind(this), lease),
-      RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),
       this.validateSingleNodeState({excludedStates: []}),
       this.tasks.identifyExistingNodes(),
       this.tasks.loadAdminKey(),
@@ -282,7 +278,6 @@ export class NodeCommandHandlers implements CommandHandlers {
     const action = this.parent.commandActionBuilder(
       [
         this.tasks.initialize(argv, prepareUpgradeConfigBuilder.bind(this), lease),
-        RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),
         this.tasks.prepareUpgradeZip(),
         this.tasks.sendPrepareUpgradeTransaction(),
       ],
@@ -304,7 +299,6 @@ export class NodeCommandHandlers implements CommandHandlers {
     const action = this.parent.commandActionBuilder(
       [
         this.tasks.initialize(argv, prepareUpgradeConfigBuilder.bind(this), null),
-        RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),
         this.tasks.prepareUpgradeZip(),
         this.tasks.sendFreezeUpgradeTransaction(),
       ],
@@ -328,7 +322,6 @@ export class NodeCommandHandlers implements CommandHandlers {
     const action = this.parent.commandActionBuilder(
       [
         this.tasks.initialize(argv, downloadGeneratedFilesConfigBuilder.bind(this), lease),
-        RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),
         this.tasks.identifyExistingNodes(),
         this.tasks.downloadNodeGeneratedFiles(),
       ],
@@ -394,7 +387,6 @@ export class NodeCommandHandlers implements CommandHandlers {
     const action = this.parent.commandActionBuilder(
       [
         this.tasks.initialize(argv, updateConfigBuilder.bind(this), lease),
-        RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),
         this.tasks.loadContextData(argv, NodeCommandHandlers.UPDATE_CONTEXT_FILE, NodeHelper.updateLoadContextParser),
         ...this.updateSubmitTransactionsTasks(argv),
       ],
@@ -416,7 +408,6 @@ export class NodeCommandHandlers implements CommandHandlers {
     const action = this.parent.commandActionBuilder(
       [
         this.tasks.initialize(argv, updateConfigBuilder.bind(this), lease, false),
-        RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),
         this.tasks.loadContextData(argv, NodeCommandHandlers.UPDATE_CONTEXT_FILE, NodeHelper.updateLoadContextParser),
         ...this.updateExecuteTasks(argv),
       ],
@@ -457,7 +448,6 @@ export class NodeCommandHandlers implements CommandHandlers {
     const action = this.parent.commandActionBuilder(
       [
         this.tasks.initialize(argv, upgradeConfigBuilder.bind(this), lease),
-        RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),
         this.tasks.loadContextData(argv, NodeCommandHandlers.UPGRADE_CONTEXT_FILE, NodeHelper.upgradeLoadContextParser),
         ...this.upgradeSubmitTransactionsTasks(argv),
       ],
@@ -479,7 +469,6 @@ export class NodeCommandHandlers implements CommandHandlers {
     const action = this.parent.commandActionBuilder(
       [
         this.tasks.initialize(argv, upgradeConfigBuilder.bind(this), lease, false),
-        RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),
         this.tasks.loadContextData(argv, NodeCommandHandlers.UPGRADE_CONTEXT_FILE, NodeHelper.upgradeLoadContextParser),
         ...this.upgradeExecuteTasks(argv),
       ],
@@ -654,7 +643,6 @@ export class NodeCommandHandlers implements CommandHandlers {
     const action = this.parent.commandActionBuilder(
       [
         this.tasks.initialize(argv, addConfigBuilder.bind(this), lease),
-        RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),
         this.tasks.loadContextData(argv, NodeCommandHandlers.ADD_CONTEXT_FILE, helpers.addLoadContextParser),
         ...this.addSubmitTransactionsTasks(argv),
       ],
@@ -678,7 +666,6 @@ export class NodeCommandHandlers implements CommandHandlers {
     const action = this.parent.commandActionBuilder(
       [
         this.tasks.initialize(argv, addConfigBuilder.bind(this), lease, false),
-        RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),
         this.tasks.identifyExistingNodes(),
         this.tasks.loadContextData(argv, NodeCommandHandlers.ADD_CONTEXT_FILE, helpers.addLoadContextParser),
         ...this.addExecuteTasks(argv),
@@ -700,7 +687,6 @@ export class NodeCommandHandlers implements CommandHandlers {
     const action = this.parent.commandActionBuilder(
       [
         this.tasks.initialize(argv, logsConfigBuilder.bind(this), null),
-        RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),
         this.tasks.getNodeLogsAndConfigs(),
       ],
       {
@@ -740,7 +726,6 @@ export class NodeCommandHandlers implements CommandHandlers {
     const action = this.parent.commandActionBuilder(
       [
         this.tasks.initialize(argv, refreshConfigBuilder.bind(this), lease),
-        RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),
         this.validateAllNodeStates({
           acceptedStates: [ConsensusNodeStates.STARTED, ConsensusNodeStates.SETUP, ConsensusNodeStates.INITIALIZED],
         }),
@@ -794,7 +779,6 @@ export class NodeCommandHandlers implements CommandHandlers {
     const action = this.parent.commandActionBuilder(
       [
         this.tasks.initialize(argv, stopConfigBuilder.bind(this), lease),
-        RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),
         this.validateAllNodeStates({
           acceptedStates: [ConsensusNodeStates.STARTED, ConsensusNodeStates.SETUP],
         }),
@@ -822,7 +806,6 @@ export class NodeCommandHandlers implements CommandHandlers {
     const action = this.parent.commandActionBuilder(
       [
         this.tasks.initialize(argv, startConfigBuilder.bind(this), lease),
-        RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),
         this.validateAllNodeStates({acceptedStates: [ConsensusNodeStates.SETUP]}),
         this.tasks.identifyExistingNodes(),
         this.tasks.uploadStateFiles((ctx: any) => ctx.config.stateFile.length === 0),
@@ -853,7 +836,6 @@ export class NodeCommandHandlers implements CommandHandlers {
     const action = this.parent.commandActionBuilder(
       [
         this.tasks.initialize(argv, setupConfigBuilder.bind(this), lease),
-        RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),
         this.validateAllNodeStates({
           acceptedStates: [ConsensusNodeStates.INITIALIZED],
         }),

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -221,7 +221,6 @@ export class RelayCommand extends BaseCommand {
             return ListrLease.newAcquireLeaseTask(lease, task);
           },
         },
-        RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),
         {
           title: 'Prepare chart values',
           task: async ctx => {
@@ -350,7 +349,6 @@ export class RelayCommand extends BaseCommand {
             return ListrLease.newAcquireLeaseTask(lease, task);
           },
         },
-        RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),
         {
           title: 'Destroy JSON RPC Relay',
           task: async ctx => {

--- a/src/core/config/remote/remote_config_manager.ts
+++ b/src/core/config/remote/remote_config_manager.ts
@@ -183,44 +183,44 @@ export class RemoteConfigManager {
 
   /* ---------- Listr Task Builders ---------- */
 
-    /**
-     * Performs the loading of the remote configuration.
-     * Checks if the configuration is already loaded, otherwise loads and adds the command to history.
-     *
-     * @param argv - arguments containing command input for historical reference.
-     */
+  /**
+   * Performs the loading of the remote configuration.
+   * Checks if the configuration is already loaded, otherwise loads and adds the command to history.
+   *
+   * @param argv - arguments containing command input for historical reference.
+   */
   public async loadAndValidate(argv: {_: string[]}) {
-      const self = this;
-      try {
-          self.setDefaultNamespaceIfNotSet();
-          self.setDefaultContextIfNotSet();
-      } catch (e) {
-          self.logger.showUser(chalk.red(e.message));
-          return;
-      }
+    const self = this;
+    try {
+      self.setDefaultNamespaceIfNotSet();
+      self.setDefaultContextIfNotSet();
+    } catch (e) {
+      self.logger.showUser(chalk.red(e.message));
+      return;
+    }
 
-      if (!(await self.load())) {
-          self.logger.showUser(chalk.red('remote config not found'));
+    if (!(await self.load())) {
+      self.logger.showUser(chalk.red('remote config not found'));
 
-          // TODO see if this should be disabled to make it an optional feature
-          return;
-          // throw new SoloError('Failed to load remote config')
-      }
+      // TODO see if this should be disabled to make it an optional feature
+      return;
+      // throw new SoloError('Failed to load remote config')
+    }
 
-      await RemoteConfigValidator.validateComponents(self.remoteConfig.components, self.k8);
+    await RemoteConfigValidator.validateComponents(self.remoteConfig.components, self.k8);
 
-      const currentCommand = argv._.join(' ');
-      self.remoteConfig!.addCommandToHistory(currentCommand);
+    const currentCommand = argv._.join(' ');
+    self.remoteConfig!.addCommandToHistory(currentCommand);
 
-      await self.save();
+    await self.save();
   }
 
-    /**
-     * Builds a listr task for loading the remote configuration.
-     *
-     * @param argv - arguments containing command input for historical reference.
-     * @returns a Listr task which loads the remote configuration.
-     */
+  /**
+   * Builds a listr task for loading the remote configuration.
+   *
+   * @param argv - arguments containing command input for historical reference.
+   * @returns a Listr task which loads the remote configuration.
+   */
   public buildLoadTask(argv: {_: string[]}): SoloListrTask<EmptyContextConfig> {
     const self = this;
 

--- a/src/core/config/remote/remote_config_manager.ts
+++ b/src/core/config/remote/remote_config_manager.ts
@@ -153,40 +153,51 @@ export class RemoteConfigManager {
 
   /* ---------- Listr Task Builders ---------- */
 
-  /**
-   * Builds a task for loading the remote configuration, intended for use with Listr task management.
-   * Checks if the configuration is already loaded, otherwise loads and adds the command to history.
-   *
-   * @param argv - arguments containing command input for historical reference.
-   * @returns a Listr task which loads the remote configuration.
-   */
+    /**
+     * Performs the loading of the remote configuration.
+     * Checks if the configuration is already loaded, otherwise loads and adds the command to history.
+     *
+     * @param argv - arguments containing command input for historical reference.
+     */
+  public async loadAndValidate(argv: {_: string[]}) {
+      const self = this;
+      try {
+          self.setDefaultNamespaceIfNotSet();
+          self.setDefaultContextIfNotSet();
+      } catch (e) {
+          self.logger.showUser(chalk.red(e.message));
+          return;
+      }
+
+      if (!(await self.load())) {
+          self.logger.showUser(chalk.red('remote config not found'));
+
+          // TODO see if this should be disabled to make it an optional feature
+          return;
+          // throw new SoloError('Failed to load remote config')
+      }
+
+      await RemoteConfigValidator.validateComponents(self.remoteConfig.components, self.k8);
+
+      const currentCommand = argv._.join(' ');
+      self.remoteConfig!.addCommandToHistory(currentCommand);
+
+      await self.save();
+  }
+
+    /**
+     * Builds a listr task for loading the remote configuration.
+     *
+     * @param argv - arguments containing command input for historical reference.
+     * @returns a Listr task which loads the remote configuration.
+     */
   public buildLoadTask(argv: {_: string[]}): SoloListrTask<EmptyContextConfig> {
     const self = this;
 
     return {
       title: 'Load remote config',
       task: async (_, task): Promise<void> => {
-        try {
-          self.setDefaultNamespaceIfNotSet();
-          self.setDefaultContextIfNotSet();
-        } catch {
-          return; // TODO
-        }
-
-        if (!(await self.load())) {
-          task.title = `${task.title} - ${chalk.red('remote config not found')}`;
-
-          // TODO see if this should be disabled to make it an optional feature
-          return;
-          // throw new SoloError('Failed to load remote config')
-        }
-
-        await RemoteConfigValidator.validateComponents(self.remoteConfig.components, self.k8);
-
-        const currentCommand = argv._.join(' ');
-        self.remoteConfig!.addCommandToHistory(currentCommand);
-
-        await self.save();
+        await self.loadAndValidate(argv);
       },
     };
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,6 +133,22 @@ export function main(argv: any) {
       return argv;
     };
 
+    const loadRemoteConfig = async (argv: any, yargs: any): Promise<any> => {
+        const command = argv._[0];
+        const subCommand = argv._[1];
+        const skip = command === 'init'
+            || (command === 'node' && subCommand === 'keys')
+            || (command === 'cluster' && subCommand === 'connect')
+            || (command === 'cluster' && subCommand === 'info')
+            || (command === 'cluster' && subCommand === 'list')
+            || (command === 'deployment' && subCommand === 'create')
+        if (!skip) {
+            await remoteConfigManager.loadAndValidate(argv);
+        }
+
+        return argv;
+    };
+
     return (
       yargs(hideBin(argv))
         .scriptName('')
@@ -147,7 +163,7 @@ export function main(argv: any) {
         .wrap(120)
         .demand(1, 'Select a command')
         // @ts-ignore
-        .middleware(processArguments, false) // applyBeforeValidate = false as otherwise middleware is called twice
+        .middleware([processArguments, loadRemoteConfig] , false) // applyBeforeValidate = false as otherwise middleware is called twice
         .parse()
     );
   } catch (e: Error | any) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -133,19 +133,20 @@ export function main(argv: any) {
     };
 
     const loadRemoteConfig = async (argv: any, yargs: any): Promise<any> => {
-        const command = argv._[0];
-        const subCommand = argv._[1];
-        const skip = command === 'init'
-            || (command === 'node' && subCommand === 'keys')
-            || (command === 'cluster' && subCommand === 'connect')
-            || (command === 'cluster' && subCommand === 'info')
-            || (command === 'cluster' && subCommand === 'list')
-            || (command === 'deployment' && subCommand === 'create')
-        if (!skip) {
-            await remoteConfigManager.loadAndValidate(argv);
-        }
+      const command = argv._[0];
+      const subCommand = argv._[1];
+      const skip =
+        command === 'init' ||
+        (command === 'node' && subCommand === 'keys') ||
+        (command === 'cluster' && subCommand === 'connect') ||
+        (command === 'cluster' && subCommand === 'info') ||
+        (command === 'cluster' && subCommand === 'list') ||
+        (command === 'deployment' && subCommand === 'create');
+      if (!skip) {
+        await remoteConfigManager.loadAndValidate(argv);
+      }
 
-        return argv;
+      return argv;
     };
 
     return (
@@ -162,7 +163,7 @@ export function main(argv: any) {
         .wrap(120)
         .demand(1, 'Select a command')
         // @ts-ignore
-        .middleware([processArguments, loadRemoteConfig] , false) // applyBeforeValidate = false as otherwise middleware is called twice
+        .middleware([processArguments, loadRemoteConfig], false) // applyBeforeValidate = false as otherwise middleware is called twice
         .parse()
     );
   } catch (e: Error | any) {


### PR DESCRIPTION
## Description

- Removes all usages of `RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),`
- Adds a new middleware that loads the remote config before the commands are executed. This is skipped for several commands:
`init`, `node keys`, `cluster info`, `cluster list` - They do not require connecting to a remote cluster.
`deployment create`, `cluster connect` - Require connecting to several clusters and that is handled by the command task logic.

### Related Issues

* Closes #1171 
