### PR TITLE
refactor: switch codebase to use K8 interface, added k8.listSvcs(), removed k8.kubeClient references, updated interface optional parameters

### DIFF
--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -9,7 +9,7 @@ import type {LeaseManager} from '../core/lease/lease_manager.js';
 import type {LocalConfig} from '../core/config/local_config.js';
 import type {RemoteConfigManager} from '../core/config/remote/remote_config_manager.js';
 import type {Helm} from '../core/helm.js';
-import type {K8} from '../core/k8.js';
+import type K8 from '../core/kube/k8.js';
 import type {ChartManager} from '../core/chart_manager.js';
 import type {ConfigManager} from '../core/config_manager.js';
 import type {DependencyManager} from '../core/dependency_managers/index.js';

--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -9,7 +9,7 @@ import type {LeaseManager} from '../core/lease/lease_manager.js';
 import type {LocalConfig} from '../core/config/local_config.js';
 import type {RemoteConfigManager} from '../core/config/remote/remote_config_manager.js';
 import type {Helm} from '../core/helm.js';
-import type K8 from '../core/kube/k8.js';
+import {type K8} from '../core/kube/k8.js';
 import type {ChartManager} from '../core/chart_manager.js';
 import type {ConfigManager} from '../core/config_manager.js';
 import type {DependencyManager} from '../core/dependency_managers/index.js';

--- a/src/commands/cluster/tasks.ts
+++ b/src/commands/cluster/tasks.ts
@@ -15,7 +15,7 @@ import {ErrorMessages} from '../../core/error_messages.js';
 import {SoloError} from '../../core/errors.js';
 import {RemoteConfigManager} from '../../core/config/remote/remote_config_manager.js';
 import type {RemoteConfigDataWrapper} from '../../core/config/remote/remote_config_data_wrapper.js';
-import type K8 from '../../core/kube/k8.js';
+import {type K8} from '../../core/kube/k8.js';
 import type {SoloListrTask, SoloListrTaskWrapper} from '../../types/index.js';
 import type {SelectClusterContextContext} from './configs.js';
 import type {Namespace} from '../../core/config/remote/types.js';

--- a/src/commands/cluster/tasks.ts
+++ b/src/commands/cluster/tasks.ts
@@ -15,7 +15,7 @@ import {ErrorMessages} from '../../core/error_messages.js';
 import {SoloError} from '../../core/errors.js';
 import {RemoteConfigManager} from '../../core/config/remote/remote_config_manager.js';
 import type {RemoteConfigDataWrapper} from '../../core/config/remote/remote_config_data_wrapper.js';
-import type {K8} from '../../core/k8.js';
+import type K8 from '../../core/kube/k8.js';
 import type {SoloListrTask, SoloListrTaskWrapper} from '../../types/index.js';
 import type {SelectClusterContextContext} from './configs.js';
 import type {Namespace} from '../../core/config/remote/types.js';

--- a/src/commands/node/handlers.ts
+++ b/src/commands/node/handlers.ts
@@ -23,7 +23,7 @@ import * as constants from '../../core/constants.js';
 import type {AccountManager} from '../../core/account_manager.js';
 import type {ConfigManager} from '../../core/config_manager.js';
 import type {PlatformInstaller} from '../../core/platform_installer.js';
-import type K8 from '../../core/kube/k8.js';
+import {type K8} from '../../core/kube/k8.js';
 import type {LeaseManager} from '../../core/lease/lease_manager.js';
 import type {RemoteConfigManager} from '../../core/config/remote/remote_config_manager.js';
 import {IllegalArgumentError, SoloError} from '../../core/errors.js';

--- a/src/commands/node/handlers.ts
+++ b/src/commands/node/handlers.ts
@@ -23,7 +23,7 @@ import * as constants from '../../core/constants.js';
 import type {AccountManager} from '../../core/account_manager.js';
 import type {ConfigManager} from '../../core/config_manager.js';
 import type {PlatformInstaller} from '../../core/platform_installer.js';
-import type {K8} from '../../core/k8.js';
+import type K8 from '../../core/kube/k8.js';
 import type {LeaseManager} from '../../core/lease/lease_manager.js';
 import type {RemoteConfigManager} from '../../core/config/remote/remote_config_manager.js';
 import {IllegalArgumentError, SoloError} from '../../core/errors.js';

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -6,7 +6,7 @@ import type {ConfigManager} from '../../core/config_manager.js';
 import type {KeyManager} from '../../core/key_manager.js';
 import type {ProfileManager} from '../../core/profile_manager.js';
 import type {PlatformInstaller} from '../../core/platform_installer.js';
-import type {K8} from '../../core/k8.js';
+import type K8 from '../../core/kube/k8.js';
 import type {ChartManager} from '../../core/chart_manager.js';
 import type {CertificateManager} from '../../core/certificate_manager.js';
 import {Zippy} from '../../core/zippy.js';

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -6,7 +6,7 @@ import type {ConfigManager} from '../../core/config_manager.js';
 import type {KeyManager} from '../../core/key_manager.js';
 import type {ProfileManager} from '../../core/profile_manager.js';
 import type {PlatformInstaller} from '../../core/platform_installer.js';
-import type K8 from '../../core/kube/k8.js';
+import {type K8} from '../../core/kube/k8.js';
 import type {ChartManager} from '../../core/chart_manager.js';
 import type {CertificateManager} from '../../core/certificate_manager.js';
 import {Zippy} from '../../core/zippy.js';

--- a/src/core/account_manager.ts
+++ b/src/core/account_manager.ts
@@ -28,7 +28,7 @@ import {NetworkNodeServicesBuilder} from './network_node_services.js';
 import path from 'path';
 
 import {SoloLogger} from './logging.js';
-import {K8} from './k8.js';
+import type K8 from './kube/k8.js';
 import type {AccountIdWithKeyPairObject, ExtendedNetServer} from '../types/index.js';
 import type {NodeAlias, PodName, SdkNetworkEndpoint} from '../types/aliases.js';
 import {IGNORED_NODE_ACCOUNT_ID} from './constants.js';
