### PR TITLE
fix: remove k8.getKubeConfig

### DIFF
--- a/src/commands/cluster/tasks.ts
+++ b/src/commands/cluster/tasks.ts
@@ -55,7 +55,7 @@ export class ClusterCommandTasks {
         if (!context) {
           const isQuiet = self.parent.getConfigManager().getFlag(flags.quiet);
           if (isQuiet) {
-            context = self.parent.getK8().getKubeConfig().currentContext;
+            context = self.parent.getK8().getCurrentContext();
           } else {
             context = await self.promptForContext(parentTask, cluster);
           }
@@ -96,11 +96,12 @@ export class ClusterCommandTasks {
       title: 'Read clusters from remote config',
       task: async (ctx, task) => {
         const localConfig = this.parent.getLocalConfig();
-        const currentCluster = this.parent.getK8().getKubeConfig().getCurrentCluster();
+        const currentCluster = this.parent.getK8().getCurrentCluster();
+        const currentClusterName = this.parent.getK8().getCurrentClusterName();
         const currentRemoteConfig: RemoteConfigDataWrapper = await this.parent.getRemoteConfigManager().get();
         const subTasks = [];
         const remoteConfigClusters = Object.keys(currentRemoteConfig.clusters);
-        const otherRemoteConfigClusters: string[] = remoteConfigClusters.filter(c => c !== currentCluster.name);
+        const otherRemoteConfigClusters: string[] = remoteConfigClusters.filter(c => c !== currentClusterName);
 
         // Validate connections for the other clusters
         for (const cluster of otherRemoteConfigClusters) {
@@ -163,7 +164,7 @@ export class ClusterCommandTasks {
           } else if (!localConfig.clusterContextMapping[cluster]) {
             // In quiet mode, use the currently selected context to update the mapping
             if (isQuiet) {
-              localConfig.clusterContextMapping[cluster] = this.parent.getK8().getKubeConfig().getCurrentContext();
+              localConfig.clusterContextMapping[cluster] = this.parent.getK8().getCurrentContext();
             }
 
             // Prompt the user to select a context if mapping value is missing
@@ -186,7 +187,7 @@ export class ClusterCommandTasks {
   ) {
     let selectedContext;
     if (isQuiet) {
-      selectedContext = this.parent.getK8().getKubeConfig().getCurrentContext();
+      selectedContext = this.parent.getK8().getCurrentContext();
     } else {
       selectedContext = await this.promptForContext(task, selectedCluster);
       localConfig.clusterContextMapping[selectedCluster] = selectedContext;
@@ -304,8 +305,8 @@ export class ClusterCommandTasks {
           else {
             // Add the deployment to the LocalConfig with the currently selected cluster and context in KubeConfig
             if (isQuiet) {
-              selectedContext = this.parent.getK8().getKubeConfig().getCurrentContext();
-              selectedCluster = this.parent.getK8().getKubeConfig().getCurrentCluster().name;
+              selectedContext = this.parent.getK8().getCurrentContext();
+              selectedCluster = this.parent.getK8().getCurrentClusterName();
               localConfig.deployments[deploymentName] = {
                 clusters: [selectedCluster],
               };
@@ -364,7 +365,7 @@ export class ClusterCommandTasks {
   getClusterInfo() {
     return new Task('Get cluster info', async (ctx: any, task: ListrTaskWrapper<any, any, any>) => {
       try {
-        const cluster = this.parent.getK8().getKubeConfig().getCurrentCluster();
+        const cluster = this.parent.getK8().getCurrentCluster();
         this.parent.logger.showJSON(`Cluster Information (${cluster.name})`, cluster);
         this.parent.logger.showUser('\n');
       } catch (e: Error | unknown) {

--- a/src/core/config/local_config.ts
+++ b/src/core/config/local_config.ts
@@ -189,7 +189,7 @@ export class LocalConfig implements LocalConfigData {
 
         if (!deploymentClusters) {
           if (isQuiet) {
-            deploymentClusters = k8.getKubeConfig().getCurrentCluster().name;
+            deploymentClusters = k8.getCurrentClusterName()
           } else {
             deploymentClusters = await flags.deploymentClusters.prompt(task, deploymentClusters);
           }
@@ -221,7 +221,7 @@ export class LocalConfig implements LocalConfigData {
             }
             self.configManager.setFlag(flags.context, promptedContexts.join(','));
           } else {
-            const context = k8.getKubeConfig().getCurrentContext();
+            const context = k8.getCurrentContext();
             for (const cluster of parsedClusters) {
               self.clusterContextMapping[cluster] = context;
             }

--- a/src/core/config/local_config.ts
+++ b/src/core/config/local_config.ts
@@ -189,7 +189,7 @@ export class LocalConfig implements LocalConfigData {
 
         if (!deploymentClusters) {
           if (isQuiet) {
-            deploymentClusters = k8.getCurrentClusterName()
+            deploymentClusters = k8.getCurrentClusterName();
           } else {
             deploymentClusters = await flags.deploymentClusters.prompt(task, deploymentClusters);
           }

--- a/src/core/config/remote/remote_config_manager.ts
+++ b/src/core/config/remote/remote_config_manager.ts
@@ -161,7 +161,7 @@ export class RemoteConfigManager {
     try {
       await RemoteConfigValidator.validateComponents(this.remoteConfig.components, this.k8);
     } catch (e) {
-      throw new SoloError(ErrorMessages.REMOTE_CONFIG_IS_INVALID(this.k8.getKubeConfig().getCurrentCluster().name));
+      throw new SoloError(ErrorMessages.REMOTE_CONFIG_IS_INVALID(this.k8.getCurrentClusterName()));
     }
     return this.remoteConfig;
   }
@@ -338,7 +338,7 @@ export class RemoteConfigManager {
   private setDefaultContextIfNotSet(): void {
     if (this.configManager.hasFlag(flags.context)) return;
 
-    const context = this.k8.getKubeConfig().currentContext;
+    const context = this.k8.getCurrentContext();
 
     if (!context) {
       this.logger.error("Context is not passed and default one can't be acquired", this.localConfig);

--- a/src/core/k8.ts
+++ b/src/core/k8.ts
@@ -1726,7 +1726,7 @@ export class K8 {
     this.logger.debug(`getNodeState(${pod.metadata.name}): ...end`);
   }
 
-  setCurrentContext(context: string) {
+  public setCurrentContext(context: string) {
     this.kubeConfig.setCurrentContext(context);
 
     // Reinitialize clients
@@ -1734,19 +1734,19 @@ export class K8 {
     this.coordinationApiClient = this.kubeConfig.makeApiClient(k8s.CoordinationV1Api);
   }
 
-  getCurrentContext(): string {
+  public getCurrentContext(): string {
       return this.kubeConfig.getCurrentContext();
   }
 
-  getCurrentContextObject(): Context {
+  public getCurrentContextObject(): Context {
       return this.kubeConfig.getContextObject(this.getCurrentContext());
   }
 
-  getCurrentCluster(): Cluster {
+  public getCurrentCluster(): Cluster {
       return this.kubeConfig.getCurrentCluster();
   }
 
-  getCurrentClusterName(): string {
+  public getCurrentClusterName(): string {
       const currentCluster = this.kubeConfig.getCurrentCluster();
       if (!currentCluster) return '';
       return currentCluster.name;

--- a/src/core/k8.ts
+++ b/src/core/k8.ts
@@ -39,7 +39,7 @@ import {Duration} from './time/duration.js';
 import {inject, injectable} from 'tsyringe-neo';
 import {patchInject} from './container_helper.js';
 import type {Namespace} from './config/remote/types.js';
-import {Cluster} from "@kubernetes/client-node/dist/config_types.js";
+import {type Cluster} from '@kubernetes/client-node/dist/config_types.js';
 
 interface TDirectoryData {
   directory: boolean;
@@ -1735,20 +1735,20 @@ export class K8 {
   }
 
   public getCurrentContext(): string {
-      return this.kubeConfig.getCurrentContext();
+    return this.kubeConfig.getCurrentContext();
   }
 
   public getCurrentContextObject(): Context {
-      return this.kubeConfig.getContextObject(this.getCurrentContext());
+    return this.kubeConfig.getContextObject(this.getCurrentContext());
   }
 
   public getCurrentCluster(): Cluster {
-      return this.kubeConfig.getCurrentCluster();
+    return this.kubeConfig.getCurrentCluster();
   }
 
   public getCurrentClusterName(): string {
-      const currentCluster = this.kubeConfig.getCurrentCluster();
-      if (!currentCluster) return '';
-      return currentCluster.name;
+    const currentCluster = this.kubeConfig.getCurrentCluster();
+    if (!currentCluster) return '';
+    return currentCluster.name;
   }
 }

--- a/src/core/k8.ts
+++ b/src/core/k8.ts
@@ -39,6 +39,7 @@ import {Duration} from './time/duration.js';
 import {inject, injectable} from 'tsyringe-neo';
 import {patchInject} from './container_helper.js';
 import type {Namespace} from './config/remote/types.js';
+import {Cluster} from "@kubernetes/client-node/dist/config_types.js";
 
 interface TDirectoryData {
   directory: boolean;
@@ -76,10 +77,6 @@ export class K8 {
     this.logger = patchInject(logger, SoloLogger, this.constructor.name);
 
     this.init();
-  }
-
-  getKubeConfig() {
-    return this.kubeConfig;
   }
 
   init() {
@@ -1735,5 +1732,23 @@ export class K8 {
     // Reinitialize clients
     this.kubeClient = this.kubeConfig.makeApiClient(k8s.CoreV1Api);
     this.coordinationApiClient = this.kubeConfig.makeApiClient(k8s.CoordinationV1Api);
+  }
+
+  getCurrentContext(): string {
+      return this.kubeConfig.getCurrentContext();
+  }
+
+  getCurrentContextObject(): Context {
+      return this.kubeConfig.getContextObject(this.getCurrentContext());
+  }
+
+  getCurrentCluster(): Cluster {
+      return this.kubeConfig.getCurrentCluster();
+  }
+
+  getCurrentClusterName(): string {
+      const currentCluster = this.kubeConfig.getCurrentCluster();
+      if (!currentCluster) return '';
+      return currentCluster.name;
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -79,9 +79,8 @@ export function main(argv: any) {
 
     // set cluster and namespace in the global configManager from kubernetes context
     // so that we don't need to prompt the user
-    const kubeConfig = k8.getKubeConfig();
-    const context = kubeConfig.getContextObject(kubeConfig.getCurrentContext());
-    const cluster = kubeConfig.getCurrentCluster();
+    const context = k8.getCurrentContextObject();
+    const currentClusterName = k8.getCurrentClusterName();
 
     const opts: Opts = {
       logger,
@@ -106,7 +105,7 @@ export function main(argv: any) {
         configManager.reset();
       }
 
-      const clusterName = configManager.getFlag(flags.clusterName) || cluster.name;
+      const clusterName = configManager.getFlag(flags.clusterName) || currentClusterName;
 
       if (context.namespace) {
         configManager.setFlag(flags.namespace, context.namespace);

--- a/test/unit/commands/cluster.test.ts
+++ b/test/unit/commands/cluster.test.ts
@@ -201,7 +201,6 @@ describe('ClusterCommand unit tests', () => {
       });
       remoteConfigManagerStub.get.resolves(remoteConfig);
 
-      // k8Stub.getKubeConfig.returns(kubeConfigStub);
       k8Stub.getCurrentClusterName.returns(kubeConfigClusterObject.name);
       k8Stub.getCurrentCluster.returns(kubeConfigClusterObject);
       k8Stub.getCurrentContext.returns('context-from-kubeConfig');

--- a/test/unit/commands/cluster.test.ts
+++ b/test/unit/commands/cluster.test.ts
@@ -183,12 +183,12 @@ describe('ClusterCommand unit tests', () => {
       }
 
       const kubeConfigClusterObject = {
-          name: 'cluster-3',
-          caData: 'caData',
-          caFile: 'caFile',
-          server: 'server-3',
-          skipTLSVerify: true,
-          tlsServerName: 'tls-3',
+        name: 'cluster-3',
+        caData: 'caData',
+        caFile: 'caFile',
+        server: 'server-3',
+        skipTLSVerify: true,
+        tlsServerName: 'tls-3',
       } as Cluster;
 
       const kubeConfigStub = sandbox.createStubInstance(KubeConfig);

--- a/test/unit/commands/cluster.test.ts
+++ b/test/unit/commands/cluster.test.ts
@@ -182,16 +182,18 @@ describe('ClusterCommand unit tests', () => {
         k8Stub.testClusterConnection.resolves(true);
       }
 
+      const kubeConfigClusterObject = {
+          name: 'cluster-3',
+          caData: 'caData',
+          caFile: 'caFile',
+          server: 'server-3',
+          skipTLSVerify: true,
+          tlsServerName: 'tls-3',
+      } as Cluster;
+
       const kubeConfigStub = sandbox.createStubInstance(KubeConfig);
       kubeConfigStub.getCurrentContext.returns('context-from-kubeConfig');
-      kubeConfigStub.getCurrentCluster.returns({
-        name: 'cluster-3',
-        caData: 'caData',
-        caFile: 'caFile',
-        server: 'server-3',
-        skipTLSVerify: true,
-        tlsServerName: 'tls-3',
-      } as Cluster);
+      kubeConfigStub.getCurrentCluster.returns(kubeConfigClusterObject);
 
       remoteConfigManagerStub = sandbox.createStubInstance(RemoteConfigManager);
       remoteConfigManagerStub.modify.callsFake(async callback => {
@@ -199,7 +201,10 @@ describe('ClusterCommand unit tests', () => {
       });
       remoteConfigManagerStub.get.resolves(remoteConfig);
 
-      k8Stub.getKubeConfig.returns(kubeConfigStub);
+      // k8Stub.getKubeConfig.returns(kubeConfigStub);
+      k8Stub.getCurrentClusterName.returns(kubeConfigClusterObject.name);
+      k8Stub.getCurrentCluster.returns(kubeConfigClusterObject);
+      k8Stub.getCurrentContext.returns('context-from-kubeConfig');
 
       const configManager = sandbox.createStubInstance(ConfigManager);
 


### PR DESCRIPTION
## Description

- Removes the public method `getKubeConfig` in `K8`
- Adds new methods for accessing context and cluster data: `getCurrentContext`, `getCurrentContextObject`, `getCurrentCluster`, `getCurrentClusterName`

### Related Issues

* Closes #1179 
