### PR TITLE
refactor: create k8.Container interface, move container methods from Pod to Container, implement K8ClientContainer and implement across codebase

### DIFF
--- a/src/core/kube/container.ts
+++ b/src/core/kube/container.ts
@@ -1,0 +1,72 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {type TarCreateFilter} from '../../types/aliases.js';
+import {type TDirectoryData} from './t_directory_data.js';
+
+export interface Container {
+  /**
+   * Copy a file from a container
+   *
+   * It overwrites any existing file at the destination directory
+   * @param srcPath - the path to the file to copy
+   * @param destDir - the destination directory
+   */
+  copyFrom(srcPath: string, destDir: string): Promise<unknown>;
+
+  /**
+   * Copy a file into a container
+   *
+   * It overwrites any existing file inside the container at the destination directory
+   * @param srcPath - the path of the local file to copy
+   * @param destDir - the remote destination directory
+   * @param [filter] - the filter to pass to tar to keep or skip files or directories
+   * @returns a Promise that performs the copy operation
+   */
+  copyTo(srcPath: string, destDir: string, filter: TarCreateFilter | undefined): Promise<boolean>;
+
+  /**
+   * Invoke sh command within a container and return the console output as string
+   * @param command - sh commands as an array to be run within the containerName (e.g 'ls -la /opt/hgcapp')
+   * @returns console output as string
+   */
+  execContainer(command: string | string[]): Promise<string>;
+
+  /**
+   * Check if a directory exists in the specified container
+   * @param destPath - the path to the directory inside the container
+   */
+  hasDir(destPath: string): Promise<boolean>;
+
+  /**
+   * Check if a file exists in the specified container
+   * @param destPath - the remote path to the file
+   * @param [filters] - optional filters to apply to the tar stream
+   */
+  hasFile(destPath: string, filters: object): Promise<boolean>;
+
+  /**
+   * List files and directories in a container
+   *
+   * It runs ls -la on the specified path and returns a list of object containing the entries.
+   * For example:
+   * [{
+   *    directory: false,
+   *    owner: hedera,
+   *    group: hedera,
+   *    size: 121,
+   *    modifiedAt: Jan 15 13:50
+   *    name: config.txt
+   * }]
+   * @param destPath - the remote path to the directory
+   * @returns a promise that returns array of directory entries, custom object
+   */
+  listDir(destPath: string): Promise<any[] | TDirectoryData[]>;
+
+  /**
+   * Make a directory in the specified container
+   * @param destPath - the remote path to the directory
+   */
+  mkdir(destPath: string): Promise<string>;
+}

--- a/src/core/kube/containers.ts
+++ b/src/core/kube/containers.ts
@@ -1,0 +1,9 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {type ContainerRef} from './container_ref.js';
+import {type Container} from './container.js';
+
+export interface Containers {
+  byRef(containerRef: ContainerRef): Container;
+}

--- a/src/core/kube/containers.ts
+++ b/src/core/kube/containers.ts
@@ -5,5 +5,10 @@ import {type ContainerRef} from './container_ref.js';
 import {type Container} from './container.js';
 
 export interface Containers {
-  byRef(containerRef: ContainerRef): Container;
+  /**
+   * Get a container by reference for running operations against
+   * @param containerRef - the reference to the container
+   * @returns a container object
+   */
+  readByRef(containerRef: ContainerRef): Container;
 }

--- a/src/core/kube/k8.ts
+++ b/src/core/kube/k8.ts
@@ -9,9 +9,9 @@ import {type TDirectoryData} from './t_directory_data.js';
 import {type V1Lease} from '@kubernetes/client-node';
 import {type Namespaces} from './namespaces.js';
 import {type NamespaceName} from './namespace_name.js';
+import {type Containers} from './containers.js';
 import {type Clusters} from './clusters.js';
 import {type ConfigMaps} from './config_maps.js';
