### PR TITLE
feat: separate explorer from mirror node install/uninstall

### DIFF
--- a/.github/workflows/flow-task-test.yaml
+++ b/.github/workflows/flow-task-test.yaml
@@ -36,7 +36,7 @@ permissions:
 
 jobs:
   example-task-file-test:
-    timeout-minutes: 20
+    timeout-minutes: 30
     runs-on: solo-linux-large
     strategy:
       matrix:

--- a/Taskfile.helper.yml
+++ b/Taskfile.helper.yml
@@ -420,7 +420,8 @@ tasks:
     deps:
       - task: "init"
     cmds:
-      - SOLO_HOME_DIR=${SOLO_HOME_DIR} npm run solo -- mirror-node deploy --namespace "${SOLO_NAMESPACE}" -s ${SOLO_CLUSTER_SETUP_NAMESPACE} ${SOLO_CHARTS_DIR_FLAG} ${ENABLE_EXPLORER_TLS_FLAG} ${TLS_CLUSTER_ISSUER_TYPE_FLAG} ${MIRROR_NODE_DEPLOY_EXTRA_FLAGS} --pinger -q --dev
+      - SOLO_HOME_DIR=${SOLO_HOME_DIR} npm run solo -- mirror-node deploy --namespace "${SOLO_NAMESPACE}" ${SOLO_CHARTS_DIR_FLAG} ${MIRROR_NODE_DEPLOY_EXTRA_FLAGS} --pinger -q --dev
+      - SOLO_HOME_DIR=${SOLO_HOME_DIR} npm run solo -- explorer deploy --namespace "${SOLO_NAMESPACE}" -s ${SOLO_CLUSTER_SETUP_NAMESPACE} ${SOLO_CHARTS_DIR_FLAG} ${ENABLE_EXPLORER_TLS_FLAG} ${TLS_CLUSTER_ISSUER_TYPE_FLAG} -q --dev
       - |
         if [[ "{{ .use_port_forwards }}" == "true" ]];then
           echo "Enable port forwarding for Hedera Explorer & Mirror Node Network"
@@ -442,6 +443,7 @@ tasks:
       - task: "init"
     cmds:
       - SOLO_HOME_DIR=${SOLO_HOME_DIR} npm run solo -- mirror-node destroy --namespace "${SOLO_NAMESPACE}" --force -q --dev || true
+      - SOLO_HOME_DIR=${SOLO_HOME_DIR} npm run solo -- explorer destroy --namespace "${SOLO_NAMESPACE}" --force -q --dev || true
 
   clean:
     desc: destroy, then remove cache directory, logs directory, config, and port forwards

--- a/src/commands/explorer.ts
+++ b/src/commands/explorer.ts
@@ -282,6 +282,7 @@ export class ExplorerCommand extends BaseCommand {
               1,
               constants.PODS_READY_MAX_ATTEMPTS,
               constants.PODS_READY_DELAY,
+              constants.SOLO_SETUP_NAMESPACE,
             );
           },
           skip: ctx => !ctx.config.enableHederaExplorerTls,

--- a/src/commands/explorer.ts
+++ b/src/commands/explorer.ts
@@ -182,7 +182,6 @@ export class ExplorerCommand extends BaseCommand {
               'valuesArg',
             ]) as ExplorerDeployConfigClass;
 
