### PR TITLE
refactor: rename k8.testClusterConnection to testContextConnection + remove cluster parameter; removed unused methods k8.getPodIP + k8.testSocketConnection

### DIFF
--- a/src/commands/cluster/tasks.ts
+++ b/src/commands/cluster/tasks.ts
@@ -48,7 +48,7 @@ export class ClusterCommandTasks {
 
           localConfig.clusterContextMapping[cluster] = context;
         }
-        if (!(await self.parent.getK8().testClusterConnection(context, cluster))) {
+        if (!(await self.parent.getK8().testContextConnection(context))) {
           subTask.title = `${subTask.title} - ${chalk.red('Cluster connection failed')}`;
           throw new SoloError(`${ErrorMessages.INVALID_CONTEXT_FOR_CLUSTER_DETAILED(context, cluster)}`);
         }
@@ -322,7 +322,7 @@ export class ClusterCommandTasks {
           }
         }
 
-        const connectionValid = await this.parent.getK8().testClusterConnection(selectedContext, selectedCluster);
+        const connectionValid = await this.parent.getK8().testContextConnection(selectedContext);
         if (!connectionValid) {
           throw new SoloError(ErrorMessages.INVALID_CONTEXT_FOR_CLUSTER(selectedContext, selectedCluster));
         }