-import {type ContainerName} from './container_name.js';
 import {type ContainerRef} from './container_ref.js';
 
 export interface K8 {
@@ -20,6 +20,12 @@ export interface K8 {
    * @returns an object instance providing namespace operations
    */
   namespaces(): Namespaces;
+
+  /**
+   * Fluent accessor for reading and manipulating containers.
+   * returns an object instance providing container operations
+   */
+  containers(): Containers;
 
   /**
    * Fluent accessor for reading and manipulating cluster information from the kubeconfig file.

--- a/src/core/kube/k8_client.ts
+++ b/src/core/kube/k8_client.ts
@@ -5,15 +5,10 @@ import * as k8s from '@kubernetes/client-node';
 import {type Context, type V1Lease, V1ObjectMeta, type V1Pod, V1Secret} from '@kubernetes/client-node';
 import fs from 'fs';
 import net from 'net';
-import os from 'os';
 import path from 'path';
 import {Flags as flags} from '../../commands/flags.js';
-import {IllegalArgumentError, MissingArgumentError, SoloError} from './../errors.js';
-import * as tar from 'tar';
-import {v4 as uuid4} from 'uuid';
-import * as stream from 'node:stream';
+import {MissingArgumentError, SoloError} from './../errors.js';
 import type * as http from 'node:http';
-import type * as WebSocket from 'ws';
 import {getReasonPhrase, StatusCodes} from 'http-status-codes';
 import {sleep} from './../helpers.js';
 import * as constants from './../constants.js';
@@ -22,12 +17,11 @@ import {ConfigManager} from './../config_manager.js';
 import {SoloLogger} from './../logging.js';
 import {type TarCreateFilter} from '../../types/aliases.js';
 import {PodName} from './pod_name.js';
-import {type ExtendedNetServer, type LocalContextObject, type Optional} from '../../types/index.js';
+import {type ExtendedNetServer, type Optional} from '../../types/index.js';
 import {Duration} from './../time/duration.js';
 import {inject, injectable} from 'tsyringe-neo';
 import {patchInject} from './../container_helper.js';
 import {type K8} from './k8.js';
-import {type TDirectoryData} from './t_directory_data.js';
 import {type Namespaces} from './namespaces.js';
 import {NamespaceName} from './namespace_name.js';
 import K8ClientClusters from './k8_client/k8_client_clusters.js';
@@ -35,8 +29,9 @@ import {type Clusters} from './clusters.js';
 import {type ConfigMaps} from './config_maps.js';
 import K8ClientConfigMaps from './k8_client/k8_client_config_maps.js';
 import {PodRef} from './pod_ref.js';
-import {type ContainerName} from './container_name.js';
 import {ContainerRef} from './container_ref.js';
+import {K8ClientContainers} from './k8_client/k8_client_containers.js';
+import {type Containers} from './containers.js';
 
 /**
  * A kubernetes API wrapper class providing custom functionalities required by solo
@@ -61,6 +56,8 @@ export class K8Client implements K8 {
 
   private k8Clusters: K8ClientClusters;
   private k8ConfigMaps: K8ClientConfigMaps;
+
+  private k8Containers: K8ClientContainers;
 
   constructor(
     @inject(ConfigManager) private readonly configManager?: ConfigManager,
@@ -91,6 +88,7 @@ export class K8Client implements K8 {
 
     this.k8Clusters = new K8ClientClusters(this.kubeConfig);
     this.k8ConfigMaps = new K8ClientConfigMaps(this.kubeClient);
+    this.k8Containers = new K8ClientContainers(this.kubeConfig);
 
     return this; // to enable chaining
   }
@@ -114,6 +112,14 @@ export class K8Client implements K8 {
    */
   public configMaps(): ConfigMaps {
     return this.k8ConfigMaps;
+  }
+
+  /**
+   * Fluent accessor for reading and manipulating containers.
+   * returns an object instance providing container operations
+   */
+  public containers(): Containers {
+    return this.k8Containers;
   }
 
   /**
@@ -300,202 +306,19 @@ export class K8Client implements K8 {
   }
 
   public async listDir(containerRef: ContainerRef, destPath: string) {
-    // TODO future, return the following
-    // return this.pods.byName(podName).listDir(containerName, destPath);
-    // byName(podName) can use an underlying cache to avoid multiple calls to the API
-    // caching can be added later, it doesn't have to be done right away
-    // byLabel(label) can also cache/lazy initialize if desired
-    // pods are qualified by namespace, so we should really also be passing namespace
-    // string is also an object with a large prototype, same weight as a class instance
-    // PodName can be turned into a class that we can use for the parameters for more control.
-    // PodName.of(namespace, podName)
-    // TODO - make namespace first on all of the methods
-    // TODO - create ContainerName for the containerName, validate the containerName.  ContainerName.of(containerName)
-    //  - to avoid having to do (new ContainerName(containerName))
-    //  - NamespaceName.of(namespace): store as class instead of string after we have validated and put it in ConfigManager
-    //  - PodRef.of(namespace, podName)
-    //  - ContainerRef.of(podRef, containerName)
-    //  - ContainerRef.of(PodRef.of(namespace, podName), containerName)
-    //  - namespace is coming from user and should definitely be validate and kick back if it is invalid
-    // below implementation moves to K8Pod class, current usage would still compile.
-
-    try {
-      const output = (await this.execContainer(containerRef, ['ls', '-la', destPath])) as string;
-      if (!output) return [];
-
-      // parse the output and return the entries
-      const items: TDirectoryData[] = [];
-      const lines = output.split('\n');
-      for (let line of lines) {
-        line = line.replace(/\s+/g, '|');
-        const parts = line.split('|');
-        if (parts.length >= 9) {
-          let name = parts[parts.length - 1];
-          // handle unique file format (without single quotes): 'usedAddressBook_vHederaSoftwareVersion{hapiVersion=v0.53.0, servicesVersion=v0.53.0}_2024-07-30-20-39-06_node_0.txt.debug'
-          for (let i = parts.length - 1; i > 8; i--) {
-            name = `${parts[i - 1]} ${name}`;
-          }
-
-          if (name !== '.' && name !== '..') {
-            const permission = parts[0];
-            const item: TDirectoryData = {
-              directory: permission[0] === 'd',
-              owner: parts[2],
-              group: parts[3],
-              size: parts[4],
-              modifiedAt: `${parts[5]} ${parts[6]} ${parts[7]}`,
-              name,
-            };
-
-            items.push(item);
-          }
-        }
-      }
-
-      return items;
-    } catch (e) {
-      throw new SoloError(
-        `unable to check path in '${containerRef.podRef.podName.name}':${containerRef.containerName.name}' - ${destPath}: ${e.message}`,
-        e,
-      );
-    }
+    return this.containers().byRef(containerRef).listDir(destPath);
   }
 
   public async hasFile(containerRef: ContainerRef, destPath: string, filters: object = {}) {
-    const parentDir = path.dirname(destPath);
-    const fileName = path.basename(destPath);
-    const filterMap = new Map(Object.entries(filters));
-
-    try {
-      const entries = await this.listDir(containerRef, parentDir);
-
-      for (const item of entries) {
-        if (item.name === fileName && !item.directory) {
-          let found = true;
-
-          for (const entry of filterMap.entries()) {
-            const field = entry[0];
-            const value = entry[1];
-            this.logger.debug(
-              `Checking file ${containerRef.podRef.podName.name}:${containerRef.containerName.name} ${destPath}; ${field} expected ${value}, found ${item[field]}`,
-              {filters},
-            );
-            if (`${value}` !== `${item[field]}`) {
-              found = false;
-              break;
-            }
-          }
-
-          if (found) {
-            this.logger.debug(
-              `File check succeeded ${containerRef.podRef.podName.name}:${containerRef.containerName.name} ${destPath}`,
-              {
-                filters,
-              },
-            );
-            return true;
-          }
-        }
-      }
-    } catch (e) {
-      const error = new SoloError(
-        `unable to check file in '${containerRef.podRef.podName.name}':${containerRef.containerName.name}' - ${destPath}: ${e.message}`,
-        e,
-      );
-      this.logger.error(error.message, error);
-      throw error;
-    }
-
-    return false;
+    return this.containers().byRef(containerRef).hasFile(destPath, filters);
   }
 
   public async hasDir(containerRef: ContainerRef, destPath: string) {
-    return (
-      (await this.execContainer(containerRef, [
-        'bash',
-        '-c',
-        '[[ -d "' + destPath + '" ]] && echo -n "true" || echo -n "false"',
-      ])) === 'true'
-    );
+    return this.containers().byRef(containerRef).hasDir(destPath);
   }
 
   public mkdir(containerRef: ContainerRef, destPath: string) {
-    return this.execContainer(containerRef, ['bash', '-c', 'mkdir -p "' + destPath + '"']);
-  }
-
-  private exitWithError(localContext: LocalContextObject, errorMessage: string) {
-    localContext.errorMessage = localContext.errorMessage
-      ? `${localContext.errorMessage}:${errorMessage}`
-      : errorMessage;
-    this.logger.warn(errorMessage);
-    return localContext.reject(new SoloError(localContext.errorMessage));
-  }
-
-  private handleCallback(status: string, localContext: LocalContextObject, messagePrefix: string) {
-    if (status === 'Failure') {
-      return this.exitWithError(localContext, `${messagePrefix} Failure occurred`);
-    }
-    this.logger.debug(`${messagePrefix} callback(status)=${status}`);
-  }
-
-  private registerConnectionOnError(
-    localContext: LocalContextObject,
-    messagePrefix: string,
-    conn: WebSocket.WebSocket,
-  ) {
-    conn.on('error', e => {
-      return this.exitWithError(localContext, `${messagePrefix} failed, connection error: ${e.message}`);
-    });
-  }
-
-  private registerConnectionOnMessage(messagePrefix: string) {
-    this.logger.debug(`${messagePrefix} received message`);
-  }
-
-  private registerErrorStreamOnData(localContext: LocalContextObject, stream: stream.PassThrough) {
-    stream.on('data', data => {
-      localContext.errorMessage = localContext.errorMessage
-        ? `${localContext.errorMessage}${data.toString()}`
-        : data.toString();
-    });
-  }
-
-  private registerErrorStreamOnError(
-    localContext: LocalContextObject,
-    messagePrefix: string,
-    stream: stream.PassThrough | fs.WriteStream,
-  ) {
-    stream.on('error', err => {
-      return this.exitWithError(localContext, `${messagePrefix} error encountered, err: ${err.toString()}`);
-    });
-  }
-
-  private registerOutputPassthroughStreamOnData(
-    localContext: LocalContextObject,
-    messagePrefix: string,
-    outputPassthroughStream: stream.PassThrough,
-    outputFileStream: fs.WriteStream,
-  ) {
-    outputPassthroughStream.on('data', chunk => {
-      this.logger.debug(`${messagePrefix} received chunk size=${chunk.length}`);
-      const canWrite = outputFileStream.write(chunk); // Write chunk to file and check if buffer is full
-      if (!canWrite) {
-        this.logger.debug(`${messagePrefix} buffer is full, pausing data stream...`);
-        outputPassthroughStream.pause(); // Pause the data stream if buffer is full
-      }
-    });
-  }
-
-  private registerOutputFileStreamOnDrain(
-    localContext: LocalContextObject,
-    messagePrefix: string,
-    outputPassthroughStream: stream.PassThrough,
-    outputFileStream: fs.WriteStream,
-  ) {
-    outputFileStream.on('drain', () => {
-      outputPassthroughStream.resume();
-      this.logger.debug(`${messagePrefix} stream drained, resume write`);
-    });
+    return this.containers().byRef(containerRef).mkdir(destPath);
   }
 
   public async copyTo(
@@ -504,302 +327,15 @@ export class K8Client implements K8 {
     destDir: string,
     filter: TarCreateFilter | undefined = undefined,
   ) {
-    const self = this;
-    const namespace = containerRef.podRef.namespaceName;
-    const guid = uuid4();
-    const messagePrefix = `copyTo[${containerRef.podRef.podName.name},${guid}]: `;
-
-    if (!(await self.getPodByName(containerRef.podRef)))
-      throw new IllegalArgumentError(`Invalid pod ${containerRef.podRef.podName.name}`);
-
-    self.logger.info(`${messagePrefix}[srcPath=${srcPath}, destDir=${destDir}]`);
-
-    if (!(await this.hasDir(containerRef, destDir))) {
-      throw new SoloError(`invalid destination path: ${destDir}`);
-    }
-
-    if (!fs.existsSync(srcPath)) {
-      throw new SoloError(`invalid source path: ${srcPath}`);
-    }
-
-    const localContext = {} as LocalContextObject;
-    try {
-      const srcFile = path.basename(srcPath);
-      const srcDir = path.dirname(srcPath);
-
-      // Create a temporary tar file for the source file
-      const tmpFile = self.tempFileFor(srcFile);
-
-      await tar.c({file: tmpFile, cwd: srcDir, filter}, [srcFile]);
-
-      return new Promise<boolean>((resolve, reject) => {
-        localContext.reject = reject;
-        const execInstance = new k8s.Exec(self.kubeConfig);
-        const command = ['tar', 'xf', '-', '-C', destDir];
-        const inputStream = fs.createReadStream(tmpFile);
-        const errPassthroughStream = new stream.PassThrough();
-        const inputPassthroughStream = new stream.PassThrough({highWaterMark: 10 * 1024 * 1024}); // Handle backpressure
-
-        // Use pipe() to automatically handle backpressure
-        inputStream.pipe(inputPassthroughStream);
-
-        execInstance
-          .exec(
-            namespace.name,
-            containerRef.podRef.podName.name,
-            containerRef.containerName.name,
-            command,
-            null,
-            errPassthroughStream,
-            inputPassthroughStream,
-            false,
-            ({status}) => self.handleCallback(status, localContext, messagePrefix),
-          )
-          .then(conn => {
-            localContext.connection = conn;
-
-            self.registerConnectionOnError(localContext, messagePrefix, conn);
-
-            self.registerConnectionOnMessage(messagePrefix);
-
-            conn.on('close', (code, reason) => {
-              self.logger.debug(`${messagePrefix} connection closed`);
-              if (code !== 1000) {
-                // code 1000 is the success code
-                return self.exitWithError(localContext, `${messagePrefix} failed with code=${code}, reason=${reason}`);
-              }
-
-              // Cleanup temp file after successful copy
-              inputPassthroughStream.end(); // End the passthrough stream
-              self.deleteTempFile(tmpFile); // Cleanup temp file
-              self.logger.info(`${messagePrefix} Successfully copied!`);
-              return resolve(true);
-            });
-          });
-
-        self.registerErrorStreamOnData(localContext, errPassthroughStream);
-
-        self.registerErrorStreamOnError(localContext, messagePrefix, inputPassthroughStream);
-      });
-    } catch (e) {
-      const errorMessage = `${messagePrefix} failed to upload file: ${e.message}`;
-      self.logger.error(errorMessage, e);
-      throw new SoloError(errorMessage, e);
-    }
+    return this.containers().byRef(containerRef).copyTo(srcPath, destDir, filter);
   }
 
   public async copyFrom(containerRef: ContainerRef, srcPath: string, destDir: string) {
-    const self = this;
-    const namespace = containerRef.podRef.namespaceName;
-    const guid = uuid4();
-    const messagePrefix = `copyFrom[${containerRef.podRef.podName.name},${guid}]: `;
-
-    if (!(await self.getPodByName(containerRef.podRef)))
-      throw new IllegalArgumentError(`Invalid pod ${containerRef.podRef.podName.name}`);
-
-    self.logger.info(`${messagePrefix}[srcPath=${srcPath}, destDir=${destDir}]`);
-
-    // get stat for source file in the container
-    let entries = await self.listDir(containerRef, srcPath);
-    if (entries.length !== 1) {
-      throw new SoloError(`${messagePrefix}invalid source path: ${srcPath}`);
-    }
-    // handle symbolic link
-    if (entries[0].name.indexOf(' -> ') > -1) {
-      const redirectSrcPath = path.join(
-        path.dirname(srcPath),
-        entries[0].name.substring(entries[0].name.indexOf(' -> ') + 4),
-      );
-      entries = await self.listDir(containerRef, redirectSrcPath);
-      if (entries.length !== 1) {
-        throw new SoloError(`${messagePrefix}invalid source path: ${redirectSrcPath}`);
-      }
-    }
-    const srcFileDesc = entries[0]; // cache for later comparison after copy
-
-    if (!fs.existsSync(destDir)) {
-      throw new SoloError(`${messagePrefix}invalid destination path: ${destDir}`);
-    }
-
-    const localContext = {} as LocalContextObject;
-    try {
-      const srcFileSize = Number.parseInt(srcFileDesc.size);
-
-      const srcFile = path.basename(entries[0].name);
-      const srcDir = path.dirname(entries[0].name);
-      const destPath = path.join(destDir, srcFile);
-
-      // download the tar file to a temp location
-      const tmpFile = self.tempFileFor(srcFile);
-
-      return new Promise((resolve, reject) => {
-        localContext.reject = reject;
-        const execInstance = new k8s.Exec(self.kubeConfig);
-        const command = ['cat', `${srcDir}/${srcFile}`];
-        const outputFileStream = fs.createWriteStream(tmpFile);
-        const outputPassthroughStream = new stream.PassThrough({highWaterMark: 10 * 1024 * 1024});
-        const errPassthroughStream = new stream.PassThrough();
-
-        // Use pipe() to automatically handle backpressure between streams
-        outputPassthroughStream.pipe(outputFileStream);
-
-        self.registerOutputPassthroughStreamOnData(
-          localContext,
-          messagePrefix,
-          outputPassthroughStream,
-          outputFileStream,
-        );
-
-        self.registerOutputFileStreamOnDrain(localContext, messagePrefix, outputPassthroughStream, outputFileStream);
-
-        execInstance
-          .exec(
-            namespace.name,
-            containerRef.podRef.podName.name,
-            containerRef.containerName.name,
-            command,
-            outputFileStream,
-            errPassthroughStream,
-            null,
-            false,
-            ({status}) => {
-              if (status === 'Failure') {
-                self.deleteTempFile(tmpFile);
-                return self.exitWithError(localContext, `${messagePrefix} Failure occurred`);
-              }
-              self.logger.debug(`${messagePrefix} callback(status)=${status}`);
-            },
-          )
-          .then(conn => {
-            localContext.connection = conn;
-
-            conn.on('error', e => {
-              self.deleteTempFile(tmpFile);
-              return self.exitWithError(localContext, `${messagePrefix} failed, connection error: ${e.message}`);
-            });
-
-            self.registerConnectionOnMessage(messagePrefix);
-
-            conn.on('close', (code, reason) => {
-              self.logger.debug(`${messagePrefix} connection closed`);
-              if (code !== 1000) {
-                // code 1000 is the success code
-                return self.exitWithError(localContext, `${messagePrefix} failed with code=${code}, reason=${reason}`);
-              }
-
-              outputFileStream.end();
-              outputFileStream.close(() => {
-                try {
-                  fs.copyFileSync(tmpFile, destPath);
-
-                  self.deleteTempFile(tmpFile);
-
-                  const stat = fs.statSync(destPath);
-                  if (stat && stat.size === srcFileSize) {
-                    self.logger.debug(`${messagePrefix} finished`);
-                    return resolve(true);
-                  }
-
-                  return self.exitWithError(
-                    localContext,
-                    `${messagePrefix} files did not match, srcFileSize=${srcFileSize}, stat.size=${stat?.size}`,
-                  );
-                } catch {
-                  return self.exitWithError(localContext, `${messagePrefix} failed to complete download`);
-                }
-              });
-            });
-          });
-
-        self.registerErrorStreamOnData(localContext, errPassthroughStream);
-
-        self.registerErrorStreamOnError(localContext, messagePrefix, outputFileStream);
-      });
-    } catch (e) {
-      const errorMessage = `${messagePrefix}failed to download file: ${e.message}`;
-      self.logger.error(errorMessage, e);
-      throw new SoloError(errorMessage, e);
-    }
+    return this.containers().byRef(containerRef).copyFrom(srcPath, destDir);
   }
 
   public async execContainer(containerRef: ContainerRef, command: string | string[]) {
-    const self = this;
-    const namespace = containerRef.podRef.namespaceName;
-    const guid = uuid4();
-    const messagePrefix = `execContainer[${containerRef.podRef.podName.name},${guid}]:`;
-
-    if (!(await self.getPodByName(containerRef.podRef)))
-      throw new IllegalArgumentError(`Invalid pod ${containerRef.podRef.podName.name}`);
-
-    if (!command) throw new MissingArgumentError('command cannot be empty');
-    if (!Array.isArray(command)) {
-      command = command.split(' ');
-    }
-
-    self.logger.info(`${messagePrefix} begin... command=[${command.join(' ')}]`);
-
-    return new Promise<string>((resolve, reject) => {
-      const localContext = {} as LocalContextObject;
-      localContext.reject = reject;
-      const execInstance = new k8s.Exec(self.kubeConfig);
-      const tmpFile = self.tempFileFor(`${containerRef.podRef.podName.name}-output.txt`);
-      const outputFileStream = fs.createWriteStream(tmpFile);
-      const outputPassthroughStream = new stream.PassThrough({highWaterMark: 10 * 1024 * 1024});
-      const errPassthroughStream = new stream.PassThrough();
-
-      // Use pipe() to automatically handle backpressure between streams
-      outputPassthroughStream.pipe(outputFileStream);
-
-      self.registerOutputPassthroughStreamOnData(
-        localContext,
-        messagePrefix,
-        outputPassthroughStream,
-        outputFileStream,
-      );
-
-      self.registerOutputFileStreamOnDrain(localContext, messagePrefix, outputPassthroughStream, outputFileStream);
-
-      execInstance
-        .exec(
-          namespace.name,
-          containerRef.podRef.podName.name,
-          containerRef.containerName.name,
-          command,
-          outputFileStream,
-          errPassthroughStream,
-          null,
-          false,
-          ({status}) => self.handleCallback(status, localContext, messagePrefix),
-        )
-        .then(conn => {
-          localContext.connection = conn;
-
-          self.registerConnectionOnError(localContext, messagePrefix, conn);
-
-          self.registerConnectionOnMessage(messagePrefix);
-
-          conn.on('close', (code, reason) => {
-            self.logger.debug(`${messagePrefix} connection closed`);
-            if (!localContext.errorMessage) {
-              if (code !== 1000) {
-                // code 1000 is the success code
-                return self.exitWithError(localContext, `${messagePrefix} failed with code=${code}, reason=${reason}`);
-              }
-
-              outputFileStream.end();
-              outputFileStream.close(() => {
-                self.logger.debug(`${messagePrefix} finished`);
-                const outData = fs.readFileSync(tmpFile);
-                return resolve(outData.toString());
-              });
-            }
-          });
-        });
-
-      self.registerErrorStreamOnData(localContext, errPassthroughStream);
-
-      self.registerErrorStreamOnError(localContext, messagePrefix, outputFileStream);
-    });
+    return this.containers().byRef(containerRef).execContainer(command);
   }
 
   public async portForward(podRef: PodRef, localPort: number, podPort: number) {
@@ -1428,17 +964,6 @@ export class K8Client implements K8 {
     const ns = this.configManager.getFlag<NamespaceName>(flags.namespace);
     if (!ns) throw new MissingArgumentError('namespace is not set');
     return ns;
-  }
-
-  private tempFileFor(fileName: string) {
-    const tmpFile = `${fileName}-${uuid4()}`;
-    return path.join(os.tmpdir(), tmpFile);
-  }
-
-  private deleteTempFile(tmpFile: string) {
-    if (fs.existsSync(tmpFile)) {
-      fs.rmSync(tmpFile);
-    }
   }
 
   public async killPod(podRef: PodRef) {

--- a/src/core/kube/k8_client.ts
+++ b/src/core/kube/k8_client.ts
@@ -306,19 +306,19 @@ export class K8Client implements K8 {
   }
 
   public async listDir(containerRef: ContainerRef, destPath: string) {
-    return this.containers().byRef(containerRef).listDir(destPath);
+    return this.containers().readByRef(containerRef).listDir(destPath);
   }
 
   public async hasFile(containerRef: ContainerRef, destPath: string, filters: object = {}) {
-    return this.containers().byRef(containerRef).hasFile(destPath, filters);
+    return this.containers().readByRef(containerRef).hasFile(destPath, filters);
   }
 
   public async hasDir(containerRef: ContainerRef, destPath: string) {
-    return this.containers().byRef(containerRef).hasDir(destPath);
+    return this.containers().readByRef(containerRef).hasDir(destPath);
   }
 
   public mkdir(containerRef: ContainerRef, destPath: string) {
-    return this.containers().byRef(containerRef).mkdir(destPath);
+    return this.containers().readByRef(containerRef).mkdir(destPath);
   }
 
   public async copyTo(
@@ -327,15 +327,15 @@ export class K8Client implements K8 {
     destDir: string,
     filter: TarCreateFilter | undefined = undefined,
   ) {
-    return this.containers().byRef(containerRef).copyTo(srcPath, destDir, filter);
+    return this.containers().readByRef(containerRef).copyTo(srcPath, destDir, filter);
   }
 
   public async copyFrom(containerRef: ContainerRef, srcPath: string, destDir: string) {
-    return this.containers().byRef(containerRef).copyFrom(srcPath, destDir);
+    return this.containers().readByRef(containerRef).copyFrom(srcPath, destDir);
   }
 
   public async execContainer(containerRef: ContainerRef, command: string | string[]) {
-    return this.containers().byRef(containerRef).execContainer(command);
+    return this.containers().readByRef(containerRef).execContainer(command);
   }
 
   public async portForward(podRef: PodRef, localPort: number, podPort: number) {

--- a/src/core/kube/k8_client/k8_client_container.ts
+++ b/src/core/kube/k8_client/k8_client_container.ts
@@ -1,0 +1,539 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {type Container} from '../container.js';
+import {type TarCreateFilter} from '../../../types/aliases.js';
+import {type TDirectoryData} from '../t_directory_data.js';
+import {type ContainerRef} from '../container_ref.js';
+import {IllegalArgumentError, MissingArgumentError, SoloError} from '../../errors.js';
+import path from 'path';
+import fs from 'fs';
+import {type LocalContextObject} from '../../../types/index.js';
+import stream from 'node:stream';
+import {v4 as uuid4} from 'uuid';
+import {SoloLogger} from '../../logging.js';
+import {type K8} from '../k8.js';
+import os from 'os';
+import {Exec, type KubeConfig} from '@kubernetes/client-node';
+import {container} from 'tsyringe-neo';
+import type * as WebSocket from 'ws';
+import * as tar from 'tar';
+
+export class K8ClientContainer implements Container {
+  private readonly logger: SoloLogger;
+  private readonly k8: K8; // TODO switches to Pods after that implementation is ready
+
+  public constructor(
+    private readonly kubeConfig: KubeConfig,
+    private readonly containerRef: ContainerRef,
+  ) {
+    this.logger = container.resolve(SoloLogger);
+    this.k8 = container.resolve('K8') as K8;
+  }
+
+  async copyFrom(srcPath: string, destDir: string): Promise<unknown> {
+    const self = this;
+    const namespace = this.containerRef.podRef.namespaceName;
+    const guid = uuid4();
+    const messagePrefix = `copyFrom[${this.containerRef.podRef.podName.name},${guid}]: `;
+
+    if (!(await self.k8.getPodByName(this.containerRef.podRef)))
+      throw new IllegalArgumentError(`Invalid pod ${this.containerRef.podRef.podName.name}`);
+
+    self.logger.info(`${messagePrefix}[srcPath=${srcPath}, destDir=${destDir}]`);
+
+    // get stat for source file in the container
+    let entries = await self.listDir(srcPath);
+    if (entries.length !== 1) {
+      throw new SoloError(`${messagePrefix}invalid source path: ${srcPath}`);
+    }
+    // handle symbolic link
+    if (entries[0].name.indexOf(' -> ') > -1) {
+      const redirectSrcPath = path.join(
+        path.dirname(srcPath),
+        entries[0].name.substring(entries[0].name.indexOf(' -> ') + 4),
+      );
+      entries = await self.listDir(redirectSrcPath);
+      if (entries.length !== 1) {
+        throw new SoloError(`${messagePrefix}invalid source path: ${redirectSrcPath}`);
+      }
+    }
+    const srcFileDesc = entries[0]; // cache for later comparison after copy
+
+    if (!fs.existsSync(destDir)) {
+      throw new SoloError(`${messagePrefix}invalid destination path: ${destDir}`);
+    }
+
+    const localContext = {} as LocalContextObject;
+    try {
+      const srcFileSize = Number.parseInt(srcFileDesc.size);
+
+      const srcFile = path.basename(entries[0].name);
+      const srcDir = path.dirname(entries[0].name);
+      const destPath = path.join(destDir, srcFile);
+
+      // download the tar file to a temp location
+      const tmpFile = self.tempFileFor(srcFile);
+
+      return new Promise((resolve, reject) => {
+        localContext.reject = reject;
+        const execInstance = new Exec(self.kubeConfig);
+        const command = ['cat', `${srcDir}/${srcFile}`];
+        const outputFileStream = fs.createWriteStream(tmpFile);
+        const outputPassthroughStream = new stream.PassThrough({highWaterMark: 10 * 1024 * 1024});
+        const errPassthroughStream = new stream.PassThrough();
+
+        // Use pipe() to automatically handle backpressure between streams
+        outputPassthroughStream.pipe(outputFileStream);
+
+        self.registerOutputPassthroughStreamOnData(
+          localContext,
+          messagePrefix,
+          outputPassthroughStream,
+          outputFileStream,
+        );
+
+        self.registerOutputFileStreamOnDrain(localContext, messagePrefix, outputPassthroughStream, outputFileStream);
+
+        execInstance
+          .exec(
+            namespace.name,
+            this.containerRef.podRef.podName.name,
+            this.containerRef.containerName.name,
+            command,
+            outputFileStream,
+            errPassthroughStream,
+            null,
+            false,
+            ({status}) => {
+              if (status === 'Failure') {
+                self.deleteTempFile(tmpFile);
+                return self.exitWithError(localContext, `${messagePrefix} Failure occurred`);
+              }
+              self.logger.debug(`${messagePrefix} callback(status)=${status}`);
+            },
+          )
+          .then(conn => {
+            localContext.connection = conn;
+
+            conn.on('error', e => {
+              self.deleteTempFile(tmpFile);
+              return self.exitWithError(localContext, `${messagePrefix} failed, connection error: ${e.message}`);
+            });
+
+            self.registerConnectionOnMessage(messagePrefix);
+
+            conn.on('close', (code, reason) => {
+              self.logger.debug(`${messagePrefix} connection closed`);
+              if (code !== 1000) {
+                // code 1000 is the success code
+                return self.exitWithError(localContext, `${messagePrefix} failed with code=${code}, reason=${reason}`);
+              }
+
+              outputFileStream.end();
+              outputFileStream.close(() => {
+                try {
+                  fs.copyFileSync(tmpFile, destPath);
+
+                  self.deleteTempFile(tmpFile);
+
+                  const stat = fs.statSync(destPath);
+                  if (stat && stat.size === srcFileSize) {
+                    self.logger.debug(`${messagePrefix} finished`);
+                    return resolve(true);
+                  }
+
+                  return self.exitWithError(
+                    localContext,
+                    `${messagePrefix} files did not match, srcFileSize=${srcFileSize}, stat.size=${stat?.size}`,
+                  );
+                } catch {
+                  return self.exitWithError(localContext, `${messagePrefix} failed to complete download`);
+                }
+              });
+            });
+          });
+
+        self.registerErrorStreamOnData(localContext, errPassthroughStream);
+
+        self.registerErrorStreamOnError(localContext, messagePrefix, outputFileStream);
+      });
+    } catch (e) {
+      const errorMessage = `${messagePrefix}failed to download file: ${e.message}`;
+      self.logger.error(errorMessage, e);
+      throw new SoloError(errorMessage, e);
+    }
+  }
+
+  async copyTo(srcPath: string, destDir: string, filter: TarCreateFilter | undefined): Promise<boolean> {
+    const self = this;
+    const namespace = this.containerRef.podRef.namespaceName;
+    const guid = uuid4();
+    const messagePrefix = `copyTo[${this.containerRef.podRef.podName.name},${guid}]: `;
+
+    if (!(await self.k8.getPodByName(this.containerRef.podRef)))
+      throw new IllegalArgumentError(`Invalid pod ${this.containerRef.podRef.podName.name}`);
+
+    self.logger.info(`${messagePrefix}[srcPath=${srcPath}, destDir=${destDir}]`);
+
+    if (!(await this.hasDir(destDir))) {
+      throw new SoloError(`invalid destination path: ${destDir}`);
+    }
+
+    if (!fs.existsSync(srcPath)) {
+      throw new SoloError(`invalid source path: ${srcPath}`);
+    }
+
+    const localContext = {} as LocalContextObject;
+    try {
+      const srcFile = path.basename(srcPath);
+      const srcDir = path.dirname(srcPath);
+
+      // Create a temporary tar file for the source file
+      const tmpFile = self.tempFileFor(srcFile);
+
+      await tar.c({file: tmpFile, cwd: srcDir, filter}, [srcFile]);
+
+      return new Promise<boolean>((resolve, reject) => {
+        localContext.reject = reject;
+        const execInstance = new Exec(self.kubeConfig);
+        const command = ['tar', 'xf', '-', '-C', destDir];
+        const inputStream = fs.createReadStream(tmpFile);
+        const errPassthroughStream = new stream.PassThrough();
+        const inputPassthroughStream = new stream.PassThrough({highWaterMark: 10 * 1024 * 1024}); // Handle backpressure
+
+        // Use pipe() to automatically handle backpressure
+        inputStream.pipe(inputPassthroughStream);
+
+        execInstance
+          .exec(
+            namespace.name,
+            this.containerRef.podRef.podName.name,
+            this.containerRef.containerName.name,
+            command,
+            null,
+            errPassthroughStream,
+            inputPassthroughStream,
+            false,
+            ({status}) => self.handleCallback(status, localContext, messagePrefix),
+          )
+          .then(conn => {
+            localContext.connection = conn;
+
+            self.registerConnectionOnError(localContext, messagePrefix, conn);
+
+            self.registerConnectionOnMessage(messagePrefix);
+
+            conn.on('close', (code, reason) => {
+              self.logger.debug(`${messagePrefix} connection closed`);
+              if (code !== 1000) {
+                // code 1000 is the success code
+                return self.exitWithError(localContext, `${messagePrefix} failed with code=${code}, reason=${reason}`);
+              }
+
+              // Cleanup temp file after successful copy
+              inputPassthroughStream.end(); // End the passthrough stream
+              self.deleteTempFile(tmpFile); // Cleanup temp file
+              self.logger.info(`${messagePrefix} Successfully copied!`);
+              return resolve(true);
+            });
+          });
+
+        self.registerErrorStreamOnData(localContext, errPassthroughStream);
+
+        self.registerErrorStreamOnError(localContext, messagePrefix, inputPassthroughStream);
+      });
+    } catch (e) {
+      const errorMessage = `${messagePrefix} failed to upload file: ${e.message}`;
+      self.logger.error(errorMessage, e);
+      throw new SoloError(errorMessage, e);
+    }
+  }
+
+  async execContainer(command: string | string[]): Promise<string> {
+    const self = this;
+    const namespace = this.containerRef.podRef.namespaceName;
+    const guid = uuid4();
+    const messagePrefix = `execContainer[${this.containerRef.podRef.podName.name},${guid}]:`;
+
+    if (!(await self.k8.getPodByName(this.containerRef.podRef)))
+      throw new IllegalArgumentError(`Invalid pod ${this.containerRef.podRef.podName.name}`);
+
+    if (!command) throw new MissingArgumentError('command cannot be empty');
+    if (!Array.isArray(command)) {
+      command = command.split(' ');
+    }
+
+    self.logger.info(`${messagePrefix} begin... command=[${command.join(' ')}]`);
+
+    return new Promise<string>((resolve, reject) => {
+      const localContext = {} as LocalContextObject;
+      localContext.reject = reject;
+      const execInstance = new Exec(self.kubeConfig);
+      const tmpFile = self.tempFileFor(`${this.containerRef.podRef.podName.name}-output.txt`);
+      const outputFileStream = fs.createWriteStream(tmpFile);
+      const outputPassthroughStream = new stream.PassThrough({highWaterMark: 10 * 1024 * 1024});
+      const errPassthroughStream = new stream.PassThrough();
+
+      // Use pipe() to automatically handle backpressure between streams
+      outputPassthroughStream.pipe(outputFileStream);
+
+      self.registerOutputPassthroughStreamOnData(
+        localContext,
+        messagePrefix,
+        outputPassthroughStream,
+        outputFileStream,
+      );
+
+      self.registerOutputFileStreamOnDrain(localContext, messagePrefix, outputPassthroughStream, outputFileStream);
+
+      execInstance
+        .exec(
+          namespace.name,
+          this.containerRef.podRef.podName.name,
+          this.containerRef.containerName.name,
+          command,
+          outputFileStream,
+          errPassthroughStream,
+          null,
+          false,
+          ({status}) => self.handleCallback(status, localContext, messagePrefix),
+        )
+        .then(conn => {
+          localContext.connection = conn;
+
+          self.registerConnectionOnError(localContext, messagePrefix, conn);
+
+          self.registerConnectionOnMessage(messagePrefix);
+
+          conn.on('close', (code, reason) => {
+            self.logger.debug(`${messagePrefix} connection closed`);
+            if (!localContext.errorMessage) {
+              if (code !== 1000) {
+                // code 1000 is the success code
+                return self.exitWithError(localContext, `${messagePrefix} failed with code=${code}, reason=${reason}`);
+              }
+
+              outputFileStream.end();
+              outputFileStream.close(() => {
+                self.logger.debug(`${messagePrefix} finished`);
+                const outData = fs.readFileSync(tmpFile);
+                return resolve(outData.toString());
+              });
+            }
+          });
+        });
+
+      self.registerErrorStreamOnData(localContext, errPassthroughStream);
+
+      self.registerErrorStreamOnError(localContext, messagePrefix, outputFileStream);
+    });
+  }
+
+  async hasDir(destPath: string): Promise<boolean> {
+    return (
+      (await this.execContainer(['bash', '-c', '[[ -d "' + destPath + '" ]] && echo -n "true" || echo -n "false"'])) ===
+      'true'
+    );
+  }
+
+  async hasFile(destPath: string, filters: object): Promise<boolean> {
+    const parentDir = path.dirname(destPath);
+    const fileName = path.basename(destPath);
+    const filterMap = new Map(Object.entries(filters));
+
+    try {
+      const entries = await this.listDir(parentDir);
+
+      for (const item of entries) {
+        if (item.name === fileName && !item.directory) {
+          let found = true;
+
+          for (const entry of filterMap.entries()) {
+            const field = entry[0];
+            const value = entry[1];
+            this.logger.debug(
+              `Checking file ${this.containerRef.podRef.podName.name}:${this.containerRef.containerName.name} ${destPath}; ${field} expected ${value}, found ${item[field]}`,
+              {filters},
+            );
+            if (`${value}` !== `${item[field]}`) {
+              found = false;
+              break;
+            }
+          }
+
+          if (found) {
+            this.logger.debug(
+              `File check succeeded ${this.containerRef.podRef.podName.name}:${this.containerRef.containerName.name} ${destPath}`,
+              {
+                filters,
+              },
+            );
+            return true;
+          }
+        }
+      }
+    } catch (e) {
+      const error = new SoloError(
+        `unable to check file in '${this.containerRef.podRef.podName.name}':${this.containerRef.containerName.name}' - ${destPath}: ${e.message}`,
+        e,
+      );
+      this.logger.error(error.message, error);
+      throw error;
+    }
+
+    return false;
+  }
+
+  async listDir(destPath: string): Promise<any[] | TDirectoryData[]> {
+    // TODO future, return the following
+    // return this.pods.byName(podName).listDir(containerName, destPath);
+    // byName(podName) can use an underlying cache to avoid multiple calls to the API
+    // caching can be added later, it doesn't have to be done right away
+    // byLabel(label) can also cache/lazy initialize if desired
+    // pods are qualified by namespace, so we should really also be passing namespace
+    // string is also an object with a large prototype, same weight as a class instance
+    // PodName can be turned into a class that we can use for the parameters for more control.
+    // PodName.of(namespace, podName)
+    // TODO - make namespace first on all of the methods
+    // TODO - create ContainerName for the containerName, validate the containerName.  ContainerName.of(containerName)
+    //  - to avoid having to do (new ContainerName(containerName))
+    //  - NamespaceName.of(namespace): store as class instead of string after we have validated and put it in ConfigManager
+    //  - PodRef.of(namespace, podName)
+    //  - ContainerRef.of(podRef, containerName)
+    //  - ContainerRef.of(PodRef.of(namespace, podName), containerName)
+    //  - namespace is coming from user and should definitely be validate and kick back if it is invalid
+    // below implementation moves to K8Pod class, current usage would still compile.
+
+    try {
+      const output = (await this.execContainer(['ls', '-la', destPath])) as string;
+      if (!output) return [];
+
+      // parse the output and return the entries
+      const items: TDirectoryData[] = [];
+      const lines = output.split('\n');
+      for (let line of lines) {
+        line = line.replace(/\s+/g, '|');
+        const parts = line.split('|');
+        if (parts.length >= 9) {
+          let name = parts[parts.length - 1];
+          // handle unique file format (without single quotes): 'usedAddressBook_vHederaSoftwareVersion{hapiVersion=v0.53.0, servicesVersion=v0.53.0}_2024-07-30-20-39-06_node_0.txt.debug'
+          for (let i = parts.length - 1; i > 8; i--) {
+            name = `${parts[i - 1]} ${name}`;
+          }
+
+          if (name !== '.' && name !== '..') {
+            const permission = parts[0];
+            const item: TDirectoryData = {
+              directory: permission[0] === 'd',
+              owner: parts[2],
+              group: parts[3],
+              size: parts[4],
+              modifiedAt: `${parts[5]} ${parts[6]} ${parts[7]}`,
+              name,
+            };
+
+            items.push(item);
+          }
+        }
+      }
+
+      return items;
+    } catch (e) {
+      throw new SoloError(
+        `unable to check path in '${this.containerRef.podRef.podName.name}':${this.containerRef.containerName.name}' - ${destPath}: ${e.message}`,
+        e,
+      );
+    }
+  }
+
+  async mkdir(destPath: string): Promise<string> {
+    return this.execContainer(['bash', '-c', 'mkdir -p "' + destPath + '"']);
+  }
+
+  private tempFileFor(fileName: string) {
+    const tmpFile = `${fileName}-${uuid4()}`;
+    return path.join(os.tmpdir(), tmpFile);
+  }
+
+  private deleteTempFile(tmpFile: string) {
+    if (fs.existsSync(tmpFile)) {
+      fs.rmSync(tmpFile);
+    }
+  }
+
+  private exitWithError(localContext: LocalContextObject, errorMessage: string) {
+    localContext.errorMessage = localContext.errorMessage
+      ? `${localContext.errorMessage}:${errorMessage}`
+      : errorMessage;
+    this.logger.warn(errorMessage);
+    return localContext.reject(new SoloError(localContext.errorMessage));
+  }
+
+  private handleCallback(status: string, localContext: LocalContextObject, messagePrefix: string) {
+    if (status === 'Failure') {
+      return this.exitWithError(localContext, `${messagePrefix} Failure occurred`);
+    }
+    this.logger.debug(`${messagePrefix} callback(status)=${status}`);
+  }
+
+  private registerConnectionOnError(
+    localContext: LocalContextObject,
+    messagePrefix: string,
+    conn: WebSocket.WebSocket,
+  ) {
+    conn.on('error', e => {
+      return this.exitWithError(localContext, `${messagePrefix} failed, connection error: ${e.message}`);
+    });
+  }
+
+  private registerConnectionOnMessage(messagePrefix: string) {
+    this.logger.debug(`${messagePrefix} received message`);
+  }
+
+  private registerErrorStreamOnData(localContext: LocalContextObject, stream: stream.PassThrough) {
+    stream.on('data', data => {
+      localContext.errorMessage = localContext.errorMessage
+        ? `${localContext.errorMessage}${data.toString()}`
+        : data.toString();
+    });
+  }
+
+  private registerErrorStreamOnError(
+    localContext: LocalContextObject,
+    messagePrefix: string,
+    stream: stream.PassThrough | fs.WriteStream,
+  ) {
+    stream.on('error', err => {
+      return this.exitWithError(localContext, `${messagePrefix} error encountered, err: ${err.toString()}`);
+    });
+  }
+
+  private registerOutputPassthroughStreamOnData(
+    localContext: LocalContextObject,
+    messagePrefix: string,
+    outputPassthroughStream: stream.PassThrough,
+    outputFileStream: fs.WriteStream,
+  ) {
+    outputPassthroughStream.on('data', chunk => {
+      this.logger.debug(`${messagePrefix} received chunk size=${chunk.length}`);
+      const canWrite = outputFileStream.write(chunk); // Write chunk to file and check if buffer is full
+      if (!canWrite) {
+        this.logger.debug(`${messagePrefix} buffer is full, pausing data stream...`);
+        outputPassthroughStream.pause(); // Pause the data stream if buffer is full
+      }
+    });
+  }
+
+  private registerOutputFileStreamOnDrain(
+    localContext: LocalContextObject,
+    messagePrefix: string,
+    outputPassthroughStream: stream.PassThrough,
+    outputFileStream: fs.WriteStream,
+  ) {
+    outputFileStream.on('drain', () => {
+      outputPassthroughStream.resume();
+      this.logger.debug(`${messagePrefix} stream drained, resume write`);
+    });
+  }
+}

--- a/src/core/kube/k8_client/k8_client_containers.ts
+++ b/src/core/kube/k8_client/k8_client_containers.ts
@@ -13,7 +13,7 @@ import {type KubeConfig} from '@kubernetes/client-node';
 export class K8ClientContainers implements Containers {
   constructor(private readonly kubeConfig: KubeConfig) {}
 
-  byRef(containerRef: ContainerRef): Container {
+  readByRef(containerRef: ContainerRef): Container {
     return new K8ClientContainer(this.kubeConfig, containerRef);
   }
 }

--- a/src/core/kube/k8_client/k8_client_containers.ts
+++ b/src/core/kube/k8_client/k8_client_containers.ts
@@ -1,0 +1,19 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {type Containers} from '../containers.js';
+import {type ContainerRef} from '../container_ref.js';
+import {type Container} from '../container.js';
+import {K8ClientContainer} from './k8_client_container.js';
+import {type KubeConfig} from '@kubernetes/client-node';
+
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+export class K8ClientContainers implements Containers {
+  constructor(private readonly kubeConfig: KubeConfig) {}
+
+  byRef(containerRef: ContainerRef): Container {
+    return new K8ClientContainer(this.kubeConfig, containerRef);
+  }
+}

--- a/src/core/kube/pod.ts
+++ b/src/core/kube/pod.ts
@@ -2,93 +2,13 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import {type ExtendedNetServer} from '../../types/index.js';
-import {type TDirectoryData} from './t_directory_data.js';
-import {type TarCreateFilter} from '../../types/aliases.js';
-import {type ContainerName} from './container_name.js';
-import {type ContainerRef} from './container_ref.js';
 
 export interface Pod {
-  /**
-   * Copy a file from a container
-   *
-   * It overwrites any existing file at the destination directory
-   * @param containerRef - the reference to the container
-   * @param srcPath - the path to the file to copy
-   * @param destDir - the destination directory
-   */
-  copyFrom(containerRef: ContainerRef, srcPath: string, destDir: string): Promise<unknown>;
-
-  /**
-   * Copy a file into a container
-   *
-   * It overwrites any existing file inside the container at the destination directory
-   * @param containerRef - the reference to the container
-   * @param srcPath - the path of the local file to copy
-   * @param destDir - the remote destination directory
-   * @param [filter] - the filter to pass to tar to keep or skip files or directories
-   * @returns a Promise that performs the copy operation
-   */
-  copyTo(
-    containerRef: ContainerRef,
-    srcPath: string,
-    destDir: string,
-    filter: TarCreateFilter | undefined,
-  ): Promise<boolean>;
-
-  /**
-   * Invoke sh command within a container and return the console output as string
-   * @param containerRef - the reference to the container
-   * @param command - sh commands as an array to be run within the containerName (e.g 'ls -la /opt/hgcapp')
-   * @returns console output as string
-   */
-  execContainer(containerRef: ContainerRef, command: string | string[]): Promise<string>;
-
-  /**
-   * Check if a directory exists in the specified container
-   * @param containerRef - the reference to the container
-   * @param destPath - the path to the directory inside the container
-   */
-  hasDir(containerRef: ContainerRef, destPath: string): Promise<boolean>;
-
-  /**
-   * Check if a file exists in the specified container
-   * @param containerRef - the reference to the container
-   * @param destPath - the remote path to the file
-   * @param [filters] - optional filters to apply to the tar stream
-   */
-  hasFile(containerRef: ContainerRef, destPath: string, filters: object): Promise<boolean>;
-
   /**
    * Get a pod by name and namespace, will check every 1 second until the pod is no longer found.
    * Can throw a SoloError if there is an error while deleting the pod.
    */
   killPod(): Promise<void>;
-
-  /**
-   * List files and directories in a container
-   *
-   * It runs ls -la on the specified path and returns a list of object containing the entries.
-   * For example:
-   * [{
-   *    directory: false,
-   *    owner: hedera,
-   *    group: hedera,
-   *    size: 121,
-   *    modifiedAt: Jan 15 13:50
-   *    name: config.txt
-   * }]
-   * @param containerRef - the reference to the container
-   * @param destPath - the remote path to the directory
-   * @returns a promise that returns array of directory entries, custom object
-   */
-  listDir(containerRef: ContainerRef, destPath: string): Promise<any[] | TDirectoryData[]>;
-
-  /**
-   * Make a directory in the specified container
-   * @param containerRef - the reference to the container
-   * @param destPath - the remote path to the directory
-   */
-  mkdir(containerRef: ContainerRef, destPath: string): Promise<string>;
 
   /**
    * Port forward a port from a pod to localhost


### PR DESCRIPTION
## Description

This pull request changes the following:

* create k8.Container interface
* move container methods from Pod to Container
* implement K8ClientContainer and implement across codebase)

### Related Issues

* Closes #1257 
* Closes #1256 
* Closes #1258 
