### PR TITLE
refactor: minor refactors to K8 setting private and public modifiers

### DIFF
--- a/src/commands/cluster/tasks.ts
+++ b/src/commands/cluster/tasks.ts
@@ -369,7 +369,7 @@ export class ClusterCommandTasks {
     return new Task('Get cluster info', async (ctx: any, task: ListrTaskWrapper<any, any, any>) => {
       try {
         const clusterName = this.parent.getK8().getCurrentClusterName();
-        this.parent.logger.showUser(`Cluster Information (${clusterName})`);
+        this.parent.logger.showUser(`Cluster Name (${clusterName})`);
         this.parent.logger.showUser('\n');
       } catch (e: Error | unknown) {
         this.parent.logger.showUserError(e);

--- a/src/commands/cluster/tasks.ts
+++ b/src/commands/cluster/tasks.ts
@@ -196,12 +196,8 @@ export class ClusterCommandTasks {
   }
 
   private async promptForContext(task: SoloListrTaskWrapper<SelectClusterContextContext>, cluster: string) {
-    const kubeContexts = this.parent.getK8().getContexts();
-    return flags.context.prompt(
-      task,
-      kubeContexts.map(c => c.name),
-      cluster,
-    );
+    const kubeContexts = this.parent.getK8().getContextNames();
+    return flags.context.prompt(task, kubeContexts, cluster);
   }
 
   private async selectContextForFirstCluster(

--- a/src/core/config/local_config.ts
+++ b/src/core/config/local_config.ts
@@ -203,12 +203,8 @@ export class LocalConfig implements LocalConfigData {
           if (!isQuiet) {
             const promptedContexts: string[] = [];
             for (const cluster of parsedClusters) {
-              const kubeContexts = k8.getContexts();
-              const context: string = await flags.context.prompt(
-                task,
-                kubeContexts.map(c => c.name),
-                cluster,
-              );
+              const kubeContexts = k8.getContextNames();
+              const context: string = await flags.context.prompt(task, kubeContexts, cluster);
               self.clusterContextMapping[cluster] = context;
               promptedContexts.push(context);
 

--- a/src/core/k8.ts
+++ b/src/core/k8.ts
@@ -40,15 +40,7 @@ import {inject, injectable} from 'tsyringe-neo';
 import {patchInject} from './container_helper.js';
 import type {Namespace} from './config/remote/types.js';
 import type {Cluster} from '@kubernetes/client-node/dist/config_types.js';
-
-interface TDirectoryData {
-  directory: boolean;
-  owner: string;
-  group: string;
-  size: string;
-  modifiedAt: string;
-  name: string;
-}
+import type TDirectoryData from './kube/t_directory_data.js';
 
 /**
  * A kubernetes API wrapper class providing custom functionalities required by solo

--- a/src/core/k8.ts
+++ b/src/core/k8.ts
@@ -50,7 +50,7 @@ import type TDirectoryData from './kube/t_directory_data.js';
  */
 @injectable()
 export class K8 {
-  private _cachedContexts: Context[];
+  private cachedContexts: Context[];
 
   static PodReadyCondition = new Map<string, string>().set(
     constants.POD_CONDITION_READY,
@@ -63,7 +63,7 @@ export class K8 {
 
   constructor(
     @inject(ConfigManager) private readonly configManager?: ConfigManager,
-    @inject(SoloLogger) public readonly logger?: SoloLogger,
+    @inject(SoloLogger) private readonly logger?: SoloLogger,
   ) {
     this.configManager = patchInject(configManager, ConfigManager, this.constructor.name);
     this.logger = patchInject(logger, SoloLogger, this.constructor.name);
@@ -330,11 +330,11 @@ export class K8 {
   }
 
   getContexts(): Context[] {
-    if (!this._cachedContexts) {
-      this._cachedContexts = this.kubeConfig.getContexts();
+    if (!this.cachedContexts) {
+      this.cachedContexts = this.kubeConfig.getContexts();
     }
 
-    return this._cachedContexts;
+    return this.cachedContexts;
   }
 
   /**

--- a/src/core/k8.ts
+++ b/src/core/k8.ts
@@ -1730,8 +1730,8 @@ export class K8 {
     return this.kubeConfig.getCurrentContext();
   }
 
-  public getCurrentContextObject(): Context {
-    return this.kubeConfig.getContextObject(this.getCurrentContext());
+  public getCurrentContextNamespace(): Namespace {
+    return this.kubeConfig.getContextObject(this.getCurrentContext())?.namespace;
   }
 
   public getCurrentClusterName(): string {

--- a/src/core/k8.ts
+++ b/src/core/k8.ts
@@ -1734,10 +1734,6 @@ export class K8 {
     return this.kubeConfig.getContextObject(this.getCurrentContext());
   }
 
-  public getCurrentCluster(): Cluster {
-    return this.kubeConfig.getCurrentCluster();
-  }
-
   public getCurrentClusterName(): string {
     const currentCluster = this.kubeConfig.getCurrentCluster();
     if (!currentCluster) return '';

--- a/src/core/kube/t_directory_data.ts
+++ b/src/core/kube/t_directory_data.ts
@@ -1,0 +1,24 @@
+/**
+ * Copyright (C) 2024 Hedera Hashgraph, LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the ""License"");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an ""AS IS"" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+export default interface TDirectoryData {
+  directory: boolean;
+  owner: string;
+  group: string;
+  size: string;
+  modifiedAt: string;
+  name: string;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -80,6 +80,7 @@ export function main(argv: any) {
     // so that we don't need to prompt the user
     const contextNamespace = k8.getCurrentContextNamespace();
     const currentClusterName = k8.getCurrentClusterName();
+    const contextName = k8.getCurrentContext();
 
     const opts: Opts = {
       logger,
@@ -124,7 +125,7 @@ export function main(argv: any) {
         chalk.cyan('\n******************************* Solo *********************************************'),
       );
       logger.showUser(chalk.cyan('Version\t\t\t:'), chalk.yellow(configManager.getVersion()));
-      logger.showUser(chalk.cyan('Kubernetes Context\t:'), chalk.yellow(context.name));
+      logger.showUser(chalk.cyan('Kubernetes Context\t:'), chalk.yellow(contextName));
       logger.showUser(chalk.cyan('Kubernetes Cluster\t:'), chalk.yellow(clusterName));
       logger.showUser(chalk.cyan('Current Command\t\t:'), chalk.yellow(commandData));
       if (configManager.getFlag(flags.namespace) !== undefined) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -78,7 +78,7 @@ export function main(argv: any) {
 
     // set cluster and namespace in the global configManager from kubernetes context
     // so that we don't need to prompt the user
-    const context = k8.getCurrentContextObject();
+    const contextNamespace = k8.getCurrentContextNamespace();
     const currentClusterName = k8.getCurrentClusterName();
 
     const opts: Opts = {
@@ -106,8 +106,8 @@ export function main(argv: any) {
 
       const clusterName = configManager.getFlag(flags.clusterName) || currentClusterName;
 
-      if (context.namespace) {
-        configManager.setFlag(flags.namespace, context.namespace);
+      if (contextNamespace) {
+        configManager.setFlag(flags.namespace, contextNamespace);
       }
 
       // apply precedence for flags

--- a/test/e2e/e2e_node_util.ts
+++ b/test/e2e/e2e_node_util.ts
@@ -199,7 +199,7 @@ export function e2eNodeKeyRefreshTest(testName: string, mode: string, releaseTag
 
           if (podArray.length > 0) {
             const podName = podArray[0].metadata.name;
-            k8.logger.info(`nodeRefreshTestSetup: podName: ${podName}`);
+            nodeCmd.logger.info(`nodeRefreshTestSetup: podName: ${podName}`);
             return podName;
           }
           throw new Error(`pod for ${nodeAliases} not found`);

--- a/test/e2e/integration/core/k8_e2e.test.ts
+++ b/test/e2e/integration/core/k8_e2e.test.ts
@@ -146,11 +146,6 @@ describe('K8', () => {
     expect(contexts).not.to.have.lengthOf(0);
   }).timeout(defaultTimeout);
 
-  it('should be able to list contexts', () => {
-    const contexts = k8.getContexts();
-    expect(contexts).not.to.have.lengthOf(0);
-  }).timeout(defaultTimeout);
-
   it('should be able to create and delete a namespaces', async () => {
     const name = uuid4();
     expect(await k8.createNamespace(name)).to.be.true;
@@ -187,11 +182,6 @@ describe('K8', () => {
     const podName = pods[0].metadata.name;
     await expect(k8.getPodIP(podName)).to.eventually.not.be.null;
     await expect(k8.getPodIP('INVALID')).to.be.rejectedWith(SoloError);
-  }).timeout(defaultTimeout);
-
-  it('should be able to detect cluster IP', async () => {
-    await expect(k8.getClusterIP(serviceName)).to.eventually.not.be.null;
-    await expect(k8.getClusterIP('INVALID')).to.be.rejectedWith(SoloError);
   }).timeout(defaultTimeout);
 
   it('should be able to check if a path is directory inside a container', async () => {

--- a/test/unit/commands/cluster.test.ts
+++ b/test/unit/commands/cluster.test.ts
@@ -37,7 +37,6 @@ import {ROOT_DIR} from '../../../src/core/constants.js';
 import path from 'path';
 import {container} from 'tsyringe-neo';
 import {resetTestContainer} from '../../test_container.js';
-import * as test from 'node:test';
 import {ClusterCommandTasks} from '../../../src/commands/cluster/tasks.js';
 import type {BaseCommand} from '../../../src/commands/base.js';
 import {LocalConfig} from '../../../src/core/config/local_config.js';
@@ -58,8 +57,6 @@ import type {ListrTaskWrapper} from 'listr2';
 import fs from 'fs';
 import {stringify} from 'yaml';
 import {ErrorMessages} from '../../../src/core/error_messages.js';
-import {SoloError} from '../../../src/core/errors.js';
-import {RemoteConfigDataWrapper} from '../../../src/core/config/remote/remote_config_data_wrapper.js';
 
 const getBaseCommandOpts = () => ({
   logger: sinon.stub(),
@@ -167,7 +164,7 @@ describe('ClusterCommand unit tests', () => {
     ) => {
       const loggerStub = sandbox.createStubInstance(SoloLogger);
       k8Stub = sandbox.createStubInstance(K8);
-      k8Stub.getContextNames.returns(['cluster-1', 'cluster-2', 'cluster-3']);
+      k8Stub.getContextNames.returns(['context-1', 'context-2', 'context-3']);
       k8Stub.isMinioInstalled.returns(new Promise<boolean>(() => true));
       k8Stub.isPrometheusInstalled.returns(new Promise<boolean>(() => true));
       k8Stub.isCertManagerInstalled.returns(new Promise<boolean>(() => true));

--- a/test/unit/commands/cluster.test.ts
+++ b/test/unit/commands/cluster.test.ts
@@ -195,7 +195,6 @@ describe('ClusterCommand unit tests', () => {
       remoteConfigManagerStub.get.resolves(remoteConfig);
 
       k8Stub.getCurrentClusterName.returns(kubeConfigClusterObject.name);
-      k8Stub.getCurrentCluster.returns(kubeConfigClusterObject);
       k8Stub.getCurrentContext.returns('context-from-kubeConfig');
 
       const configManager = sandbox.createStubInstance(ConfigManager);

--- a/test/unit/commands/cluster.test.ts
+++ b/test/unit/commands/cluster.test.ts
@@ -167,11 +167,7 @@ describe('ClusterCommand unit tests', () => {
     ) => {
       const loggerStub = sandbox.createStubInstance(SoloLogger);
       k8Stub = sandbox.createStubInstance(K8);
-      k8Stub.getContexts.returns([
-        {cluster: 'cluster-1', user: 'user-1', name: 'context-1', namespace: 'deployment-1'},
-        {cluster: 'cluster-2', user: 'user-2', name: 'context-2', namespace: 'deployment-2'},
-        {cluster: 'cluster-3', user: 'user-3', name: 'context-3', namespace: 'deployment-3'},
-      ]);
+      k8Stub.getContextNames.returns(['cluster-1', 'cluster-2', 'cluster-3']);
       k8Stub.isMinioInstalled.returns(new Promise<boolean>(() => true));
       k8Stub.isPrometheusInstalled.returns(new Promise<boolean>(() => true));
       k8Stub.isCertManagerInstalled.returns(new Promise<boolean>(() => true));


### PR DESCRIPTION
## Description

This pull request changes the following:

* made getContexts() private and instead have classes use getContextNames()
* moved interface TDirectoryData into its own file
* removed unused method getClusterIP()
* made methods in K8 that were only used in K8 private
* added public modifier to public methods in K8

### Related Issues

* Relates to #1039