--- a/src/commands/deployment.ts
+++ b/src/commands/deployment.ts
@@ -96,7 +96,7 @@ export class DeploymentCommand extends BaseCommand {
               subTasks.push({
                 title: `Testing connection to cluster: ${chalk.cyan(cluster)}`,
                 task: async (_, task) => {
-                  if (!(await self.k8.testClusterConnection(context, cluster))) {
+                  if (!(await self.k8.testContextConnection(context))) {
                     task.title = `${task.title} - ${chalk.red('Cluster connection failed')}`;
 
                     throw new SoloError(`Cluster connection failed for: ${cluster}`);

--- a/test/e2e/integration/core/account_manager.test.ts
+++ b/test/e2e/integration/core/account_manager.test.ts
@@ -57,18 +57,9 @@ e2eTestSuite(namespace, argv, undefined, undefined, undefined, undefined, undefi
       // ports should be opened
       // @ts-expect-error - TS2341: Property _portForwards is private and only accessible within class AccountManager
       accountManager._portForwards.push(await k8.portForward(podName, localPort, podPort));
-      const status = await k8.testSocketConnection(localHost, localPort);
-      expect(status, 'test connection status should be true').to.be.ok;
 
       // ports should be closed
       await accountManager.close();
-      try {
-        await k8.testSocketConnection(localHost, localPort);
-      } catch (e) {
-        expect(e.message, 'expect failed test connection').to.include(
-          `failed to connect to '${localHost}:${localPort}'`,
-        );
-      }
       expect(
         // @ts-expect-error - TS2341: Property _portForwards is private and only accessible within class AccountManager
         accountManager._portForwards,

--- a/test/e2e/integration/core/k8_e2e.test.ts
+++ b/test/e2e/integration/core/k8_e2e.test.ts
@@ -164,13 +164,6 @@ describe('K8', () => {
     expect(pods).to.have.lengthOf(1);
   }).timeout(defaultTimeout);
 
-  it('should be able to detect pod IP of a pod', async () => {
-    const pods = await k8.getPodsByLabel([`app=${podLabelValue}`]);
-    const podName = pods[0].metadata.name;
-    await expect(k8.getPodIP(podName)).to.eventually.not.be.null;
-    await expect(k8.getPodIP('INVALID')).to.be.rejectedWith(SoloError);
-  }).timeout(defaultTimeout);
-
   it('should be able to check if a path is directory inside a container', async () => {
     const pods = await k8.getPodsByLabel([`app=${podLabelValue}`]);
     const podName = pods[0].metadata.name;

--- a/test/unit/commands/cluster.test.ts
+++ b/test/unit/commands/cluster.test.ts
@@ -146,7 +146,7 @@ describe('ClusterCommand unit tests', () => {
       // @ts-expect-error - TS2344: Type CommandFlag does not satisfy the constraint string | number | symbol
       stubbedFlags: Record<CommandFlag, any>[] = [],
       opts: any = {
-        testClusterConnectionError: false,
+        testContextConnectionError: false,
       },
     ) => {
       const loggerStub = sandbox.createStubInstance(SoloLogger);
@@ -156,10 +156,10 @@ describe('ClusterCommand unit tests', () => {
       k8Stub.isPrometheusInstalled.returns(new Promise<boolean>(() => true));
       k8Stub.isCertManagerInstalled.returns(new Promise<boolean>(() => true));
 
-      if (opts.testClusterConnectionError) {
-        k8Stub.testClusterConnection.resolves(false);
+      if (opts.testContextConnectionError) {
+        k8Stub.testContextConnection.resolves(false);
       } else {
-        k8Stub.testClusterConnection.resolves(true);
+        k8Stub.testContextConnection.resolves(true);
       }
 
       const kubeConfigClusterObject = {
@@ -465,7 +465,7 @@ describe('ClusterCommand unit tests', () => {
 
       it('throws error when context is invalid', async () => {
         const opts = getBaseCommandOpts(sandbox, {}, [[flags.context, 'invalid-context']], {
-          testClusterConnectionError: true,
+          testContextConnectionError: true,
         });
 
         try {
@@ -545,8 +545,8 @@ describe('ClusterCommand unit tests', () => {
         await runSubTasks(subTasks);
         expect(contextPromptStub).not.called;
         expect(command.getK8().setCurrentContext).to.have.been.calledWith('context-2');
-        expect(command.getK8().testClusterConnection).calledOnce;
-        expect(command.getK8().testClusterConnection).calledWith('context-2', 'cluster-2');
+        expect(command.getK8().testContextConnection).calledOnce;
+        expect(command.getK8().testContextConnection).calledWith('context-2');
       });
 
       it('should prompt for context when reading unknown cluster', async () => {
@@ -564,8 +564,8 @@ describe('ClusterCommand unit tests', () => {
         await runSubTasks(subTasks);
         expect(contextPromptStub).calledOnce;
         expect(command.getK8().setCurrentContext).to.have.been.calledWith('prompted-context');
-        expect(command.getK8().testClusterConnection).calledOnce;
-        expect(command.getK8().testClusterConnection).calledWith('prompted-context', 'cluster-4');
+        expect(command.getK8().testContextConnection).calledOnce;
+        expect(command.getK8().testContextConnection).calledWith('prompted-context');
       });
 
       it('should throw error for invalid prompted context', async () => {
@@ -575,7 +575,7 @@ describe('ClusterCommand unit tests', () => {
             'cluster-4': 'deployment',
           },
         });
-        const opts = getBaseCommandOpts(sandbox, remoteConfig, [], {testClusterConnectionError: true});
+        const opts = getBaseCommandOpts(sandbox, remoteConfig, [], {testContextConnectionError: true});
         command = await runReadClustersFromRemoteConfigTask(opts);
         expect(taskStub.newListr).calledOnce;
         const subTasks = taskStub.newListr.firstCall.firstArg;
@@ -586,8 +586,8 @@ describe('ClusterCommand unit tests', () => {
         } catch (e) {
           expect(e.message).to.eq(ErrorMessages.INVALID_CONTEXT_FOR_CLUSTER_DETAILED('prompted-context', 'cluster-4'));
           expect(contextPromptStub).calledOnce;
-          expect(command.getK8().testClusterConnection).calledOnce;
-          expect(command.getK8().testClusterConnection).calledWith('prompted-context', 'cluster-4');
+          expect(command.getK8().testContextConnection).calledOnce;
+          expect(command.getK8().testContextConnection).calledWith('prompted-context');
         }
       });
 
@@ -615,8 +615,8 @@ describe('ClusterCommand unit tests', () => {
         } catch (e) {
           expect(e.message).to.eq(ErrorMessages.REMOTE_CONFIGS_DO_NOT_MATCH('cluster-3', 'cluster-4'));
           expect(contextPromptStub).calledOnce;
-          expect(command.getK8().testClusterConnection).calledOnce;
-          expect(command.getK8().testClusterConnection).calledWith('prompted-context', 'cluster-4');
+          expect(command.getK8().testContextConnection).calledOnce;
+          expect(command.getK8().testContextConnection).calledWith('prompted-context');
         }
       });
     });


### PR DESCRIPTION
## Description

This pull request changes the following:

* rename k8.testClusterConnection to testContextConnection
* remove cluster parameter from k8.testContextConnection
* removed k8.getPodIP
* removed k8.testSocketConnection


### Related Issues

* Relates to #1039 