@@ -51,10 +51,10 @@ export class AccountManager {
 
   constructor(
     @inject(SoloLogger) private readonly logger?: SoloLogger,
-    @inject(K8) private readonly k8?: K8,
+    @inject('K8') private readonly k8?: K8,
   ) {
     this.logger = patchInject(logger, SoloLogger, this.constructor.name);
-    this.k8 = patchInject(k8, K8, this.constructor.name);
+    this.k8 = patchInject(k8, 'K8', this.constructor.name);
 
     this._portForwards = [];
     this._nodeClient = null;
@@ -403,18 +403,11 @@ export class AccountManager {
     const serviceBuilderMap = new Map<NodeAlias, NetworkNodeServicesBuilder>();
 
     try {
-      const serviceList = await this.k8.kubeClient.listNamespacedService(
-        namespace,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        labelSelector,
-      );
+      const serviceList = await this.k8.listSvcs(namespace, [labelSelector]);
 
       let nodeId = '0';
       // retrieve the list of services and build custom objects for the attributes we need
-      for (const service of serviceList.body.items) {
+      for (const service of serviceList) {
         let serviceBuilder = new NetworkNodeServicesBuilder(
           service.metadata.labels['solo.hedera.com/node-name'] as NodeAlias,
         );
@@ -488,15 +481,8 @@ export class AccountManager {
 
       // get the pod name for the service to use with portForward if needed
       for (const serviceBuilder of serviceBuilderMap.values()) {
-        const podList = await this.k8.kubeClient.listNamespacedPod(
-          namespace,
-          undefined,
-          undefined,
-          undefined,
-          undefined,
-          `app=${serviceBuilder.haProxyAppSelector}`,
-        );
-        serviceBuilder.withHaProxyPodName(podList.body!.items[0].metadata.name as PodName);
+        const podList = await this.k8.getPodsByLabel([`app=${serviceBuilder.haProxyAppSelector}`]);
+        serviceBuilder.withHaProxyPodName(podList[0].metadata.name as PodName);
       }
 
       // get the pod name of the network node

--- a/src/core/account_manager.ts
+++ b/src/core/account_manager.ts
@@ -28,7 +28,7 @@ import {NetworkNodeServicesBuilder} from './network_node_services.js';
 import path from 'path';
 
 import {SoloLogger} from './logging.js';
-import type K8 from './kube/k8.js';
+import {type K8} from './kube/k8.js';
 import type {AccountIdWithKeyPairObject, ExtendedNetServer} from '../types/index.js';
 import type {NodeAlias, PodName, SdkNetworkEndpoint} from '../types/aliases.js';
 import {IGNORED_NODE_ACCOUNT_ID} from './constants.js';

--- a/src/core/certificate_manager.ts
+++ b/src/core/certificate_manager.ts
@@ -8,7 +8,7 @@ import {Templates} from './templates.js';
 import {GrpcProxyTlsEnums} from './enumerations.js';
 
 import {ConfigManager} from './config_manager.js';
-import type K8 from './kube/k8.js';
+import {type K8} from './kube/k8.js';
 import {SoloLogger} from './logging.js';
 import type {ListrTaskWrapper} from 'listr2';
 import type {NodeAlias} from '../types/aliases.js';

--- a/src/core/certificate_manager.ts
+++ b/src/core/certificate_manager.ts
@@ -8,7 +8,7 @@ import {Templates} from './templates.js';
 import {GrpcProxyTlsEnums} from './enumerations.js';
 
 import {ConfigManager} from './config_manager.js';
-import {K8} from './k8.js';
+import type K8 from './kube/k8.js';
 import {SoloLogger} from './logging.js';
 import type {ListrTaskWrapper} from 'listr2';
 import type {NodeAlias} from '../types/aliases.js';
@@ -21,11 +21,11 @@ import {patchInject} from './container_helper.js';
 @injectable()
 export class CertificateManager {
   constructor(
-    @inject(K8) private readonly k8?: K8,
+    @inject('K8') private readonly k8?: K8,
     @inject(SoloLogger) private readonly logger?: SoloLogger,
     @inject(ConfigManager) private readonly configManager?: ConfigManager,
   ) {
-    this.k8 = patchInject(k8, K8, this.constructor.name);
+    this.k8 = patchInject(k8, 'K8', this.constructor.name);
     this.logger = patchInject(logger, SoloLogger, this.constructor.name);
     this.configManager = patchInject(configManager, ConfigManager, this.constructor.name);
   }

--- a/src/core/config/local_config.ts
+++ b/src/core/config/local_config.ts
@@ -12,7 +12,7 @@ import {IsClusterContextMapping, IsDeployments} from '../validator_decorators.js
 import {ConfigManager} from '../config_manager.js';
 import type {EmailAddress, Namespace} from './remote/types.js';
 import {ErrorMessages} from '../error_messages.js';
-import type {K8} from '../k8.js';
+import type K8 from '../../core/kube/k8.js';
 import {splitFlagInput} from '../helpers.js';
 import {inject, injectable} from 'tsyringe-neo';
 import {patchInject} from '../container_helper.js';

--- a/src/core/config/local_config.ts
+++ b/src/core/config/local_config.ts
@@ -12,7 +12,7 @@ import {IsClusterContextMapping, IsDeployments} from '../validator_decorators.js
 import {ConfigManager} from '../config_manager.js';
 import type {EmailAddress, Namespace} from './remote/types.js';
 import {ErrorMessages} from '../error_messages.js';
-import type K8 from '../../core/kube/k8.js';
+import {type K8} from '../../core/kube/k8.js';
 import {splitFlagInput} from '../helpers.js';
 import {inject, injectable} from 'tsyringe-neo';
 import {patchInject} from '../container_helper.js';

--- a/src/core/config/remote/remote_config_manager.ts
+++ b/src/core/config/remote/remote_config_manager.ts
@@ -10,7 +10,7 @@ import {Flags as flags} from '../../../commands/flags.js';
 import * as yaml from 'yaml';
 import {ComponentsDataWrapper} from './components_data_wrapper.js';
 import {RemoteConfigValidator} from './remote_config_validator.js';
-import type K8 from '../../kube/k8.js';
+import {type K8} from '../../kube/k8.js';
 import type {Cluster, Context, Namespace} from './types.js';
 import {SoloLogger} from '../../logging.js';
 import {ConfigManager} from '../../config_manager.js';

--- a/src/core/config/remote/remote_config_manager.ts
+++ b/src/core/config/remote/remote_config_manager.ts
@@ -10,7 +10,7 @@ import {Flags as flags} from '../../../commands/flags.js';
 import * as yaml from 'yaml';
 import {ComponentsDataWrapper} from './components_data_wrapper.js';
 import {RemoteConfigValidator} from './remote_config_validator.js';
-import {K8} from '../../k8.js';
+import type K8 from '../../kube/k8.js';
 import type {Cluster, Context, Namespace} from './types.js';
 import {SoloLogger} from '../../logging.js';
 import {ConfigManager} from '../../config_manager.js';
@@ -41,12 +41,12 @@ export class RemoteConfigManager {
    * @param configManager - Manager to retrieve application flags and settings.
    */
   public constructor(
-    @inject(K8) private readonly k8?: K8,
+    @inject('K8') private readonly k8?: K8,
     @inject(SoloLogger) private readonly logger?: SoloLogger,
     @inject(LocalConfig) private readonly localConfig?: LocalConfig,
     @inject(ConfigManager) private readonly configManager?: ConfigManager,
   ) {
-    this.k8 = patchInject(k8, K8, this.constructor.name);
+    this.k8 = patchInject(k8, 'K8', this.constructor.name);
     this.logger = patchInject(logger, SoloLogger, this.constructor.name);
     this.localConfig = patchInject(localConfig, LocalConfig, this.constructor.name);
     this.configManager = patchInject(configManager, ConfigManager, this.constructor.name);

--- a/src/core/config/remote/remote_config_validator.ts
+++ b/src/core/config/remote/remote_config_validator.ts
@@ -4,7 +4,7 @@
 import * as constants from '../../constants.js';
 import {SoloError} from '../../errors.js';
 
-import type {K8} from '../../k8.js';
+import type K8 from '../../kube/k8.js';
 import type {ComponentsDataWrapper} from './components_data_wrapper.js';
 import type {BaseComponent} from './components/base_component.js';
 

--- a/src/core/config/remote/remote_config_validator.ts
+++ b/src/core/config/remote/remote_config_validator.ts
@@ -4,7 +4,7 @@
 import * as constants from '../../constants.js';
 import {SoloError} from '../../errors.js';
 
-import type K8 from '../../kube/k8.js';
+import {type K8} from '../../kube/k8.js';
 import type {ComponentsDataWrapper} from './components_data_wrapper.js';
 import type {BaseComponent} from './components/base_component.js';
 

--- a/src/core/container_init.ts
+++ b/src/core/container_init.ts
@@ -10,7 +10,7 @@ import * as constants from './constants.js';
 import {Helm} from './helm.js';
 import {ChartManager} from './chart_manager.js';
 import {ConfigManager} from './config_manager.js';
-import {K8} from './k8.js';
+import {K8Client} from './kube/k8_client.js';
 import {AccountManager} from './account_manager.js';
 import {PlatformInstaller} from './platform_installer.js';
 import {KeyManager} from './key_manager.js';
@@ -72,7 +72,7 @@ export class Container {
 
     container.register(ChartManager, {useClass: ChartManager}, {lifecycle: Lifecycle.Singleton});
     container.register(ConfigManager, {useClass: ConfigManager}, {lifecycle: Lifecycle.Singleton});
-    container.register(K8, {useClass: K8}, {lifecycle: Lifecycle.Singleton});
+    container.register('K8', {useClass: K8Client}, {lifecycle: Lifecycle.Singleton});
     container.register(AccountManager, {useClass: AccountManager}, {lifecycle: Lifecycle.Singleton});
     container.register(PlatformInstaller, {useClass: PlatformInstaller}, {lifecycle: Lifecycle.Singleton});
     container.register(KeyManager, {useClass: KeyManager}, {lifecycle: Lifecycle.Singleton});

--- a/src/core/kube/clusters.ts
+++ b/src/core/kube/clusters.ts
@@ -1,7 +1,7 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-export default interface Clusters {
+export interface Clusters {
   /**
    * Returns a list of clusters that are in the kubeconfig file
    * @returns a list of cluster names

--- a/src/core/kube/config_maps.ts
+++ b/src/core/kube/config_maps.ts
@@ -3,7 +3,7 @@
  */
 import {type V1ConfigMap} from '@kubernetes/client-node';
 
-export default interface Config_maps {
+export interface ConfigMaps {
   /**
    * Create a new config map
    * @param namespace - for the config map

--- a/src/core/kube/contexts.ts
+++ b/src/core/kube/contexts.ts
@@ -1,7 +1,7 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-export default interface Contexts {
+export interface Contexts {
   /**
    * List all contexts in the kubeconfig
    * @returns a list of context names

--- a/src/core/kube/k8.ts
+++ b/src/core/kube/k8.ts
@@ -2,14 +2,14 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type * as k8s from '@kubernetes/client-node';
-import type {PodName, TarCreateFilter} from '../../types/aliases.js';
-import type {ExtendedNetServer, Optional} from '../../types/index.js';
-import type TDirectoryData from './t_directory_data.js';
+import {type PodName, type TarCreateFilter} from '../../types/aliases.js';
+import {type ExtendedNetServer, type Optional} from '../../types/index.js';
+import {type TDirectoryData} from './t_directory_data.js';
 import {type V1Lease} from '@kubernetes/client-node';
 import {type Namespace} from '../config/remote/types.js';
 import {type Namespaces} from './namespaces.js';
 
-export default interface K8 {
+export interface K8 {
   namespaces(): Namespaces;
 
   /**

--- a/src/core/kube/k8.ts
+++ b/src/core/kube/k8.ts
@@ -9,11 +9,7 @@ import {type V1Lease} from '@kubernetes/client-node';
 import {type Namespace} from '../config/remote/types.js';
 import {type Namespaces} from './namespaces.js';
 
-// TODO rename TK8 to K8 and K8 to K8Client
-// TODO talk about get and set implies local with no integration, versus read and update implies remote should we use
-//  - read and update or something besides get/set to avoid confusion
-//  - Nathan: use read() instead of get(), and update() instead of set()
-export default interface TK8 {
+export default interface K8 {
   namespaces(): Namespaces;
 
   /**

--- a/src/core/kube/k8.ts
+++ b/src/core/kube/k8.ts
@@ -56,6 +56,8 @@ export default interface K8 {
    */
   getSvcByName(name: string): Promise<k8s.V1Service>;
 
+  listSvcs(namespace: string, labels: string[]): Promise<k8s.V1Service[]>;
+
   /**
    * Get a list of clusters
    * @returns a list of cluster names
@@ -96,7 +98,7 @@ export default interface K8 {
    * @param destPath - path inside the container
    * @param [filters] - an object with metadata fields and value
    */
-  hasFile(podName: PodName, containerName: string, destPath: string, filters: object): Promise<boolean>;
+  hasFile(podName: PodName, containerName: string, destPath: string, filters?: object): Promise<boolean>;
 
   /**
    * Check if a directory path exists in the container
@@ -125,7 +127,7 @@ export default interface K8 {
     containerName: string,
     srcPath: string,
     destDir: string,
-    filter: TarCreateFilter | undefined,
+    filter?: TarCreateFilter | undefined,
   ): Promise<boolean>;
 
   /**
@@ -164,14 +166,14 @@ export default interface K8 {
    * @param [maxAttempts] - the maximum number of attempts to check if the server is stopped
    * @param [timeout] - the delay between checks in milliseconds
    */
-  stopPortForward(server: ExtendedNetServer, maxAttempts, timeout): Promise<void>;
+  stopPortForward(server: ExtendedNetServer, maxAttempts?, timeout?): Promise<void>;
 
   waitForPods(
-    phases,
-    labels: string[],
-    podCount,
-    maxAttempts,
-    delay,
+    phases?,
+    labels?: string[],
+    podCount?,
+    maxAttempts?,
+    delay?,
     podItemPredicate?: (items: k8s.V1Pod) => boolean,
     namespace?: string,
   ): Promise<k8s.V1Pod[]>;
@@ -184,7 +186,7 @@ export default interface K8 {
    * @param [delay] - delay between checks in milliseconds
    * @param [namespace] - namespace
    */
-  waitForPodReady(labels: string[], podCount, maxAttempts, delay, namespace?: string): Promise<k8s.V1Pod[]>;
+  waitForPodReady(labels: string[], podCount?, maxAttempts?, delay?, namespace?: string): Promise<k8s.V1Pod[]>;
 
   /**
    * Get a list of persistent volume claim names for the given namespace
@@ -192,7 +194,7 @@ export default interface K8 {
    * @param [labels] - labels
    * @returns list of persistent volume claim names
    */
-  listPvcsByNamespace(namespace: string, labels: string[]): Promise<string[]>;
+  listPvcsByNamespace(namespace: string, labels?: string[]): Promise<string[]>;
 
   /**
    * Get a list of secrets for the given namespace
@@ -200,7 +202,7 @@ export default interface K8 {
    * @param [labels] - labels
    * @returns list of secret names
    */
-  listSecretsByNamespace(namespace: string, labels: string[]): Promise<string[]>;
+  listSecretsByNamespace(namespace: string, labels?: string[]): Promise<string[]>;
 
   /**
    * Delete a persistent volume claim
@@ -295,7 +297,7 @@ export default interface K8 {
     durationSeconds,
   ): Promise<k8s.V1Lease>;
 
-  readNamespacedLease(leaseName: string, namespace: string, timesCalled): Promise<any>;
+  readNamespacedLease(leaseName: string, namespace: string, timesCalled?): Promise<any>;
 
   renewNamespaceLease(leaseName: string, namespace: string, lease: k8s.V1Lease): Promise<k8s.V1Lease>;
 

--- a/src/core/kube/k8_client.ts
+++ b/src/core/kube/k8_client.ts
@@ -20,14 +20,14 @@ import * as constants from './../constants.js';
 import {HEDERA_HAPI_PATH, ROOT_CONTAINER, SOLO_LOGS_DIR} from './../constants.js';
 import {ConfigManager} from './../config_manager.js';
 import {SoloLogger} from './../logging.js';
-import type {PodName, TarCreateFilter} from '../../types/aliases.js';
-import type {ExtendedNetServer, LocalContextObject, Optional} from '../../types/index.js';
+import {type PodName, type TarCreateFilter} from '../../types/aliases.js';
+import {type ExtendedNetServer, type LocalContextObject, type Optional} from '../../types/index.js';
 import {Duration} from './../time/duration.js';
 import {inject, injectable} from 'tsyringe-neo';
 import {patchInject} from './../container_helper.js';
-import type {Namespace} from './../config/remote/types.js';
-import type K8 from './k8.js';
-import type TDirectoryData from './t_directory_data.js';
+import {type Namespace} from './../config/remote/types.js';
+import {type K8} from './k8.js';
+import {type TDirectoryData} from './t_directory_data.js';
 import {type Namespaces} from './namespaces.js';
 
 /**

--- a/src/core/kube/k8_client.ts
+++ b/src/core/kube/k8_client.ts
@@ -1552,4 +1552,17 @@ export class K8Client implements K8 {
     if (!currentCluster) return '';
     return currentCluster.name;
   }
+
+  public async listSvcs(namespace: string, labels: string[]): Promise<k8s.V1Service[]> {
+    const labelSelector = labels.join(',');
+    const serviceList = await this.kubeClient.listNamespacedService(
+      namespace,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      labelSelector,
+    );
+    return serviceList.body.items;
+  }
 }

--- a/src/core/kube/leases.ts
+++ b/src/core/kube/leases.ts
@@ -3,7 +3,7 @@
  */
 import {type V1Lease, type V1Status} from '@kubernetes/client-node';
 
-export default interface Leases {
+export interface Leases {
   /**
    * Create a new lease
    * @param namespace - the namespace to create the lease in

--- a/src/core/kube/pod.ts
+++ b/src/core/kube/pod.ts
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import {type ExtendedNetServer} from '../../types/index.js';
-import type TDirectoryData from './t_directory_data.js';
+import {type TDirectoryData} from './t_directory_data.js';
 import {type TarCreateFilter} from '../../types/aliases.js';
 
 export interface Pod {

--- a/src/core/kube/pods.ts
+++ b/src/core/kube/pods.ts
@@ -3,7 +3,7 @@
  */
 import {type V1Pod} from '@kubernetes/client-node';
 
-export default interface Pods {
+export interface Pods {
   /**
    * Get a pod by name
    * @param namespace - the namespace of the pod

--- a/src/core/kube/pvcs.ts
+++ b/src/core/kube/pvcs.ts
@@ -1,7 +1,7 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-export default interface Pvcs {
+export interface Pvcs {
   /**
    * Delete a persistent volume claim
    * @param namespace - the namespace of the persistent volume claim to delete

--- a/src/core/kube/secrets.ts
+++ b/src/core/kube/secrets.ts
@@ -3,7 +3,7 @@
  */
 import {type Optional} from '../../types/index.js';
 
-export default interface Secrets {
+export interface Secrets {
   /**
    * creates a new Kubernetes secret with the provided attributes
    * @param namespace - the namespace to store the secret

--- a/src/core/kube/services.ts
+++ b/src/core/kube/services.ts
@@ -3,7 +3,7 @@
  */
 import {type V1Service} from '@kubernetes/client-node';
 
-export default interface Services {
+export interface Services {
   /**
    * Get a svc by name
    * @param namespace - namespace

--- a/src/core/kube/services.ts
+++ b/src/core/kube/services.ts
@@ -10,4 +10,11 @@ export default interface Services {
    * @param name - service name
    */
   read(namespace: string, name: string): Promise<V1Service>; // TODO was getSvcByName
+
+  /**
+   * List all services in a namespace
+   * @param namespace - namespace
+   * @param labels - labels
+   */
+  list(namespace: string, labels: string[]): Promise<V1Service[]>; // TODO was listSvcs
 }

--- a/src/core/kube/t_directory_data.ts
+++ b/src/core/kube/t_directory_data.ts
@@ -1,7 +1,7 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-export default interface TDirectoryData {
+export interface TDirectoryData {
   directory: boolean;
   owner: string;
   group: string;

--- a/src/core/lease/interval_lease.ts
+++ b/src/core/lease/interval_lease.ts
@@ -3,7 +3,7 @@
  */
 import {MissingArgumentError, SoloError} from '../errors.js';
 import type {V1Lease} from '@kubernetes/client-node';
-import type K8 from '../../core/kube/k8.js';
+import {type K8} from '../../core/kube/k8.js';
 import {LeaseHolder} from './lease_holder.js';
 import {LeaseAcquisitionError, LeaseRelinquishmentError} from './lease_errors.js';
 import {sleep} from '../helpers.js';

--- a/src/core/lease/interval_lease.ts
+++ b/src/core/lease/interval_lease.ts
@@ -3,7 +3,7 @@
  */
 import {MissingArgumentError, SoloError} from '../errors.js';
 import type {V1Lease} from '@kubernetes/client-node';
-import type {K8} from '../k8.js';
+import type K8 from '../../core/kube/k8.js';
 import {LeaseHolder} from './lease_holder.js';
 import {LeaseAcquisitionError, LeaseRelinquishmentError} from './lease_errors.js';
 import {sleep} from '../helpers.js';

--- a/src/core/lease/lease.ts
+++ b/src/core/lease/lease.ts
@@ -1,7 +1,7 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-import type K8 from '../../core/kube/k8.js';
+import {type K8} from '../../core/kube/k8.js';
 import type {LeaseHolder} from './lease_holder.js';
 import type {Duration} from '../time/duration.js';
 

--- a/src/core/lease/lease.ts
+++ b/src/core/lease/lease.ts
@@ -1,7 +1,7 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-import type {K8} from '../k8.js';
+import type K8 from '../../core/kube/k8.js';
 import type {LeaseHolder} from './lease_holder.js';
 import type {Duration} from '../time/duration.js';
 

--- a/src/core/lease/lease_manager.ts
+++ b/src/core/lease/lease_manager.ts
@@ -3,7 +3,7 @@
  */
 import {Flags as flags} from '../../commands/flags.js';
 import {ConfigManager} from '../config_manager.js';
-import type K8 from '../../core/kube/k8.js';
+import {type K8} from '../../core/kube/k8.js';
 import {SoloLogger} from '../logging.js';
 import {type Lease, type LeaseRenewalService} from './lease.js';
 import {IntervalLease} from './interval_lease.js';

--- a/src/core/lease/lease_manager.ts
+++ b/src/core/lease/lease_manager.ts
@@ -3,7 +3,7 @@
  */
 import {Flags as flags} from '../../commands/flags.js';
 import {ConfigManager} from '../config_manager.js';
-import {K8} from '../k8.js';
+import type K8 from '../../core/kube/k8.js';
 import {SoloLogger} from '../logging.js';
 import {type Lease, type LeaseRenewalService} from './lease.js';
 import {IntervalLease} from './interval_lease.js';
@@ -28,12 +28,12 @@ export class LeaseManager {
   constructor(
     @inject('LeaseRenewalService') private readonly _renewalService?: LeaseRenewalService,
     @inject(SoloLogger) private readonly _logger?: SoloLogger,
-    @inject(K8) private readonly k8?: K8,
+    @inject('K8') private readonly k8?: K8,
     @inject(ConfigManager) private readonly configManager?: ConfigManager,
   ) {
     this._renewalService = patchInject(_renewalService, 'LeaseRenewalService', this.constructor.name);
     this._logger = patchInject(_logger, SoloLogger, this.constructor.name);
-    this.k8 = patchInject(k8, K8, this.constructor.name);
+    this.k8 = patchInject(k8, 'K8', this.constructor.name);
     this.configManager = patchInject(configManager, ConfigManager, this.constructor.name);
   }
 

--- a/src/core/platform_installer.ts
+++ b/src/core/platform_installer.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import {SoloError, IllegalArgumentError, MissingArgumentError} from './errors.js';
 import * as constants from './constants.js';
 import {ConfigManager} from './config_manager.js';
-import {K8} from './k8.js';
+import type K8 from '../core/kube/k8.js';
 import {Templates} from './templates.js';
 import {Flags as flags} from '../commands/flags.js';
 import * as Base64 from 'js-base64';
@@ -25,11 +25,11 @@ import {patchInject} from './container_helper.js';
 export class PlatformInstaller {
   constructor(
     @inject(SoloLogger) private logger?: SoloLogger,
-    @inject(K8) private k8?: K8,
+    @inject('K8') private k8?: K8,
     @inject(ConfigManager) private configManager?: ConfigManager,
   ) {
     this.logger = patchInject(logger, SoloLogger, this.constructor.name);
-    this.k8 = patchInject(k8, K8, this.constructor.name);
+    this.k8 = patchInject(k8, 'K8', this.constructor.name);
     this.configManager = patchInject(configManager, ConfigManager, this.constructor.name);
   }
 

--- a/src/core/platform_installer.ts
+++ b/src/core/platform_installer.ts
@@ -7,7 +7,7 @@ import * as path from 'path';
 import {SoloError, IllegalArgumentError, MissingArgumentError} from './errors.js';
 import * as constants from './constants.js';
 import {ConfigManager} from './config_manager.js';
-import type K8 from '../core/kube/k8.js';
+import {type K8} from '../core/kube/k8.js';
 import {Templates} from './templates.js';
 import {Flags as flags} from '../commands/flags.js';
 import * as Base64 from 'js-base64';

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import {CertificateManager} from './core/certificate_manager.js';
 import {LocalConfig} from './core/config/local_config.js';
 import {RemoteConfigManager} from './core/config/remote/remote_config_manager.js';
 import * as helpers from './core/helpers.js';
-import {K8} from './core/k8.js';
+import type K8 from './core/kube/k8.js';
 import {CustomProcessOutput} from './core/process_output.js';
 import type {Opts} from './types/command_types.js';
 import {SoloLogger} from './core/logging.js';
@@ -53,7 +53,7 @@ export function main(argv: any) {
     const helm = container.resolve(Helm);
     const chartManager = container.resolve(ChartManager);
     const configManager = container.resolve(ConfigManager);
-    const k8 = container.resolve(K8);
+    const k8 = container.resolve('K8') as K8;
     const accountManager = container.resolve(AccountManager);
     const platformInstaller = container.resolve(PlatformInstaller);
     const keyManager = container.resolve(KeyManager);

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ import {CertificateManager} from './core/certificate_manager.js';
 import {LocalConfig} from './core/config/local_config.js';
 import {RemoteConfigManager} from './core/config/remote/remote_config_manager.js';
 import * as helpers from './core/helpers.js';
-import type K8 from './core/kube/k8.js';
+import {type K8} from './core/kube/k8.js';
 import {CustomProcessOutput} from './core/process_output.js';
 import type {Opts} from './types/command_types.js';
 import {SoloLogger} from './core/logging.js';

--- a/src/types/command_types.ts
+++ b/src/types/command_types.ts
@@ -3,7 +3,7 @@
  */
 import type {SoloLogger} from '../core/logging.js';
 import type {Helm} from '../core/helm.js';
-import type K8 from '../core/kube/k8.js';
+import {type K8} from '../core/kube/k8.js';
 import type {PackageDownloader} from '../core/package_downloader.js';
 import type {PlatformInstaller} from '../core/platform_installer.js';
 import type {ChartManager} from '../core/chart_manager.js';

--- a/src/types/command_types.ts
+++ b/src/types/command_types.ts
@@ -3,7 +3,7 @@
  */
 import type {SoloLogger} from '../core/logging.js';
 import type {Helm} from '../core/helm.js';
-import type {K8} from '../core/k8.js';
+import type K8 from '../core/kube/k8.js';
 import type {PackageDownloader} from '../core/package_downloader.js';
 import type {PlatformInstaller} from '../core/platform_installer.js';
 import type {ChartManager} from '../core/chart_manager.js';

--- a/test/e2e/commands/account.test.ts
+++ b/test/e2e/commands/account.test.ts
@@ -23,7 +23,7 @@ import {e2eTestSuite, getDefaultArgv, HEDERA_PLATFORM_VERSION_TAG, TEST_CLUSTER,
 import {AccountCommand} from '../../../src/commands/account.js';
 import {Flags as flags} from '../../../src/commands/flags.js';
 import {Duration} from '../../../src/core/time/duration.js';
-import type K8 from '../../../src/core/kube/k8.js';
+import {type K8} from '../../../src/core/kube/k8.js';
 import {type AccountManager} from '../../../src/core/account_manager.js';
 import {type ConfigManager} from '../../../src/core/config_manager.js';
 import {type NodeCommand} from '../../../src/commands/node/index.js';

--- a/test/e2e/commands/account.test.ts
+++ b/test/e2e/commands/account.test.ts
@@ -23,7 +23,7 @@ import {e2eTestSuite, getDefaultArgv, HEDERA_PLATFORM_VERSION_TAG, TEST_CLUSTER,
 import {AccountCommand} from '../../../src/commands/account.js';
 import {Flags as flags} from '../../../src/commands/flags.js';
 import {Duration} from '../../../src/core/time/duration.js';
-import {type K8} from '../../../src/core/k8.js';
+import type K8 from '../../../src/core/kube/k8.js';
 import {type AccountManager} from '../../../src/core/account_manager.js';
 import {type ConfigManager} from '../../../src/core/config_manager.js';
 import {type NodeCommand} from '../../../src/commands/node/index.js';

--- a/test/e2e/commands/node_local_hedera.test.ts
+++ b/test/e2e/commands/node_local_hedera.test.ts
@@ -7,7 +7,7 @@ import {Flags as flags} from '../../../src/commands/flags.js';
 import {e2eTestSuite, getDefaultArgv, TEST_CLUSTER} from '../../test_util.js';
 import {sleep} from '../../../src/core/helpers.js';
 import {SOLO_LOGS_DIR} from '../../../src/core/constants.js';
-import type K8 from '../../../src/core/kube/k8.js';
+import {type K8} from '../../../src/core/kube/k8.js';
 import path from 'path';
 import {expect} from 'chai';
 import {AccountBalanceQuery, AccountCreateTransaction, Hbar, HbarUnit, PrivateKey} from '@hashgraph/sdk';

--- a/test/e2e/commands/node_local_hedera.test.ts
+++ b/test/e2e/commands/node_local_hedera.test.ts
@@ -7,7 +7,7 @@ import {Flags as flags} from '../../../src/commands/flags.js';
 import {e2eTestSuite, getDefaultArgv, TEST_CLUSTER} from '../../test_util.js';
 import {sleep} from '../../../src/core/helpers.js';
 import {SOLO_LOGS_DIR} from '../../../src/core/constants.js';
-import {type K8} from '../../../src/core/k8.js';
+import type K8 from '../../../src/core/kube/k8.js';
 import path from 'path';
 import {expect} from 'chai';
 import {AccountBalanceQuery, AccountCreateTransaction, Hbar, HbarUnit, PrivateKey} from '@hashgraph/sdk';

--- a/test/e2e/commands/node_local_ptt.test.ts
+++ b/test/e2e/commands/node_local_ptt.test.ts
@@ -6,7 +6,7 @@ import {describe} from 'mocha';
 import {Flags as flags} from '../../../src/commands/flags.js';
 import {e2eTestSuite, getDefaultArgv, TEST_CLUSTER} from '../../test_util.js';
 import {Duration} from '../../../src/core/time/duration.js';
-import type K8 from '../../../src/core/kube/k8.js';
+import {type K8} from '../../../src/core/kube/k8.js';
 import {LOCAL_HEDERA_PLATFORM_VERSION} from '../../../version.js';
 
 const LOCAL_PTT = 'local-ptt-app';

--- a/test/e2e/commands/node_local_ptt.test.ts
+++ b/test/e2e/commands/node_local_ptt.test.ts
@@ -6,7 +6,7 @@ import {describe} from 'mocha';
 import {Flags as flags} from '../../../src/commands/flags.js';
 import {e2eTestSuite, getDefaultArgv, TEST_CLUSTER} from '../../test_util.js';
 import {Duration} from '../../../src/core/time/duration.js';
-import {type K8} from '../../../src/core/k8.js';
+import type K8 from '../../../src/core/kube/k8.js';
 import {LOCAL_HEDERA_PLATFORM_VERSION} from '../../../version.js';
 
 const LOCAL_PTT = 'local-ptt-app';

--- a/test/e2e/e2e_node_util.ts
+++ b/test/e2e/e2e_node_util.ts
@@ -19,7 +19,7 @@ import * as NodeCommandConfigs from '../../src/commands/node/configs.js';
 import type {NodeAlias} from '../../src/types/aliases.js';
 import type {ListrTaskWrapper} from 'listr2';
 import {ConfigManager} from '../../src/core/config_manager.js';
-import {type K8} from '../../src/core/k8.js';
+import type K8 from '../../src/core/kube/k8.js';
 import {type NodeCommand} from '../../src/commands/node/index.js';
 import {Duration} from '../../src/core/time/duration.js';
 import {StatusCodes} from 'http-status-codes';
@@ -100,9 +100,7 @@ export function e2eNodeKeyRefreshTest(testName: string, mode: string, releaseTag
 
             const podName = await nodeRefreshTestSetup(argv, testName, k8, nodeAlias);
             if (mode === 'kill') {
-              const resp = await k8.kubeClient.deleteNamespacedPod(podName, namespace);
-              expect(resp.response.statusCode).to.equal(StatusCodes.OK);
-              await sleep(Duration.ofSeconds(20)); // sleep to wait for pod to finish terminating
+              await k8.killPod(podName, namespace);
             } else if (mode === 'stop') {
               expect(await nodeCmd.handlers.stop(argv)).to.be.true;
               await sleep(Duration.ofSeconds(20)); // give time for node to stop and update its logs

--- a/test/e2e/e2e_node_util.ts
+++ b/test/e2e/e2e_node_util.ts
@@ -19,7 +19,7 @@ import * as NodeCommandConfigs from '../../src/commands/node/configs.js';
 import type {NodeAlias} from '../../src/types/aliases.js';
 import type {ListrTaskWrapper} from 'listr2';
 import {ConfigManager} from '../../src/core/config_manager.js';
-import type K8 from '../../src/core/kube/k8.js';
+import {type K8} from '../../src/core/kube/k8.js';
 import {type NodeCommand} from '../../src/commands/node/index.js';
 import {Duration} from '../../src/core/time/duration.js';
 import {StatusCodes} from 'http-status-codes';

--- a/test/e2e/integration/commands/init.test.ts
+++ b/test/e2e/integration/commands/init.test.ts
@@ -9,7 +9,7 @@ import {DependencyManager} from '../../../../src/core/dependency_managers/index.
 import {Helm} from '../../../../src/core/helm.js';
 import {ChartManager} from '../../../../src/core/chart_manager.js';
 import {ConfigManager} from '../../../../src/core/config_manager.js';
-import type K8 from '../../../../src/core/kube/k8.js';
+import {type K8} from '../../../../src/core/kube/k8.js';
 import {K8Client} from '../../../../src/core/kube/k8_client.js';
 import {LocalConfig} from '../../../../src/core/config/local_config.js';
 import {KeyManager} from '../../../../src/core/key_manager.js';

--- a/test/e2e/integration/commands/init.test.ts
+++ b/test/e2e/integration/commands/init.test.ts
@@ -9,7 +9,8 @@ import {DependencyManager} from '../../../../src/core/dependency_managers/index.
 import {Helm} from '../../../../src/core/helm.js';
 import {ChartManager} from '../../../../src/core/chart_manager.js';
 import {ConfigManager} from '../../../../src/core/config_manager.js';
-import {K8} from '../../../../src/core/k8.js';
+import type K8 from '../../../../src/core/kube/k8.js';
+import {K8Client} from '../../../../src/core/kube/k8_client.js';
 import {LocalConfig} from '../../../../src/core/config/local_config.js';
 import {KeyManager} from '../../../../src/core/key_manager.js';
 import {LeaseManager} from '../../../../src/core/lease/lease_manager.js';
@@ -41,8 +42,8 @@ describe('InitCommand', () => {
 
   before(() => {
     sandbox = sinon.createSandbox();
-    sandbox.stub(K8.prototype, 'init').callsFake(() => this);
-    k8 = container.resolve(K8);
+    sandbox.stub(K8Client.prototype, 'init').callsFake(() => this);
+    k8 = container.resolve('K8');
     localConfig = new LocalConfig(path.join(BASE_TEST_DIR, 'local-config.yaml'));
     remoteConfigManager = container.resolve(RemoteConfigManager);
     leaseManager = container.resolve(LeaseManager);

--- a/test/e2e/integration/core/account_manager.test.ts
+++ b/test/e2e/integration/core/account_manager.test.ts
@@ -9,7 +9,7 @@ import {e2eTestSuite, getDefaultArgv, TEST_CLUSTER} from '../../../test_util.js'
 import * as version from '../../../../version.js';
 import type {PodName} from '../../../../src/types/aliases.js';
 import {Duration} from '../../../../src/core/time/duration.js';
-import type K8 from '../../../../src/core/kube/k8.js';
+import {type K8} from '../../../../src/core/kube/k8.js';
 import {type AccountManager} from '../../../../src/core/account_manager.js';
 
 const namespace = 'account-mngr-e2e';

--- a/test/e2e/integration/core/account_manager.test.ts
+++ b/test/e2e/integration/core/account_manager.test.ts
@@ -9,7 +9,7 @@ import {e2eTestSuite, getDefaultArgv, TEST_CLUSTER} from '../../../test_util.js'
 import * as version from '../../../../version.js';
 import type {PodName} from '../../../../src/types/aliases.js';
 import {Duration} from '../../../../src/core/time/duration.js';
-import {type K8} from '../../../../src/core/k8.js';
+import type K8 from '../../../../src/core/kube/k8.js';
 import {type AccountManager} from '../../../../src/core/account_manager.js';
 
 const namespace = 'account-mngr-e2e';

--- a/test/e2e/integration/core/k8_e2e.test.ts
+++ b/test/e2e/integration/core/k8_e2e.test.ts
@@ -15,7 +15,6 @@ import * as constants from '../../../../src/core/constants.js';
 import {Templates} from '../../../../src/core/templates.js';
 import {ConfigManager} from '../../../../src/core/config_manager.js';
 import * as logging from '../../../../src/core/logging.js';
-import type K8 from '../../../../src/core/kube/k8.js';
 import {Flags as flags} from '../../../../src/commands/flags.js';
 import {
   V1Container,

--- a/test/e2e/integration/core/k8_e2e.test.ts
+++ b/test/e2e/integration/core/k8_e2e.test.ts
@@ -15,7 +15,7 @@ import * as constants from '../../../../src/core/constants.js';
 import {Templates} from '../../../../src/core/templates.js';
 import {ConfigManager} from '../../../../src/core/config_manager.js';
 import * as logging from '../../../../src/core/logging.js';
-import {K8} from '../../../../src/core/k8.js';
+import type K8 from '../../../../src/core/kube/k8.js';
 import {Flags as flags} from '../../../../src/commands/flags.js';
 import {
   V1Container,
@@ -35,6 +35,7 @@ import crypto from 'crypto';
 import type {PodName} from '../../../../src/types/aliases.js';
 import {Duration} from '../../../../src/core/time/duration.js';
 import {container} from 'tsyringe-neo';
+import {type K8Client} from '../../../../src/core/kube/k8_client.js';
 
 const defaultTimeout = Duration.ofMinutes(2).toMillis();
 
@@ -43,7 +44,7 @@ async function createPod(
   containerName: string,
   podLabelValue: string,
   testNamespace: string,
-  k8: K8,
+  k8: K8Client,
 ): Promise<void> {
   const v1Pod = new V1Pod();
   const v1Metadata = new V1ObjectMeta();
@@ -69,7 +70,7 @@ async function createPod(
 describe('K8', () => {
   const testLogger = logging.NewLogger('debug', true);
   const configManager = container.resolve(ConfigManager);
-  const k8 = container.resolve(K8);
+  const k8 = container.resolve('K8') as K8Client;
   const testNamespace = 'k8-e2e';
   const argv = [];
   const podName = `test-pod-${uuid4()}` as PodName;

--- a/test/e2e/integration/core/lease.test.ts
+++ b/test/e2e/integration/core/lease.test.ts
@@ -4,7 +4,7 @@
 import {it, describe, before, after} from 'mocha';
 import {ConfigManager} from '../../../../src/core/config_manager.js';
 import * as logging from '../../../../src/core/logging.js';
-import {K8} from '../../../../src/core/k8.js';
+import type K8 from '../../../../src/core/kube/k8.js';
 import {expect} from 'chai';
 import {IntervalLease} from '../../../../src/core/lease/interval_lease.js';
 import {LeaseHolder} from '../../../../src/core/lease/lease_holder.js';
@@ -20,7 +20,7 @@ const leaseDuration = 4;
 describe('Lease', async () => {
   const testLogger = logging.NewLogger('debug', true);
   const configManager = container.resolve(ConfigManager);
-  const k8 = container.resolve(K8);
+  const k8 = container.resolve('K8') as K8;
   const testNamespace = 'lease-e2e';
   const renewalService = new NoopLeaseRenewalService();
 

--- a/test/e2e/integration/core/lease.test.ts
+++ b/test/e2e/integration/core/lease.test.ts
@@ -4,7 +4,7 @@
 import {it, describe, before, after} from 'mocha';
 import {ConfigManager} from '../../../../src/core/config_manager.js';
 import * as logging from '../../../../src/core/logging.js';
-import type K8 from '../../../../src/core/kube/k8.js';
+import {type K8} from '../../../../src/core/kube/k8.js';
 import {expect} from 'chai';
 import {IntervalLease} from '../../../../src/core/lease/interval_lease.js';
 import {LeaseHolder} from '../../../../src/core/lease/lease_holder.js';

--- a/test/e2e/integration/core/lease_renewal.test.ts
+++ b/test/e2e/integration/core/lease_renewal.test.ts
@@ -4,7 +4,7 @@
 import {it, describe, before, after} from 'mocha';
 import {ConfigManager} from '../../../../src/core/config_manager.js';
 import * as logging from '../../../../src/core/logging.js';
-import {K8} from '../../../../src/core/k8.js';
+import type K8 from '../../../../src/core/kube/k8.js';
 import {expect} from 'chai';
 import {IntervalLease} from '../../../../src/core/lease/interval_lease.js';
 import {LeaseHolder} from '../../../../src/core/lease/lease_holder.js';
@@ -20,7 +20,7 @@ const leaseDuration = 4;
 describe('LeaseRenewalService', async () => {
   const testLogger = logging.NewLogger('debug', true);
   const configManager = container.resolve(ConfigManager);
-  const k8 = container.resolve(K8);
+  const k8 = container.resolve('K8') as K8;
   const renewalService = container.resolve(IntervalLeaseRenewalService);
   const testNamespace = 'lease-renewal-e2e';
 

--- a/test/e2e/integration/core/lease_renewal.test.ts
+++ b/test/e2e/integration/core/lease_renewal.test.ts
@@ -4,7 +4,7 @@
 import {it, describe, before, after} from 'mocha';
 import {ConfigManager} from '../../../../src/core/config_manager.js';
 import * as logging from '../../../../src/core/logging.js';
-import type K8 from '../../../../src/core/kube/k8.js';
+import {type K8} from '../../../../src/core/kube/k8.js';
 import {expect} from 'chai';
 import {IntervalLease} from '../../../../src/core/lease/interval_lease.js';
 import {LeaseHolder} from '../../../../src/core/lease/lease_holder.js';

--- a/test/e2e/integration/core/platform_installer_e2e.test.ts
+++ b/test/e2e/integration/core/platform_installer_e2e.test.ts
@@ -11,7 +11,7 @@ import {e2eTestSuite, getDefaultArgv, getTestCacheDir, TEST_CLUSTER, testLogger}
 import {Flags as flags} from '../../../../src/commands/flags.js';
 import * as version from '../../../../version.js';
 import {Duration} from '../../../../src/core/time/duration.js';
-import {type K8} from '../../../../src/core/k8.js';
+import type K8 from '../../../../src/core/kube/k8.js';
 import {type AccountManager} from '../../../../src/core/account_manager.js';
 import {type PlatformInstaller} from '../../../../src/core/platform_installer.js';
 

--- a/test/e2e/integration/core/platform_installer_e2e.test.ts
+++ b/test/e2e/integration/core/platform_installer_e2e.test.ts
@@ -11,7 +11,7 @@ import {e2eTestSuite, getDefaultArgv, getTestCacheDir, TEST_CLUSTER, testLogger}
 import {Flags as flags} from '../../../../src/commands/flags.js';
 import * as version from '../../../../version.js';
 import {Duration} from '../../../../src/core/time/duration.js';
-import type K8 from '../../../../src/core/kube/k8.js';
+import {type K8} from '../../../../src/core/kube/k8.js';
 import {type AccountManager} from '../../../../src/core/account_manager.js';
 import {type PlatformInstaller} from '../../../../src/core/platform_installer.js';
 

--- a/test/e2e/integration/core/remote_config_manager.test.ts
+++ b/test/e2e/integration/core/remote_config_manager.test.ts
@@ -15,7 +15,7 @@ import {SoloError} from '../../../../src/core/errors.js';
 import {RemoteConfigDataWrapper} from '../../../../src/core/config/remote/remote_config_data_wrapper.js';
 import {Duration} from '../../../../src/core/time/duration.js';
 import {container} from 'tsyringe-neo';
-import {type K8} from '../../../../src/core/k8.js';
+import type K8 from '../../../../src/core/kube/k8.js';
 
 const defaultTimeout = Duration.ofSeconds(20).toMillis();
 

--- a/test/e2e/integration/core/remote_config_manager.test.ts
+++ b/test/e2e/integration/core/remote_config_manager.test.ts
@@ -15,7 +15,7 @@ import {SoloError} from '../../../../src/core/errors.js';
 import {RemoteConfigDataWrapper} from '../../../../src/core/config/remote/remote_config_data_wrapper.js';
 import {Duration} from '../../../../src/core/time/duration.js';
 import {container} from 'tsyringe-neo';
-import type K8 from '../../../../src/core/kube/k8.js';
+import {type K8} from '../../../../src/core/kube/k8.js';
 
 const defaultTimeout = Duration.ofSeconds(20).toMillis();
 

--- a/test/e2e/integration/core/remote_config_validator.test.ts
+++ b/test/e2e/integration/core/remote_config_validator.test.ts
@@ -6,7 +6,6 @@ import {expect} from 'chai';
 
 import * as constants from '../../../../src/core/constants.js';
 import {ConfigManager} from '../../../../src/core/config_manager.js';
-import {type K8} from '../../../../src/core/kube/k8.js';
 import {type K8Client} from '../../../../src/core/kube/k8_client.js';
 import {Templates} from '../../../../src/core/templates.js';
 import {Flags as flags} from '../../../../src/commands/flags.js';

--- a/test/e2e/integration/core/remote_config_validator.test.ts
+++ b/test/e2e/integration/core/remote_config_validator.test.ts
@@ -6,7 +6,8 @@ import {expect} from 'chai';
 
 import * as constants from '../../../../src/core/constants.js';
 import {ConfigManager} from '../../../../src/core/config_manager.js';
-import {K8} from '../../../../src/core/k8.js';
+import type K8 from '../../../../src/core/kube/k8.js';
+import {type K8Client} from '../../../../src/core/kube/k8_client.js';
 import {Templates} from '../../../../src/core/templates.js';
 import {Flags as flags} from '../../../../src/commands/flags.js';
 import {V1Container, V1ExecAction, V1ObjectMeta, V1Pod, V1PodSpec, V1Probe} from '@kubernetes/client-node';
@@ -28,12 +29,12 @@ describe('RemoteConfigValidator', () => {
   const namespace = 'remote-config-validator';
 
   let configManager: ConfigManager;
-  let k8: K8;
+  let k8: K8Client;
 
   before(async () => {
     configManager = container.resolve(ConfigManager);
     configManager.update({[flags.namespace.name]: namespace});
-    k8 = container.resolve(K8);
+    k8 = container.resolve('K8') as K8Client;
     await k8.createNamespace(namespace);
   });
 

--- a/test/e2e/integration/core/remote_config_validator.test.ts
+++ b/test/e2e/integration/core/remote_config_validator.test.ts
@@ -6,7 +6,7 @@ import {expect} from 'chai';
 
 import * as constants from '../../../../src/core/constants.js';
 import {ConfigManager} from '../../../../src/core/config_manager.js';
-import type K8 from '../../../../src/core/kube/k8.js';
+import {type K8} from '../../../../src/core/kube/k8.js';
 import {type K8Client} from '../../../../src/core/kube/k8_client.js';
 import {Templates} from '../../../../src/core/templates.js';
 import {Flags as flags} from '../../../../src/commands/flags.js';

--- a/test/test_util.ts
+++ b/test/test_util.ts
@@ -28,7 +28,7 @@ import {SoloLogger} from '../src/core/logging.js';
 import type {BaseCommand} from '../src/commands/base.js';
 import type {NodeAlias} from '../src/types/aliases.js';
 import type {NetworkNodeServices} from '../src/core/network_node_services.js';
-import {K8} from '../src/core/k8.js';
+import type K8 from '../src/core/kube/k8.js';
 import {AccountManager} from '../src/core/account_manager.js';
 import {PlatformInstaller} from '../src/core/platform_installer.js';
 import {ProfileManager} from '../src/core/profile_manager.js';
@@ -134,7 +134,7 @@ export function bootstrapTestVariables(
   const helm = container.resolve(Helm);
   const chartManager = container.resolve(ChartManager);
   const keyManager = container.resolve(KeyManager);
-  const k8 = k8Arg || container.resolve(K8);
+  const k8 = k8Arg || container.resolve('K8');
   const accountManager = container.resolve(AccountManager);
   const platformInstaller = container.resolve(PlatformInstaller);
   const profileManager = container.resolve(ProfileManager);
@@ -437,7 +437,7 @@ async function addKeyHashToMap(
 
 export function getK8Instance(configManager: ConfigManager) {
   try {
-    return container.resolve(K8);
+    return container.resolve('K8');
     // TODO: return a mock without running the init within constructor after we convert to Mocha, Jest ESModule mocks are broke.
   } catch (e) {
     if (!(e instanceof SoloError)) {
@@ -451,7 +451,7 @@ export function getK8Instance(configManager: ConfigManager) {
 
     // Create cluster
     execSync(`kind create cluster --name "${process.env.SOLO_CLUSTER_NAME}"`, {stdio: 'inherit'});
-    return container.resolve(K8);
+    return container.resolve('K8');
   }
 }
 

--- a/test/test_util.ts
+++ b/test/test_util.ts
@@ -28,7 +28,7 @@ import {SoloLogger} from '../src/core/logging.js';
 import type {BaseCommand} from '../src/commands/base.js';
 import type {NodeAlias} from '../src/types/aliases.js';
 import type {NetworkNodeServices} from '../src/core/network_node_services.js';
-import type K8 from '../src/core/kube/k8.js';
+import {type K8} from '../src/core/kube/k8.js';
 import {AccountManager} from '../src/core/account_manager.js';
 import {PlatformInstaller} from '../src/core/platform_installer.js';
 import {ProfileManager} from '../src/core/profile_manager.js';

--- a/test/unit/commands/base.test.ts
+++ b/test/unit/commands/base.test.ts
@@ -9,7 +9,7 @@ import {ChartManager} from '../../../src/core/chart_manager.js';
 import {ConfigManager} from '../../../src/core/config_manager.js';
 import {LocalConfig} from '../../../src/core/config/local_config.js';
 import {RemoteConfigManager} from '../../../src/core/config/remote/remote_config_manager.js';
-import {K8} from '../../../src/core/k8.js';
+import {K8Client} from '../../../src/core/kube/k8_client.js';
 import {BaseCommand} from '../../../src/commands/base.js';
 import {Flags as flags} from '../../../src/commands/flags.js';
 import sinon from 'sinon';
@@ -41,8 +41,8 @@ describe('BaseCommand', () => {
       remoteConfigManager = container.resolve(RemoteConfigManager);
 
       sandbox = sinon.createSandbox();
-      sandbox.stub(K8.prototype, 'init').callsFake(() => this);
-      const k8 = container.resolve(K8);
+      sandbox.stub(K8Client.prototype, 'init').callsFake(() => this);
+      const k8 = container.resolve('K8');
 
       // @ts-ignore
       baseCmd = new BaseCommand({

--- a/test/unit/commands/cluster.test.ts
+++ b/test/unit/commands/cluster.test.ts
@@ -28,7 +28,8 @@ import {ClusterCommandTasks} from '../../../src/commands/cluster/tasks.js';
 import type {BaseCommand} from '../../../src/commands/base.js';
 import {LocalConfig} from '../../../src/core/config/local_config.js';
 import type {CommandFlag} from '../../../src/types/flag_types.js';
-import {K8} from '../../../src/core/k8.js';
+import type K8 from '../../../src/core/kube/k8.js';
+import {K8Client} from '../../../src/core/kube/k8_client.js';
 import {type Cluster, KubeConfig} from '@kubernetes/client-node';
 import {RemoteConfigManager} from '../../../src/core/config/remote/remote_config_manager.js';
 import {DependencyManager} from '../../../src/core/dependency_managers/index.js';
@@ -129,7 +130,7 @@ describe('ClusterCommand unit tests', () => {
     let tasks: ClusterCommandTasks;
     let command: BaseCommand;
     let loggerStub: sinon.SinonStubbedInstance<SoloLogger>;
-    let k8Stub: sinon.SinonStubbedInstance<K8>;
+    let k8Stub: sinon.SinonStubbedInstance<K8Client>;
     let remoteConfigManagerStub: sinon.SinonStubbedInstance<RemoteConfigManager>;
     let localConfig: LocalConfig;
     const defaultRemoteConfig = {
@@ -150,7 +151,7 @@ describe('ClusterCommand unit tests', () => {
       },
     ) => {
       const loggerStub = sandbox.createStubInstance(SoloLogger);
-      k8Stub = sandbox.createStubInstance(K8);
+      k8Stub = sandbox.createStubInstance(K8Client);
       k8Stub.getContextNames.returns(['context-1', 'context-2', 'context-3']);
       k8Stub.isMinioInstalled.returns(new Promise<boolean>(() => true));
       k8Stub.isPrometheusInstalled.returns(new Promise<boolean>(() => true));

--- a/test/unit/commands/cluster.test.ts
+++ b/test/unit/commands/cluster.test.ts
@@ -28,7 +28,6 @@ import {ClusterCommandTasks} from '../../../src/commands/cluster/tasks.js';
 import type {BaseCommand} from '../../../src/commands/base.js';
 import {LocalConfig} from '../../../src/core/config/local_config.js';
 import type {CommandFlag} from '../../../src/types/flag_types.js';
-import type K8 from '../../../src/core/kube/k8.js';
 import {K8Client} from '../../../src/core/kube/k8_client.js';
 import {type Cluster, KubeConfig} from '@kubernetes/client-node';
 import {RemoteConfigManager} from '../../../src/core/config/remote/remote_config_manager.js';

--- a/test/unit/commands/network.test.ts
+++ b/test/unit/commands/network.test.ts
@@ -23,7 +23,7 @@ import {ListrLease} from '../../../src/core/lease/listr_lease.js';
 import {GenesisNetworkDataConstructor} from '../../../src/core/genesis_network_models/genesis_network_data_constructor.js';
 import {container} from 'tsyringe-neo';
 import {SoloLogger} from '../../../src/core/logging.js';
-import type K8 from '../../../src/core/kube/k8.js';
+import {type K8} from '../../../src/core/kube/k8.js';
 import {PlatformInstaller} from '../../../src/core/platform_installer.js';
 import {CertificateManager} from '../../../src/core/certificate_manager.js';
 import {DependencyManager} from '../../../src/core/dependency_managers/index.js';

--- a/test/unit/commands/network.test.ts
+++ b/test/unit/commands/network.test.ts
@@ -23,7 +23,7 @@ import {ListrLease} from '../../../src/core/lease/listr_lease.js';
 import {GenesisNetworkDataConstructor} from '../../../src/core/genesis_network_models/genesis_network_data_constructor.js';
 import {container} from 'tsyringe-neo';
 import {SoloLogger} from '../../../src/core/logging.js';
-import {K8} from '../../../src/core/k8.js';
+import type K8 from '../../../src/core/kube/k8.js';
 import {PlatformInstaller} from '../../../src/core/platform_installer.js';
 import {CertificateManager} from '../../../src/core/certificate_manager.js';
 import {DependencyManager} from '../../../src/core/dependency_managers/index.js';
@@ -69,7 +69,7 @@ describe('NetworkCommand unit tests', () => {
       opts.k8.isCertManagerInstalled = sinon.stub();
 
       opts.k8.logger = opts.logger;
-      container.registerInstance(K8, opts.k8);
+      container.registerInstance('K8', opts.k8);
 
       opts.depManager = sinon.stub() as unknown as DependencyManager;
       container.registerInstance(DependencyManager, opts.depManager);

--- a/test/unit/core/certificate_manager.test.ts
+++ b/test/unit/core/certificate_manager.test.ts
@@ -6,7 +6,7 @@ import {after, before, describe, it} from 'mocha';
 import jest from 'jest-mock';
 
 import {ConfigManager} from '../../../src/core/config_manager.js';
-import {K8} from '../../../src/core/k8.js';
+import {K8Client} from '../../../src/core/kube/k8_client.js';
 import {CertificateManager} from '../../../src/core/certificate_manager.js';
 import {Flags as flags} from '../../../src/commands/flags.js';
 import {SoloError} from '../../../src/core/errors.js';
@@ -16,8 +16,8 @@ import {resetTestContainer} from '../../test_container.js';
 describe('Certificate Manager', () => {
   const argv = {};
   // @ts-ignore
-  const k8InitSpy = jest.spyOn(K8.prototype, 'init').mockImplementation(() => {});
-  const k8CreateSecret = jest.spyOn(K8.prototype, 'createSecret').mockResolvedValue(true);
+  const k8InitSpy = jest.spyOn(K8Client.prototype, 'init').mockImplementation(() => {});
+  const k8CreateSecret = jest.spyOn(K8Client.prototype, 'createSecret').mockResolvedValue(true);
   let certificateManager: CertificateManager;
 
   before(() => {

--- a/test/unit/core/k8.test.ts
+++ b/test/unit/core/k8.test.ts
@@ -5,7 +5,7 @@ import {expect} from 'chai';
 import {describe, it, after, before} from 'mocha';
 import jest from 'jest-mock';
 import * as constants from '../../../src/core/constants.js';
-import type K8 from '../../../src/core/kube/k8.js';
+import {type K8} from '../../../src/core/kube/k8.js';
 import {K8Client} from '../../../src/core/kube/k8_client.js';
 import {ConfigManager} from '../../../src/core/config_manager.js';
 import {Flags as flags} from '../../../src/commands/flags.js';

--- a/test/unit/core/k8.test.ts
+++ b/test/unit/core/k8.test.ts
@@ -5,7 +5,8 @@ import {expect} from 'chai';
 import {describe, it, after, before} from 'mocha';
 import jest from 'jest-mock';
 import * as constants from '../../../src/core/constants.js';
-import {K8} from '../../../src/core/k8.js';
+import type K8 from '../../../src/core/kube/k8.js';
+import {K8Client} from '../../../src/core/kube/k8_client.js';
 import {ConfigManager} from '../../../src/core/config_manager.js';
 import {Flags as flags} from '../../../src/commands/flags.js';
 import {Duration} from '../../../src/core/time/duration.js';
@@ -53,8 +54,8 @@ describe('K8 Unit Tests', function () {
     },
   ];
   // @ts-ignore
-  const k8InitSpy = jest.spyOn(K8.prototype, 'init').mockImplementation(() => {});
-  const k8GetPodsByLabelSpy = jest.spyOn(K8.prototype, 'getPodsByLabel').mockResolvedValue(expectedResult);
+  const k8InitSpy = jest.spyOn(K8Client.prototype, 'init').mockImplementation(() => {});
+  const k8GetPodsByLabelSpy = jest.spyOn(K8Client.prototype, 'getPodsByLabel').mockResolvedValue(expectedResult);
   let k8: K8;
 
   before(() => {
@@ -62,7 +63,8 @@ describe('K8 Unit Tests', function () {
     argv[flags.namespace.name] = 'namespace';
     const configManager = container.resolve(ConfigManager);
     configManager.update(argv);
-    k8 = container.resolve(K8);
+    k8 = container.resolve('K8') as K8Client;
+    // @ts-ignore
     k8.kubeClient = {
       // @ts-ignore
       listNamespacedPod: jest.fn(),


### PR DESCRIPTION
## Description

This pull request changes the following:

* renamed TK8 to K8
* renamed K8 to K8Client and moved to `src/core/kube` folder
* updated injection to use 'K8' string as token instead of class name
* created k8.listSvcs() to remove need for k8.kubeClient.listNamespacedService()
* updated AccountManager to use k8.getPodsByLabel() instead of k8.kubeClient.listNamespacedPod()
* updated some of the interface methods to have optional parameters to match implementations
* added list() method to services.ts
* updated `test/e2e/e2e_node_util.ts` to use k8.killPod() instead of k8.kubeClient.deleteNamespacedPod()

### Related Issues

* Relates to #1039 