-            // user defined values later to override predefined values
             ctx.config.valuesArg += await self.prepareValuesArg(ctx.config);
 
             if (!(await self.k8.hasNamespace(ctx.config.namespace))) {

--- a/src/commands/explorer.ts
+++ b/src/commands/explorer.ts
@@ -263,7 +263,7 @@ export class ExplorerCommand extends BaseCommand {
           title: 'Check explorer pod is ready',
           task: async () => {
             await self.k8.waitForPodReady(
-              ['app.kubernetes.io/component=hedera-explorer', 'app.kubernetes.io/name=hedera-explorer'],
+              [constants.SOLO_HEDERA_EXPLORER_LABEL],
               1,
               constants.PODS_READY_MAX_ATTEMPTS,
               constants.PODS_READY_DELAY,

--- a/src/commands/explorer.ts
+++ b/src/commands/explorer.ts
@@ -1,0 +1,451 @@
+/**
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the ""License"");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an ""AS IS"" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+import {ListrEnquirerPromptAdapter} from '@listr2/prompt-adapter-enquirer';
+import {Listr} from 'listr2';
+import {SoloError, MissingArgumentError} from '../core/errors.js';
+import * as constants from '../core/constants.js';
+import {type ProfileManager} from '../core/profile_manager.js';
+import {BaseCommand} from './base.js';
+import {Flags as flags} from './flags.js';
+import {RemoteConfigTasks} from '../core/config/remote/remote_config_tasks.js';
+import {type CommandBuilder, type PodName} from '../types/aliases.js';
+import {type Opts} from '../types/command_types.js';
+import {ListrLease} from '../core/lease/listr_lease.js';
+import {ComponentType} from '../core/config/remote/enumerations.js';
+import type {Namespace} from '../core/config/remote/types.js';
+import {MirrorNodeExplorerComponent} from '../core/config/remote/components/mirror_node_explorer_component.js';
+import {type SoloListrTask} from '../types/index.js';
+
+interface ExplorerDeployConfigClass {
+  chartDirectory: string;
+  enableHederaExplorerTls: boolean;
+  hederaExplorerTlsHostName: string;
+  hederaExplorerTlsLoadBalancerIp: string | '';
+  hederaExplorerVersion: string;
+  namespace: string;
+  profileFile: string;
+  profileName: string;
+  tlsClusterIssuerType: string;
+  valuesFile: string;
+  valuesArg: string;
+  getUnusedConfigs: () => string[];
+  clusterSetupNamespace: string;
+  soloChartVersion: string;
+}
+
+interface Context {
+  config: ExplorerDeployConfigClass;
+  addressBook: string;
+}
+
+export class ExplorerCommand extends BaseCommand {
+  private readonly profileManager: ProfileManager;
+
+  constructor(opts: Opts) {
+    super(opts);
+    if (!opts || !opts.profileManager)
+      throw new MissingArgumentError('An instance of core/ProfileManager is required', opts.downloader);
+
+    this.profileManager = opts.profileManager;
+  }
+
+  static get DEPLOY_CONFIGS_NAME() {
+    return 'deployConfigs';
+  }
+
+  static get DEPLOY_FLAGS_LIST() {
+    return [
+      flags.chartDirectory,
+      flags.enableHederaExplorerTls,
+      flags.hederaExplorerTlsHostName,
+      flags.hederaExplorerTlsLoadBalancerIp,
+      flags.hederaExplorerVersion,
+      flags.namespace,
+      flags.profileFile,
+      flags.profileName,
+      flags.quiet,
+      flags.clusterSetupNamespace,
+      flags.soloChartVersion,
+      flags.tlsClusterIssuerType,
+      flags.valuesFile,
+    ];
+  }
+
+  async prepareHederaExplorerValuesArg(config: {valuesFile: string}) {
+    let valuesArg = '';
+
+    const profileName = this.configManager.getFlag<string>(flags.profileName) as string;
+    const profileValuesFile = await this.profileManager.prepareValuesHederaExplorerChart(profileName);
+    if (profileValuesFile) {
+      valuesArg += this.prepareValuesFiles(profileValuesFile);
+    }
+
+    if (config.valuesFile) {
+      valuesArg += this.prepareValuesFiles(config.valuesFile);
+    }
+
+    valuesArg += ` --set proxyPass./api="http://${constants.MIRROR_NODE_RELEASE_NAME}-rest" `;
+    return valuesArg;
+  }
+
+  /**
+   * @param config
+   * @param config.tlsClusterIssuerType - must be one of - acme-staging, acme-prod, or self-signed
+   * @param config.namespace - used for classname ingress class name prefix
+   * @param config.hederaExplorerTlsLoadBalancerIp - can be an empty string
+   * @param config.hederaExplorerTlsHostName
+   */
+  private async prepareSoloChartSetupValuesArg(config: ExplorerDeployConfigClass) {
+    const {tlsClusterIssuerType, namespace, hederaExplorerTlsLoadBalancerIp, hederaExplorerTlsHostName} = config;
+
+    let valuesArg = '';
+
+    if (!['acme-staging', 'acme-prod', 'self-signed'].includes(tlsClusterIssuerType)) {
+      throw new Error(
+        `Invalid TLS cluster issuer type: ${tlsClusterIssuerType}, must be one of: "acme-staging", "acme-prod", or "self-signed"`,
+      );
+    }
+
+    // Install ingress controller only if it's not already present
+    if (!(await this.k8.isIngressControllerInstalled())) {
+      valuesArg += ' --set ingress.enabled=true';
+      valuesArg += ' --set haproxyIngressController.enabled=true';
+      valuesArg += ` --set ingressClassName=${namespace}-hedera-explorer-ingress-class`;
+      valuesArg += ` --set-json 'ingress.hosts[0]={"host":"${hederaExplorerTlsHostName}","paths":[{"path":"/","pathType":"Prefix"}]}'`;
+    }
+
+    if (!(await this.k8.isCertManagerInstalled())) {
+      valuesArg += ' --set cloud.certManager.enabled=true';
+      valuesArg += ' --set cert-manager.installCRDs=true';
+    }
+
+    if (hederaExplorerTlsLoadBalancerIp !== '') {
+      valuesArg += ` --set haproxy-ingress.controller.service.loadBalancerIP=${hederaExplorerTlsLoadBalancerIp}`;
+    }
+
+    if (tlsClusterIssuerType === 'self-signed') {
+      valuesArg += ' --set selfSignedClusterIssuer.enabled=true';
+    } else {
+      valuesArg += ' --set acmeClusterIssuer.enabled=true';
+      valuesArg += ` --set certClusterIssuerType=${tlsClusterIssuerType}`;
+    }
+
+    return valuesArg;
+  }
+
+  async prepareValuesArg(config: ExplorerDeployConfigClass) {
+    let valuesArg = '';
+    if (config.valuesFile) {
+      valuesArg += this.prepareValuesFiles(config.valuesFile);
+    }
+    return valuesArg;
+  }
+
+  async deploy(argv: any) {
+    const self = this;
+    const lease = await self.leaseManager.create();
+
+    const tasks = new Listr<Context>(
+      [
+        {
+          title: 'Initialize',
+          task: async (ctx, task) => {
+            self.configManager.update(argv);
+
+            // disable the prompts that we don't want to prompt the user for
+            flags.disablePrompts([
+              flags.enableHederaExplorerTls,
+              flags.hederaExplorerTlsHostName,
+              flags.hederaExplorerTlsLoadBalancerIp,
+              flags.hederaExplorerVersion,
+              flags.tlsClusterIssuerType,
+              flags.valuesFile,
+            ]);
+
+            await self.configManager.executePrompt(task, ExplorerCommand.DEPLOY_FLAGS_LIST);
+
+            ctx.config = this.getConfig(ExplorerCommand.DEPLOY_CONFIGS_NAME, ExplorerCommand.DEPLOY_FLAGS_LIST, [
+              'valuesArg',
+            ]) as ExplorerDeployConfigClass;
+
+            // user defined values later to override predefined values
+            ctx.config.valuesArg += await self.prepareValuesArg(ctx.config);
+
+            if (!(await self.k8.hasNamespace(ctx.config.namespace))) {
+              throw new SoloError(`namespace ${ctx.config.namespace} does not exist`);
+            }
+
+            return ListrLease.newAcquireLeaseTask(lease, task);
+          },
+        },
+        RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),
+        {
+          title: 'Upgrade solo-setup chart',
+          task: async ctx => {
+            const config = ctx.config;
+            const {chartDirectory, clusterSetupNamespace, soloChartVersion} = config;
+
+            const chartPath = await this.prepareChartPath(
+              chartDirectory,
+              constants.SOLO_TESTING_CHART_URL,
+              constants.SOLO_CLUSTER_SETUP_CHART,
+            );
+
+            const soloChartSetupValuesArg = await self.prepareSoloChartSetupValuesArg(config);
+
+            // if cert-manager isn't already installed we want to install it separate from the certificate issuers
+            // as they will fail to be created due to the order of the installation being dependent on the cert-manager
+            // being installed first
+            if (soloChartSetupValuesArg.includes('cloud.certManager.enabled=true')) {
+              await self.chartManager.upgrade(
+                clusterSetupNamespace,
+                constants.SOLO_CLUSTER_SETUP_CHART,
+                chartPath,
+                soloChartVersion,
+                '  --set cloud.certManager.enabled=true --set cert-manager.installCRDs=true',
+              );
+            }
+
+            // sleep 20 seconds
+            await new Promise(resolve => setTimeout(resolve, 20000));
+            await self.chartManager.upgrade(
+              clusterSetupNamespace,
+              constants.SOLO_CLUSTER_SETUP_CHART,
+              chartPath,
+              soloChartVersion,
+              soloChartSetupValuesArg,
+            );
+          },
+          skip: ctx => !ctx.config.enableHederaExplorerTls,
+        },
+
+        {
+          title: 'Install explorer',
+          task: async ctx => {
+            const config = ctx.config;
+
+            let exploreValuesArg = self.prepareValuesFiles(constants.EXPLORER_VALUES_FILE);
+            exploreValuesArg += await self.prepareHederaExplorerValuesArg(config);
+
+            await self.chartManager.install(
+              config.namespace,
+              constants.HEDERA_EXPLORER_CHART,
+              constants.HEDERA_EXPLORER_CHART_UTL,
+              config.hederaExplorerVersion,
+              exploreValuesArg,
+            );
+          },
+        },
+        {
+          title: 'Check explorer pod is ready',
+          task: async () => {
+            await self.k8.waitForPodReady(
+              ['app.kubernetes.io/component=hedera-explorer', 'app.kubernetes.io/name=hedera-explorer'],
+              1,
+              constants.PODS_READY_MAX_ATTEMPTS,
+              constants.PODS_READY_DELAY,
+            );
+          },
+        },
+        this.addMirrorNodeExplorerComponents(),
+      ],
+      {
+        concurrent: false,
+        rendererOptions: constants.LISTR_DEFAULT_RENDERER_OPTION,
+      },
+    );
+
+    try {
+      await tasks.run();
+      self.logger.debug('explorer deployment has completed');
+    } catch (e) {
+      const message = `Error deploying explorer: ${e.message}`;
+      self.logger.error(message, e);
+      throw new SoloError(message, e);
+    } finally {
+      await lease.release();
+    }
+
+    return true;
+  }
+
+  async destroy(argv: any) {
+    const self = this;
+    const lease = await self.leaseManager.create();
+
+    interface Context {
+      config: {
+        namespace: string;
+        isChartInstalled: boolean;
+      };
+    }
+
+    const tasks = new Listr<Context>(
+      [
+        {
+          title: 'Initialize',
+          task: async (ctx, task) => {
+            if (!argv.force) {
+              const confirm = await task.prompt(ListrEnquirerPromptAdapter).run({
+                type: 'toggle',
+                default: false,
+                message: 'Are you sure you would like to destroy the explorer?',
+              });
+
+              if (!confirm) {
+                process.exit(0);
+              }
+            }
+
+            self.configManager.update(argv);
+            await self.configManager.executePrompt(task, [flags.namespace]);
+
+            // @ts-ignore
+            ctx.config = {
+              namespace: self.configManager.getFlag<string>(flags.namespace),
+            };
+
+            if (!(await self.k8.hasNamespace(ctx.config.namespace))) {
+              throw new SoloError(`namespace ${ctx.config.namespace} does not exist`);
+            }
+
+            ctx.config.isChartInstalled = await this.chartManager.isChartInstalled(
+              ctx.config.namespace,
+              constants.HEDERA_EXPLORER_CHART,
+            );
+            return ListrLease.newAcquireLeaseTask(lease, task);
+          },
+        },
+        RemoteConfigTasks.loadRemoteConfig.bind(this)(argv),
+        {
+          title: 'Destroy explorer',
+          task: async ctx => {
+            await this.chartManager.uninstall(ctx.config.namespace, constants.HEDERA_EXPLORER_CHART);
+          },
+          skip: ctx => !ctx.config.isChartInstalled,
+        },
+        this.removeMirrorNodeExplorerComponents(),
+      ],
+      {
+        concurrent: false,
+        rendererOptions: constants.LISTR_DEFAULT_RENDERER_OPTION,
+      },
+    );
+
+    try {
+      await tasks.run();
+      self.logger.debug('explorer destruction has completed');
+    } catch (e) {
+      throw new SoloError(`Error destroy explorer: ${e.message}`, e);
+    } finally {
+      await lease.release();
+    }
+
+    return true;
+  }
+
+  /** Return Yargs command definition for 'explorer' command */
+  getCommandDefinition(): {command: string; desc: string; builder: CommandBuilder} {
+    const self = this;
+    return {
+      command: 'explorer',
+      desc: 'Manage Explorer in solo network',
+      builder: yargs => {
+        return yargs
+          .command({
+            command: 'deploy',
+            desc: 'Deploy explorer',
+            builder: y => flags.setCommandFlags(y, ...ExplorerCommand.DEPLOY_FLAGS_LIST),
+            handler: argv => {
+              self.logger.info("==== Running explorer deploy' ===");
+              self.logger.info(argv);
+
+              self
+                .deploy(argv)
+                .then(r => {
+                  self.logger.info('==== Finished running explorer deploy`====');
+                  if (!r) process.exit(1);
+                })
+                .catch(err => {
+                  self.logger.showUserError(err);
+                  process.exit(1);
+                });
+            },
+          })
+          .command({
+            command: 'destroy',
+            desc: 'Destroy explorer',
+            builder: y => flags.setCommandFlags(y, flags.chartDirectory, flags.force, flags.quiet, flags.namespace),
+            handler: argv => {
+              self.logger.info('==== Running explorer destroy ===');
+              self.logger.info(argv);
+
+              self
+                .destroy(argv)
+                .then(r => {
+                  self.logger.info('==== Finished running explorer destroy ====');
+                  if (!r) process.exit(1);
+                })
+                .catch(err => {
+                  self.logger.showUserError(err);
+                  process.exit(1);
+                });
+            },
+          })
+          .demandCommand(1, 'Select a explorer command');
+      },
+    };
+  }
+
+  /** Removes the explorer components from remote config. */
+  private removeMirrorNodeExplorerComponents(): SoloListrTask<object> {
+    return {
+      title: 'Remove explorer from remote config',
+      skip: (): boolean => !this.remoteConfigManager.isLoaded(),
+      task: async (): Promise<void> => {
+        await this.remoteConfigManager.modify(async remoteConfig => {
+          remoteConfig.components.remove('mirrorNodeExplorer', ComponentType.MirrorNodeExplorer);
+        });
+      },
+    };
+  }
+
+  /** Adds the explorer components to remote config. */
+  private addMirrorNodeExplorerComponents(): SoloListrTask<{config: {namespace: Namespace}}> {
+    return {
+      title: 'Add explorer to remote config',
+      skip: (): boolean => !this.remoteConfigManager.isLoaded(),
+      task: async (ctx): Promise<void> => {
+        await this.remoteConfigManager.modify(async remoteConfig => {
+          const {
+            config: {namespace},
+          } = ctx;
+          const cluster = this.remoteConfigManager.currentCluster;
+          remoteConfig.components.add(
+            'mirrorNodeExplorer',
+            new MirrorNodeExplorerComponent('mirrorNodeExplorer', cluster, namespace),
+          );
+        });
+      },
+    };
+  }
+
+  close(): Promise<void> {
+    // no-op
+    return Promise.resolve();
+  }
+}

--- a/src/commands/explorer.ts
+++ b/src/commands/explorer.ts
@@ -22,7 +22,7 @@ import {type ProfileManager} from '../core/profile_manager.js';
 import {BaseCommand} from './base.js';
 import {Flags as flags} from './flags.js';
 import {RemoteConfigTasks} from '../core/config/remote/remote_config_tasks.js';
-import {type CommandBuilder, type PodName} from '../types/aliases.js';
+import {type CommandBuilder} from '../types/aliases.js';
 import {type Opts} from '../types/command_types.js';
 import {ListrLease} from '../core/lease/listr_lease.js';
 import {ComponentType} from '../core/config/remote/enumerations.js';
@@ -252,8 +252,8 @@ export class ExplorerCommand extends BaseCommand {
 
             await self.chartManager.install(
               config.namespace,
-              constants.HEDERA_EXPLORER_CHART,
-              constants.HEDERA_EXPLORER_CHART_UTL,
+              constants.HEDERA_EXPLORER_RELEASE_NAME,
+              constants.HEDERA_EXPLORER_CHART_URL,
               config.hederaExplorerVersion,
               exploreValuesArg,
             );
@@ -350,7 +350,7 @@ export class ExplorerCommand extends BaseCommand {
 
             ctx.config.isChartInstalled = await this.chartManager.isChartInstalled(
               ctx.config.namespace,
-              constants.HEDERA_EXPLORER_CHART,
+              constants.HEDERA_EXPLORER_CHART_URL,
             );
             return ListrLease.newAcquireLeaseTask(lease, task);
           },
@@ -359,7 +359,7 @@ export class ExplorerCommand extends BaseCommand {
         {
           title: 'Destroy explorer',
           task: async ctx => {
-            await this.chartManager.uninstall(ctx.config.namespace, constants.HEDERA_EXPLORER_CHART);
+            await this.chartManager.uninstall(ctx.config.namespace, constants.HEDERA_EXPLORER_RELEASE_NAME);
           },
           skip: ctx => !ctx.config.isChartInstalled,
         },

--- a/src/commands/flags.ts
+++ b/src/commands/flags.ts
@@ -183,27 +183,6 @@ export class Flags {
     },
   };
 
-  static readonly deployHederaExplorer: CommandFlag = {
-    constName: 'deployHederaExplorer',
-    name: 'hedera-explorer',
-    definition: {
-      describe: 'Deploy hedera explorer',
-      defaultValue: true,
-      alias: 'x',
-      type: 'boolean',
-    },
-    prompt: async function promptDeployHederaExplorer(task: ListrTaskWrapper<any, any, any>, input: any) {
-      return await Flags.promptToggle(
-        task,
-        input,
-        Flags.deployHederaExplorer.definition.defaultValue,
-        'Would you like to deploy Hedera Explorer? ',
-        null,
-        Flags.deployHederaExplorer.name,
-      );
-    },
-  };
-
   static readonly valuesFile: CommandFlag = {
     constName: 'valuesFile',
     name: 'values-file',
@@ -1751,7 +1730,6 @@ export class Flags {
     Flags.deleteSecrets,
     Flags.deployCertManager,
     Flags.deployCertManagerCrds,
-    Flags.deployHederaExplorer,
     Flags.deployJsonRpcRelay,
     Flags.deployMinio,
     Flags.deployPrometheusStack,

--- a/src/commands/index.ts
+++ b/src/commands/index.ts
@@ -23,6 +23,7 @@ import {RelayCommand} from './relay.js';
 import {AccountCommand} from './account.js';
 import {DeploymentCommand} from './deployment.js';
 import {type Opts} from '../types/command_types.js';
+import {ExplorerCommand} from './explorer.js';
 
 /**
  * Return a list of Yargs command builder to be exposed through CLI
@@ -37,6 +38,7 @@ export function Initialize(opts: Opts) {
   const relayCmd = new RelayCommand(opts);
   const accountCmd = new AccountCommand(opts);
   const mirrorNodeCmd = new MirrorNodeCommand(opts);
+  const explorerCommand = new ExplorerCommand(opts);
   const deploymentCommand = new DeploymentCommand(opts);
 
   return [
@@ -47,6 +49,7 @@ export function Initialize(opts: Opts) {
     nodeCmd.getCommandDefinition(),
     relayCmd.getCommandDefinition(),
     mirrorNodeCmd.getCommandDefinition(),
+    explorerCommand.getCommandDefinition(),
     deploymentCommand.getCommandDefinition(),
   ];
 }

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -28,6 +28,7 @@ export const SOLO_LOGS_DIR = path.join(SOLO_HOME_DIR, 'logs');
 export const SOLO_CACHE_DIR = path.join(SOLO_HOME_DIR, 'cache');
 export const SOLO_VALUES_DIR = path.join(SOLO_CACHE_DIR, 'values-files');
 export const DEFAULT_NAMESPACE = 'default';
+export const DEFAULT_CERT_MANAGER_NAMESPACE = 'cert-manager';
 export const HELM = 'helm';
 export const RESOURCES_DIR = normalize(path.join(ROOT_DIR, 'resources'));
 

--- a/src/core/k8.ts
+++ b/src/core/k8.ts
@@ -1010,8 +1010,9 @@ export class K8 {
     maxAttempts = constants.PODS_RUNNING_MAX_ATTEMPTS,
     delay = constants.PODS_RUNNING_DELAY,
     podItemPredicate?: (items: k8s.V1Pod) => boolean,
+    namespace?: string,
   ): Promise<k8s.V1Pod[]> {
-    const ns = this._getNamespace();
+    const ns = namespace || this._getNamespace();
     const labelSelector = labels.join(',');
 
     this.logger.info(`WaitForPod [labelSelector: ${labelSelector}, namespace:${ns}, maxAttempts: ${maxAttempts}]`);
@@ -1082,10 +1083,11 @@ export class K8 {
    * @param [podCount] - number of pod expected
    * @param [maxAttempts] - maximum attempts to check
    * @param [delay] - delay between checks in milliseconds
+   * @param [namespace] - namespace
    */
-  async waitForPodReady(labels: string[] = [], podCount = 1, maxAttempts = 10, delay = 500) {
+  async waitForPodReady(labels: string[] = [], podCount = 1, maxAttempts = 10, delay = 500, namespace?: string) {
     try {
-      return await this.waitForPodConditions(K8.PodReadyCondition, labels, podCount, maxAttempts, delay);
+      return await this.waitForPodConditions(K8.PodReadyCondition, labels, podCount, maxAttempts, delay, namespace);
     } catch (e: Error | unknown) {
       throw new SoloError(`Pod not ready [maxAttempts = ${maxAttempts}]`, e);
     }
@@ -1105,28 +1107,36 @@ export class K8 {
     podCount = 1,
     maxAttempts = 10,
     delay = 500,
+    namespace?: string,
   ) {
     if (!conditionsMap || conditionsMap.size === 0) throw new MissingArgumentError('pod conditions are required');
 
-    return await this.waitForPods([constants.POD_PHASE_RUNNING], labels, podCount, maxAttempts, delay, pod => {
-      if (pod.status?.conditions?.length > 0) {
-        for (const cond of pod.status.conditions) {
-          for (const entry of conditionsMap.entries()) {
-            const condType = entry[0];
-            const condStatus = entry[1];
-            if (cond.type === condType && cond.status === condStatus) {
-              this.logger.info(
-                `Pod condition met for ${pod.metadata?.name} [type: ${cond.type} status: ${cond.status}]`,
-              );
-              return true;
+    return await this.waitForPods(
+      [constants.POD_PHASE_RUNNING],
+      labels,
+      podCount,
+      maxAttempts,
+      delay,
+      pod => {
+        if (pod.status?.conditions?.length > 0) {
+          for (const cond of pod.status.conditions) {
+            for (const entry of conditionsMap.entries()) {
+              const condType = entry[0];
+              const condStatus = entry[1];
+              if (cond.type === condType && cond.status === condStatus) {
+                this.logger.info(
+                  `Pod condition met for ${pod.metadata?.name} [type: ${cond.type} status: ${cond.status}]`,
+                );
+                return true;
+              }
             }
           }
         }
-      }
-
-      // condition not found
-      return false;
-    });
+        // condition not found
+        return false;
+      },
+      namespace,
+    );
   }
 
   /**
@@ -1510,7 +1520,7 @@ export class K8 {
 
       return pods.body.items.length > 0;
     } catch (e) {
-      this.logger.error('Failed to find cert-manager:', e);
+      this.logger.error('Failed to find minio:', e);
 
       return false;
     }
@@ -1526,7 +1536,7 @@ export class K8 {
 
       return response.body.items.length > 0;
     } catch (e) {
-      this.logger.error('Failed to find cert-manager:', e);
+      this.logger.error('Failed to find ingress controller:', e);
 
       return false;
     }
@@ -1543,7 +1553,7 @@ export class K8 {
 
       return configmaps.body.items.length > 0;
     } catch (e) {
-      this.logger.error('Failed to find cert-manager:', e);
+      this.logger.error('Failed to find remote config:', e);
 
       return false;
     }
@@ -1562,7 +1572,7 @@ export class K8 {
 
       return pods.body.items.length > 0;
     } catch (e) {
-      this.logger.error('Failed to find cert-manager:', e);
+      this.logger.error('Failed to find prometheus:', e);
 
       return false;
     }

--- a/test/e2e/commands/mirror_node.test.ts
+++ b/test/e2e/commands/mirror_node.test.ts
@@ -34,6 +34,7 @@ import * as http from 'http';
 import type {PodName} from '../../../src/types/aliases.js';
 import {PackageDownloader} from '../../../src/core/package_downloader.js';
 import {Duration} from '../../../src/core/time/duration.js';
+import {ExplorerCommand} from '../../../src/commands/explorer.js';
 
 const testName = 'mirror-cmd-e2e';
 const namespace = testName;
@@ -57,6 +58,7 @@ e2eTestSuite(testName, argv, undefined, undefined, undefined, undefined, undefin
   describe('MirrorNodeCommand', async () => {
     const k8 = bootstrapResp.opts.k8;
     const mirrorNodeCmd = new MirrorNodeCommand(bootstrapResp.opts);
+    const explorerCommand = new ExplorerCommand(bootstrapResp.opts);
     const downloader = new PackageDownloader(mirrorNodeCmd.logger);
     const accountManager = bootstrapResp.opts.accountManager;
 
@@ -83,9 +85,10 @@ e2eTestSuite(testName, argv, undefined, undefined, undefined, undefined, undefin
 
     balanceQueryShouldSucceed(accountManager, mirrorNodeCmd, namespace);
 
-    it('mirror node deploy should success', async () => {
+    it('mirror node and explorer deploy should success', async () => {
       try {
         expect(await mirrorNodeCmd.deploy(argv)).to.be.true;
+        expect(await explorerCommand.deploy(argv)).to.be.true;
       } catch (e) {
         mirrorNodeCmd.logger.showUserError(e);
         expect.fail();
@@ -93,16 +96,22 @@ e2eTestSuite(testName, argv, undefined, undefined, undefined, undefined, undefin
 
       expect(mirrorNodeCmd.getUnusedConfigs(MirrorNodeCommand.DEPLOY_CONFIGS_NAME)).to.deep.equal([
         flags.chartDirectory.constName,
+        flags.profileFile.constName,
+        flags.profileName.constName,
+        flags.quiet.constName,
+        flags.storageSecrets.constName,
+        flags.storageEndpoint.constName,
+      ]);
+      expect(explorerCommand.getUnusedConfigs(MirrorNodeCommand.DEPLOY_CONFIGS_NAME)).to.deep.equal([
+        flags.chartDirectory.constName,
         flags.hederaExplorerTlsHostName.constName,
         flags.hederaExplorerTlsLoadBalancerIp.constName,
         flags.profileFile.constName,
         flags.profileName.constName,
         flags.quiet.constName,
-        flags.tlsClusterIssuerType.constName,
         flags.clusterSetupNamespace.constName,
         flags.soloChartVersion.constName,
-        flags.storageSecrets.constName,
-        flags.storageEndpoint.constName,
+        flags.tlsClusterIssuerType.constName,
       ]);
     }).timeout(Duration.ofMinutes(10).toMillis());
 
@@ -207,6 +216,7 @@ e2eTestSuite(testName, argv, undefined, undefined, undefined, undefined, undefin
     it('mirror node destroy should success', async () => {
       try {
         expect(await mirrorNodeCmd.destroy(argv)).to.be.true;
+        expect(await explorerCommand.destroy(argv)).to.be.true;
       } catch (e) {
         mirrorNodeCmd.logger.showUserError(e);
         expect.fail();

--- a/test/e2e/commands/mirror_node.test.ts
+++ b/test/e2e/commands/mirror_node.test.ts
@@ -54,6 +54,7 @@ argv[flags.chartDirectory.name] = process.env.SOLO_CHARTS_DIR ?? undefined;
 argv[flags.quiet.name] = true;
 argv[flags.pinger.name] = true;
 
+argv[flags.enableHederaExplorerTls.name] = true;
 e2eTestSuite(testName, argv, undefined, undefined, undefined, undefined, undefined, undefined, true, bootstrapResp => {
   describe('MirrorNodeCommand', async () => {
     const k8 = bootstrapResp.opts.k8;

--- a/test/e2e/commands/mirror_node.test.ts
+++ b/test/e2e/commands/mirror_node.test.ts
@@ -104,15 +104,9 @@ e2eTestSuite(testName, argv, undefined, undefined, undefined, undefined, undefin
         flags.storageEndpoint.constName,
       ]);
       expect(explorerCommand.getUnusedConfigs(MirrorNodeCommand.DEPLOY_CONFIGS_NAME)).to.deep.equal([
-        flags.chartDirectory.constName,
-        flags.hederaExplorerTlsHostName.constName,
-        flags.hederaExplorerTlsLoadBalancerIp.constName,
         flags.profileFile.constName,
         flags.profileName.constName,
         flags.quiet.constName,
-        flags.clusterSetupNamespace.constName,
-        flags.soloChartVersion.constName,
-        flags.tlsClusterIssuerType.constName,
       ]);
     }).timeout(Duration.ofMinutes(10).toMillis());
 


### PR DESCRIPTION
## Description

This pull request changes the following:

* Create new command for explorer deploy and destroy
* Update k8 waitingForPod with extra `namespace` parameter
* Update mirror node e2e test 

### Related Issues

* Closes #1081 
