### PR TITLE
feat: add secrets fluent interface implementation

### DIFF
--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -854,11 +854,11 @@ export class NodeCommandTasks {
         for (const nodeAlias of ctx.config.nodeAliases) {
           const podRef = ctx.config.podRefs[nodeAlias];
           const containerRef = ContainerRef.of(podRef, constants.ROOT_CONTAINER);
-          self.logger.debug(`Uploading state files to pod ${podRef.podName.name}`);
+          self.logger.debug(`Uploading state files to pod ${podRef.name}`);
           await self.k8.copyTo(containerRef, zipFile, `${constants.HEDERA_HAPI_PATH}/data`);
 
           self.logger.info(
-            `Deleting the previous state files in pod ${podRef.podName.name} directory ${constants.HEDERA_HAPI_PATH}/data/saved`,
+            `Deleting the previous state files in pod ${podRef.name} directory ${constants.HEDERA_HAPI_PATH}/data/saved`,
           );
           await self.k8.execContainer(containerRef, ['rm', '-rf', `${constants.HEDERA_HAPI_PATH}/data/saved/*`]);
           await self.k8.execContainer(containerRef, [

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -1023,7 +1023,7 @@ export class NodeCommandTasks {
       'Enable port forwarding for JVM debugger',
       async (ctx: any, task: ListrTaskWrapper<any, any, any>) => {
         const podRef = PodRef.of(ctx.config.namespace, PodName.of(`network-${ctx.config.debugNodeAlias}-0`));
-        this.logger.debug(`Enable port forwarding for JVM debugger on pod ${podRef.podName.name}`);
+        this.logger.debug(`Enable port forwarding for JVM debugger on pod ${podRef.name}`);
         await this.k8.portForward(podRef, constants.JVM_DEBUG_PORT, constants.JVM_DEBUG_PORT);
       },
       (ctx: any) => !ctx.config.debugNodeAlias,

--- a/src/core/kube/container_name.ts
+++ b/src/core/kube/container_name.ts
@@ -1,19 +1,17 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-import {isDns1123Label} from './kube_validation.js';
-import {ContainerNameInvalidError} from './errors/namespace_name_invalid_error.js';
+import {ResourceName} from './resource_name.js';
+import {ResourceType} from './resource_type.js';
 
 /**
  * Represents a Kubernetes container name. A Kubernetes container name must be a valid RFC-1123 DNS label.
  *
  * @include DNS_1123_LABEL
  */
-export class ContainerName {
-  private constructor(public readonly name: string) {
-    if (!this.isValid()) {
-      throw new ContainerNameInvalidError(name);
-    }
+export class ContainerName extends ResourceName {
+  private constructor(name: string) {
+    super(ResourceType.CONTAINER, name);
   }
 
   /**
@@ -27,49 +25,5 @@ export class ContainerName {
    */
   public static of(name: string): ContainerName {
     return new ContainerName(name);
-  }
-
-  /**
-   * Returns true if the container name is valid.  A Kubernetes container name must be a valid RFC-1123 DNS label.
-   *
-   * @include DNS_1123_LABEL
-   *
-   * @returns true if the container name is valid.
-   * @throws ContainerNameInvalidError if the container name is invalid.
-   */
-  private isValid(): boolean {
-    return isDns1123Label(this.name);
-  }
-
-  /**
-   * Compares this instance with another ContainerName.
-   * @param other The other ContainerName instance.
-   * @returns true if both instances have the same name.
-   */
-  public equals(other: ContainerName): boolean {
-    return other instanceof ContainerName && this.name === other.name;
-  }
-
-  /**
-   * Allows implicit conversion to a string.
-   * @returns The container name as a string.
-   */
-  public toString(): string {
-    return this.name;
-  }
-
-  /**
-   * Allows `ContainerName` to be used as a primitive string in operations.
-   */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public [Symbol.toPrimitive](hint: string): string {
-    return this.name;
-  }
-
-  /**
-   * Returns the primitive value of the object.
-   */
-  public valueOf(): string {
-    return this.name;
   }
 }

--- a/src/core/kube/container_ref.ts
+++ b/src/core/kube/container_ref.ts
@@ -3,22 +3,14 @@
  */
 import {type PodRef} from './pod_ref.js';
 import {type ContainerName} from './container_name.js';
-import {MissingContainerNameError, MissingPodRefError} from './errors/namespace_name_invalid_error.js';
+import {NestedResourceRef} from './nested_resource_ref.js';
 
 /**
  * Represents a Kubernetes pod reference which includes the namespace name and pod name.
  */
-export class ContainerRef {
-  private constructor(
-    public readonly podRef: PodRef,
-    public readonly containerName: ContainerName,
-  ) {
-    if (!podRef) {
-      throw new MissingPodRefError();
-    }
-    if (!containerName) {
-      throw new MissingContainerNameError();
-    }
+export class ContainerRef extends NestedResourceRef<PodRef, ContainerName> {
+  private constructor(parentRef: PodRef, name: ContainerName) {
+    super(parentRef, name);
   }
 
   /**
@@ -28,26 +20,5 @@ export class ContainerRef {
    */
   public static of(podRef: PodRef, containerName: ContainerName): ContainerRef {
     return new ContainerRef(podRef, containerName);
-  }
-
-  /**
-   * Compares this instance with another ContainerRef.
-   * @param other The other ContainerRef instance.
-   * @returns true if both instances have the same pod ref and container name.
-   */
-  public equals(other: ContainerRef): boolean {
-    return (
-      other instanceof ContainerRef &&
-      this.podRef.equals(other.podRef) &&
-      this.containerName.equals(other.containerName)
-    );
-  }
-
-  /**
-   * Allows implicit conversion to a string.
-   * @returns The container reference as a string.
-   */
-  public toString(): string {
-    return `{podRef: ${this.podRef.toString()}, containerName: ${this.containerName.toString()}}`;
   }
 }

--- a/src/core/kube/errors/invalid_resource_name_error.ts
+++ b/src/core/kube/errors/invalid_resource_name_error.ts
@@ -1,0 +1,26 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {SoloError} from '../../errors.js';
+import {type ResourceType} from '../resource_type.js';
+
+const RFC_1123_POSTFIX = (prefix: string) => `${prefix} is invalid, must be a valid RFC-1123 DNS label.  \` +
+    "A DNS 1123 label must consist of lower case alphanumeric characters, '-' " +
+    "or '.', and must start and end with an alphanumeric character.`;
+
+export class InvalidResourceNameError extends SoloError {
+  public static RESOURCE_NAME_INVALID = (type: ResourceType, name: string) =>
+    RFC_1123_POSTFIX(`${type} name '${name}'`);
+
+  /**
+   * Instantiates a new error with a message and an optional cause.
+   *
+   * @param name - the invalid pod name.
+   * @param type - the type of the resource.
+   * @param cause - optional underlying cause of the error.
+   * @param meta - optional metadata to be reported.
+   */
+  public constructor(name: string, type: ResourceType, cause: Error | any = {}, meta: any = {}) {
+    super(InvalidResourceNameError.RESOURCE_NAME_INVALID(type, name), cause, meta);
+  }
+}

--- a/src/core/kube/errors/missing_namespace_error.ts
+++ b/src/core/kube/errors/missing_namespace_error.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {SoloError} from '../../errors.js';
+
+export class MissingNamespaceError extends SoloError {
+  public static MISSING_NAMESPACE = 'Namespace is required.';
+
+  /**
+   * Instantiates a new error with a message and an optional cause.
+   *
+   * @param cause - optional underlying cause of the error.
+   * @param meta - optional metadata to be reported.
+   */
+  public constructor(cause?: Error, meta?: object) {
+    super(MissingNamespaceError.MISSING_NAMESPACE, cause, meta);
+  }
+}

--- a/src/core/kube/errors/missing_parent_resource_error.ts
+++ b/src/core/kube/errors/missing_parent_resource_error.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {SoloError} from '../../errors.js';
+
+export class MissingParentResourceRefError extends SoloError {
+  public static MISSING_PARENT_RESOURCE_REF = 'The parent ResourceRef is required.';
+
+  /**
+   * Instantiates a new error with a message and an optional cause.
+   *
+   * @param cause - optional underlying cause of the error.
+   * @param meta - optional metadata to be reported.
+   */
+  public constructor(cause?: Error, meta?: object) {
+    super(MissingParentResourceRefError.MISSING_PARENT_RESOURCE_REF, cause, meta);
+  }
+}

--- a/src/core/kube/errors/missing_resource_name_error.ts
+++ b/src/core/kube/errors/missing_resource_name_error.ts
@@ -1,0 +1,18 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {SoloError} from '../../errors.js';
+
+export class MissingResourceNameError extends SoloError {
+  public static MISSING_RESOURCE_NAME = 'Name is required.';
+
+  /**
+   * Instantiates a new error with a message and an optional cause.
+   *
+   * @param cause - optional underlying cause of the error.
+   * @param meta - optional metadata to be reported.
+   */
+  public constructor(cause?: Error, meta?: object) {
+    super(MissingResourceNameError.MISSING_RESOURCE_NAME, cause, meta);
+  }
+}

--- a/src/core/kube/errors/namespace_name_invalid_error.ts
+++ b/src/core/kube/errors/namespace_name_invalid_error.ts
@@ -22,49 +22,6 @@ export class NamespaceNameInvalidError extends SoloError {
   }
 }
 
-export class PodNameInvalidError extends SoloError {
-  public static POD_NAME_INVALID = (name: string) => RFC_1123_POSTFIX(`Pod name '${name}'`);
-
-  /**
-   * Instantiates a new error with a message and an optional cause.
-   *
-   * @param podName - the invalid pod name.
-   * @param cause - optional underlying cause of the error.
-   * @param meta - optional metadata to be reported.
-   */
-  public constructor(podName: string, cause: Error | any = {}, meta: any = {}) {
-    super(PodNameInvalidError.POD_NAME_INVALID(podName), cause, meta);
-  }
-}
-
-export class MissingNamespaceNameError extends SoloError {
-  public static MISSING_NAMESPACE_NAME = 'Namespace name is required.';
-
-  /**
-   * Instantiates a new error with a message and an optional cause.
-   *
-   * @param cause - optional underlying cause of the error.
-   * @param meta - optional metadata to be reported.
-   */
-  public constructor(cause: Error | any = {}, meta: any = {}) {
-    super(MissingNamespaceNameError.MISSING_NAMESPACE_NAME, cause, meta);
-  }
-}
-
-export class MissingPodNameError extends SoloError {
-  public static MISSING_POD_NAME = 'Pod name is required.';
-
-  /**
-   * Instantiates a new error with a message and an optional cause.
-   *
-   * @param cause - optional underlying cause of the error.
-   * @param meta - optional metadata to be reported.
-   */
-  public constructor(cause: Error | any = {}, meta: any = {}) {
-    super(MissingPodNameError.MISSING_POD_NAME, cause, meta);
-  }
-}
-
 export class ContainerNameInvalidError extends SoloError {
   public static CONTAINER_NAME_INVALID = (name: string) => RFC_1123_POSTFIX(`Container name '${name}'`);
 

--- a/src/core/kube/k8.ts
+++ b/src/core/kube/k8.ts
@@ -20,6 +20,7 @@ import {type Service} from './service.js';
 import {type Pods} from './pods.js';
 import {type Leases} from './leases.js';
 import {type IngressClasses} from './ingress_classes.js';
+import {type Secrets} from './secrets.js';
 
 export interface K8 {
   /**
@@ -75,6 +76,12 @@ export interface K8 {
    * @returns an object instance providing lease operations
    */
   leases(): Leases;
+
+  /**
+   * Fluent accessor for reading and manipulating secrets in the kubernetes cluster.
+   * @returns an object instance providing secret operations
+   */
+  secrets(): Secrets;
 
   /**
    * Fluent accessor for reading and manipulating ingress classes in the kubernetes cluster.

--- a/src/core/kube/k8_client.ts
+++ b/src/core/kube/k8_client.ts
@@ -113,42 +113,22 @@ export class K8Client extends K8ClientBase implements K8 {
     return this; // to enable chaining
   }
 
-  /**
-   * Fluent accessor for reading and manipulating namespaces in the kubernetes cluster.
-   * @returns an object instance providing namespace operations
-   */
   public namespaces(): Namespaces {
     return this.k8Namespaces;
   }
 
-  /**
-   * Fluent accessor for reading and manipulating clusters in the kubeconfig file.
-   * @returns an object instance providing cluster operations
-   */
   public clusters(): Clusters {
     return this.k8Clusters;
   }
 
-  /**
-   * Fluent accessor for reading and manipulating config maps in the kubernetes cluster.
-   * @returns an object instance providing config map operations
-   */
   public configMaps(): ConfigMaps {
     return this.k8ConfigMaps;
   }
 
-  /**
-   * Fluent accessor for reading and manipulating containers in the kubernetes cluster.
-   * @returns an object instance providing container operations
-   */
   public containers(): Containers {
     return this.k8Containers;
   }
 
-  /**
-   * Fluent accessor for reading and manipulating contexts in the kubeconfig file.
-   * @returns an object instance providing context operations
-   */
   public contexts(): Contexts {
     return this.k8Contexts;
   }
@@ -161,10 +141,6 @@ export class K8Client extends K8ClientBase implements K8 {
     return this.k8Pods;
   }
 
-  /**
-   * Fluent accessor for reading and manipulating persistent volume claims in the kubernetes cluster.
-   * @returns an object instance providing pvc operations
-   */
   public pvcs(): Pvcs {
     return this.k8Pvcs;
   }
@@ -173,10 +149,6 @@ export class K8Client extends K8ClientBase implements K8 {
     return this.k8Leases;
   }
 
-  /**
-   * Fluent accessor for reading and manipulating secrets in the kubernetes cluster.
-   * @returns an object instance providing secret operations
-   */
   public secrets(): Secrets {
     return this.k8Secrets;
   }

--- a/src/core/kube/k8_client.ts
+++ b/src/core/kube/k8_client.ts
@@ -2,17 +2,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import * as k8s from '@kubernetes/client-node';
-import {type V1Lease, V1ObjectMeta, V1Secret} from '@kubernetes/client-node';
+import {type V1Lease} from '@kubernetes/client-node';
 import {Flags as flags} from '../../commands/flags.js';
 import {MissingArgumentError, SoloError} from './../errors.js';
 import {StatusCodes} from 'http-status-codes';
-import {sleep} from './../helpers.js';
 import * as constants from './../constants.js';
 import {ConfigManager} from './../config_manager.js';
 import {SoloLogger} from './../logging.js';
 import {type TarCreateFilter} from '../../types/aliases.js';
 import {type ExtendedNetServer, type Optional} from '../../types/index.js';
-import {Duration} from './../time/duration.js';
 import {inject, injectable} from 'tsyringe-neo';
 import {patchInject} from './../container_helper.js';
 import {type K8} from './k8.js';
@@ -41,6 +39,8 @@ import {K8ClientLeases} from './k8_client/k8_client_leases.js';
 import {K8ClientNamespaces} from './k8_client/k8_client_namespaces.js';
 import {K8ClientIngressClasses} from './k8_client/k8_client_ingress_classes.js';
 import {type IngressClasses} from './ingress_classes.js';
+import {type Secrets} from './secrets.js';
+import {K8ClientSecrets} from './k8_client/k8_client_secrets.js';
 
 /**
  * A kubernetes API wrapper class providing custom functionalities required by solo
@@ -68,6 +68,7 @@ export class K8Client extends K8ClientBase implements K8 {
   private k8Pvcs: Pvcs;
   private k8Namespaces: Namespaces;
   private k8IngressClasses: IngressClasses;
+  private k8Secrets: Secrets;
 
   constructor(
     @inject(ConfigManager) private readonly configManager?: ConfigManager,
@@ -107,26 +108,47 @@ export class K8Client extends K8ClientBase implements K8 {
     this.k8Leases = new K8ClientLeases(this.coordinationApiClient);
     this.k8Namespaces = new K8ClientNamespaces(this.kubeClient);
     this.k8IngressClasses = new K8ClientIngressClasses(this.networkingApi);
+    this.k8Secrets = new K8ClientSecrets(this.kubeClient);
 
     return this; // to enable chaining
   }
 
+  /**
+   * Fluent accessor for reading and manipulating namespaces in the kubernetes cluster.
+   * @returns an object instance providing namespace operations
+   */
   public namespaces(): Namespaces {
     return this.k8Namespaces;
   }
 
+  /**
+   * Fluent accessor for reading and manipulating clusters in the kubeconfig file.
+   * @returns an object instance providing cluster operations
+   */
   public clusters(): Clusters {
     return this.k8Clusters;
   }
 
+  /**
+   * Fluent accessor for reading and manipulating config maps in the kubernetes cluster.
+   * @returns an object instance providing config map operations
+   */
   public configMaps(): ConfigMaps {
     return this.k8ConfigMaps;
   }
 
+  /**
+   * Fluent accessor for reading and manipulating containers in the kubernetes cluster.
+   * @returns an object instance providing container operations
+   */
   public containers(): Containers {
     return this.k8Containers;
   }
 
+  /**
+   * Fluent accessor for reading and manipulating contexts in the kubeconfig file.
+   * @returns an object instance providing context operations
+   */
   public contexts(): Contexts {
     return this.k8Contexts;
   }
@@ -139,12 +161,24 @@ export class K8Client extends K8ClientBase implements K8 {
     return this.k8Pods;
   }
 
+  /**
+   * Fluent accessor for reading and manipulating persistent volume claims in the kubernetes cluster.
+   * @returns an object instance providing pvc operations
+   */
   public pvcs(): Pvcs {
     return this.k8Pvcs;
   }
 
   public leases(): Leases {
     return this.k8Leases;
+  }
+
+  /**
+   * Fluent accessor for reading and manipulating secrets in the kubernetes cluster.
+   * @returns an object instance providing secret operations
+   */
+  public secrets(): Secrets {
+    return this.k8Secrets;
   }
 
   public ingressClasses(): IngressClasses {
@@ -176,23 +210,7 @@ export class K8Client extends K8ClientBase implements K8 {
   }
 
   public async getSecretsByLabel(labels: string[] = [], namespace?: NamespaceName) {
-    const ns = namespace || this.getNamespace();
-    const labelSelector = labels.join(',');
-    const result = await this.kubeClient.listNamespacedSecret(
-      ns.name,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      labelSelector,
-      undefined,
-      undefined,
-      undefined,
-      undefined,
-      Duration.ofMinutes(5).toMillis(),
-    );
-
-    return result.body.items;
+    return this.secrets().list(namespace || this.getNamespace(), labels);
   }
 
   public async getSvcByName(name: string): Promise<Service> {
@@ -276,14 +294,8 @@ export class K8Client extends K8ClientBase implements K8 {
    */
   // TODO - delete this method, and change downstream to use getSecretsByLabel(labels: string[] = [], namespace?: string): Promise<V1Secret[]>
   public async listSecretsByNamespace(namespace: NamespaceName, labels: string[] = []) {
-    const secrets: string[] = [];
-    const items = await this.getSecretsByLabel(labels, namespace);
-
-    for (const item of items) {
-      secrets.push(item.metadata!.name as string);
-    }
-
-    return secrets;
+    const results = await this.secrets().list(namespace, labels);
+    return results.map(secret => secret.name);
   }
 
   public async deletePvc(name: string, namespace: NamespaceName) {
@@ -303,20 +315,8 @@ export class K8Client extends K8ClientBase implements K8 {
    */
   // TODO - delete this method, and change downstream to use getSecretsByLabel(labels: string[] = [], namespace?: string): Promise<V1Secret[]>
   public async getSecret(namespace: NamespaceName, labelSelector: string) {
-    const labels = labelSelector.split(',');
-    const items = await this.getSecretsByLabel(labels, namespace);
-
-    if (items.length > 0) {
-      const secretObject = items[0];
-      return {
-        name: secretObject.metadata!.name as string,
-        labels: secretObject.metadata!.labels as Record<string, string>,
-        namespace: secretObject.metadata!.namespace as string,
-        type: secretObject.type as string,
-        data: secretObject.data as Record<string, string>,
-      };
-    }
-    return null;
+    const items = await this.secrets().list(namespace, labelSelector ? [labelSelector] : null);
+    return items.length > 0 ? items[0] : null;
   }
 
   public async createSecret(
@@ -328,32 +328,10 @@ export class K8Client extends K8ClientBase implements K8 {
     recreate: boolean,
   ) {
     if (recreate) {
-      try {
-        await this.kubeClient.deleteNamespacedSecret(name, namespace.name);
-      } catch {
-        // do nothing
-      }
+      return await this.secrets().createOrReplace(namespace, name, secretType, data, labels);
     }
 
-    const v1Secret = new V1Secret();
-    v1Secret.apiVersion = 'v1';
-    v1Secret.kind = 'Secret';
-    v1Secret.type = secretType;
-    v1Secret.data = data;
-    v1Secret.metadata = new V1ObjectMeta();
-    v1Secret.metadata.name = name;
-    v1Secret.metadata.labels = labels;
-
-    try {
-      const resp = await this.kubeClient.createNamespacedSecret(namespace.name, v1Secret);
-
-      return resp.response.statusCode === StatusCodes.CREATED;
-    } catch (e) {
-      throw new SoloError(
-        `failed to create secret ${name} in namespace ${namespace}: ${e.message}, ${e?.body?.message}`,
-        e,
-      );
-    }
+    return await this.secrets().create(namespace, name, secretType, data, labels);
   }
 
   public async deleteSecret(name: string, namespace: NamespaceName) {

--- a/src/core/kube/k8_client/k8_client_config_maps.ts
+++ b/src/core/kube/k8_client/k8_client_config_maps.ts
@@ -23,7 +23,7 @@ export class K8ClientConfigMaps implements ConfigMaps {
     labels: Record<string, string>,
     data: Record<string, string>,
   ): Promise<boolean> {
-    return this.createOrReplaceWithForce(namespace, name, labels, data, false, true);
+    return await this.createOrReplaceWithForce(namespace, name, labels, data, false, true);
   }
 
   public async createOrReplace(
@@ -32,7 +32,7 @@ export class K8ClientConfigMaps implements ConfigMaps {
     labels: Record<string, string>,
     data: Record<string, string>,
   ): Promise<boolean> {
-    return this.createOrReplaceWithForce(namespace, name, labels, data, false, false);
+    return await this.createOrReplaceWithForce(namespace, name, labels, data, false, false);
   }
 
   public async delete(namespace: NamespaceName, name: string): Promise<boolean> {
@@ -56,7 +56,7 @@ export class K8ClientConfigMaps implements ConfigMaps {
     labels: Record<string, string>,
     data: Record<string, string>,
   ): Promise<boolean> {
-    return this.createOrReplaceWithForce(namespace, name, labels, data, true, false);
+    return await this.createOrReplaceWithForce(namespace, name, labels, data, true, false);
   }
 
   public async exists(namespace: NamespaceName, name: string): Promise<boolean> {
@@ -117,6 +117,6 @@ export class K8ClientConfigMaps implements ConfigMaps {
       return false;
     }
 
-    return this.exists(namespace, name);
+    return await this.exists(namespace, name);
   }
 }

--- a/src/core/kube/k8_client/k8_client_config_maps.ts
+++ b/src/core/kube/k8_client/k8_client_config_maps.ts
@@ -93,7 +93,7 @@ export class K8ClientConfigMaps implements ConfigMaps {
       const resp = replace
         ? await this.kubeClient.replaceNamespacedConfigMap(name, namespace.name, configMap)
         : await this.kubeClient.createNamespacedConfigMap(namespace.name, configMap);
-      return KubeApiResponse.isFailingStatus(resp.response);
+      return KubeApiResponse.isCreatedStatus(resp.response);
     } catch (e) {
       if (replace) {
         throw new ResourceReplaceError(ResourceType.CONFIG_MAP, namespace, name, e);

--- a/src/core/kube/k8_client/k8_client_pods.ts
+++ b/src/core/kube/k8_client/k8_client_pods.ts
@@ -31,8 +31,8 @@ export class K8ClientPods extends K8ClientBase implements Pods {
   }
 
   public async readByName(podRef: PodRef): Promise<V1Pod> {
-    const ns = podRef.namespaceName;
-    const fieldSelector = `metadata.name=${podRef.podName.name}`;
+    const ns = podRef.namespace;
+    const fieldSelector = `metadata.name=${podRef.name}`;
 
     const resp = await this.kubeClient.listNamespacedPod(
       ns.name,
@@ -48,7 +48,7 @@ export class K8ClientPods extends K8ClientBase implements Pods {
       Duration.ofMinutes(5).toMillis(),
     );
 
-    return this.filterItem(resp.body.items, {name: podRef.podName.name});
+    return this.filterItem(resp.body.items, {name: podRef.name.toString()});
   }
 
   public async readManyByLabel(namespace: NamespaceName, labels: string[]): Promise<V1Pod[]> {

--- a/src/core/kube/k8_client/k8_client_secrets.ts
+++ b/src/core/kube/k8_client/k8_client_secrets.ts
@@ -21,7 +21,7 @@ export class K8ClientSecrets implements Secrets {
     data: Record<string, string>,
     labels: Optional<Record<string, string>>,
   ): Promise<boolean> {
-    return this.createOrReplaceWithForce(namespace, name, secretType, data, labels, false, true);
+    return await this.createOrReplaceWithForce(namespace, name, secretType, data, labels, false, true);
   }
 
   public async createOrReplace(
@@ -31,7 +31,7 @@ export class K8ClientSecrets implements Secrets {
     data: Record<string, string>,
     labels: Optional<Record<string, string>>,
   ): Promise<boolean> {
-    return this.createOrReplaceWithForce(namespace, name, secretType, data, labels, false, false);
+    return await this.createOrReplaceWithForce(namespace, name, secretType, data, labels, false, false);
   }
 
   public async delete(namespace: NamespaceName, name: string): Promise<boolean> {
@@ -135,7 +135,7 @@ export class K8ClientSecrets implements Secrets {
       const resp = replace
         ? await this.kubeClient.replaceNamespacedSecret(name, namespace.name, v1Secret)
         : await this.kubeClient.createNamespacedSecret(namespace.name, v1Secret);
-      return KubeApiResponse.isCreatedStatus(resp.response);
+      return !KubeApiResponse.isFailingStatus(resp.response);
     } catch (e) {
       if (replace) {
         throw new ResourceReplaceError(ResourceType.SECRET, namespace, name, e);
@@ -159,6 +159,6 @@ export class K8ClientSecrets implements Secrets {
       return false;
     }
 
-    return this.exists(namespace, name);
+    return await this.exists(namespace, name);
   }
 }

--- a/src/core/kube/k8_client/k8_client_secrets.ts
+++ b/src/core/kube/k8_client/k8_client_secrets.ts
@@ -1,0 +1,164 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {type Secrets} from '../secrets.js';
+import {type CoreV1Api, V1ObjectMeta, V1Secret} from '@kubernetes/client-node';
+import {type NamespaceName} from '../namespace_name.js';
+import {type Optional} from '../../../types/index.js';
+import {KubeApiResponse} from '../kube_api_response.js';
+import {ResourceCreateError, ResourceNotFoundError, ResourceReplaceError} from '../errors/resource_operation_errors.js';
+import {ResourceType} from '../resource_type.js';
+import {ResourceOperation} from '../resource_operation.js';
+import {Duration} from '../../time/duration.js';
+
+export class K8ClientSecrets implements Secrets {
+  public constructor(private readonly kubeClient: CoreV1Api) {}
+
+  public async create(
+    namespace: NamespaceName,
+    name: string,
+    secretType: string,
+    data: Record<string, string>,
+    labels: Optional<Record<string, string>>,
+  ): Promise<boolean> {
+    return this.createOrReplaceWithForce(namespace, name, secretType, data, labels, false, true);
+  }
+
+  public async createOrReplace(
+    namespace: NamespaceName,
+    name: string,
+    secretType: string,
+    data: Record<string, string>,
+    labels: Optional<Record<string, string>>,
+  ): Promise<boolean> {
+    return this.createOrReplaceWithForce(namespace, name, secretType, data, labels, false, false);
+  }
+
+  public async delete(namespace: NamespaceName, name: string): Promise<boolean> {
+    const resp = await this.kubeClient.deleteNamespacedSecret(name, namespace.name);
+    return !KubeApiResponse.isFailingStatus(resp.response);
+  }
+
+  public async replace(
+    namespace: NamespaceName,
+    name: string,
+    secretType: string,
+    data: Record<string, string>,
+    labels: Optional<Record<string, string>>,
+  ): Promise<boolean> {
+    return this.createOrReplaceWithForce(namespace, name, secretType, data, labels, true, false);
+  }
+
+  public async read(namespace: NamespaceName, name: string): Promise<object> {
+    const {response, body} = await this.kubeClient.readNamespacedSecret(name, namespace.name).catch(e => e);
+    KubeApiResponse.check(response, ResourceOperation.READ, ResourceType.SECRET, namespace, name);
+    return {
+      name: body.metadata!.name as string,
+      labels: body.metadata!.labels as Record<string, string>,
+      namespace: body.metadata!.namespace as string,
+      type: body.type as string,
+      data: body.data as Record<string, string>,
+    };
+  }
+
+  public async list(
+    namespace: NamespaceName,
+    labels?: string[],
+  ): Promise<
+    Array<{
+      data: Record<string, string>;
+      name: string;
+      namespace: string;
+      type: string;
+      labels: Record<string, string>;
+    }>
+  > {
+    const labelSelector = labels ? labels.join(',') : undefined;
+    const secretList = await this.kubeClient.listNamespacedSecret(
+      namespace.toString(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      labelSelector,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      Duration.ofMinutes(5).toMillis(),
+    );
+    KubeApiResponse.check(secretList.response, ResourceOperation.LIST, ResourceType.SECRET, namespace, '');
+    return secretList.body.items.map((secret: V1Secret) => {
+      return {
+        name: secret.metadata!.name as string,
+        labels: secret.metadata!.labels as Record<string, string>,
+        namespace: secret.metadata!.namespace as string,
+        type: secret.type as string,
+        data: secret.data as Record<string, string>,
+      };
+    });
+  }
+
+  public async exists(namespace: NamespaceName, name: string): Promise<boolean> {
+    try {
+      const cm = await this.read(namespace, name);
+      return !!cm;
+    } catch (e) {
+      if (e instanceof ResourceNotFoundError) {
+        return false;
+      } else {
+        throw e;
+      }
+    }
+  }
+
+  private async createOrReplaceWithForce(
+    namespace: NamespaceName,
+    name: string,
+    secretType: string,
+    data: Record<string, string>,
+    labels: Optional<Record<string, string>>,
+    forceReplace?: boolean,
+    forceCreate?: boolean,
+  ): Promise<boolean> {
+    const replace = await this.shouldReplace(namespace, name, forceReplace, forceCreate);
+    const v1Secret = new V1Secret();
+    v1Secret.apiVersion = 'v1';
+    v1Secret.kind = 'Secret';
+    v1Secret.type = secretType;
+    v1Secret.data = data;
+    v1Secret.metadata = new V1ObjectMeta();
+    v1Secret.metadata.name = name;
+    v1Secret.metadata.labels = labels;
+
+    try {
+      const resp = replace
+        ? await this.kubeClient.replaceNamespacedSecret(name, namespace.name, v1Secret)
+        : await this.kubeClient.createNamespacedSecret(namespace.name, v1Secret);
+      return KubeApiResponse.isCreatedStatus(resp.response);
+    } catch (e) {
+      if (replace) {
+        throw new ResourceReplaceError(ResourceType.SECRET, namespace, name, e);
+      } else {
+        throw new ResourceCreateError(ResourceType.SECRET, namespace, name, e);
+      }
+    }
+  }
+
+  private async shouldReplace(
+    namespace: NamespaceName,
+    name: string,
+    forceReplace?: boolean,
+    forceCreate?: boolean,
+  ): Promise<boolean> {
+    if (forceReplace && !forceCreate) {
+      return true;
+    }
+
+    if (forceCreate) {
+      return false;
+    }
+
+    return this.exists(namespace, name);
+  }
+}

--- a/src/core/kube/kube_api_response.ts
+++ b/src/core/kube/kube_api_response.ts
@@ -54,4 +54,8 @@ export class KubeApiResponse {
   public static isNotFound(response: http.IncomingMessage): boolean {
     return +response?.statusCode === StatusCodes.NOT_FOUND;
   }
+
+  public static isCreatedStatus(response: http.IncomingMessage): boolean {
+    return +response?.statusCode === StatusCodes.CREATED;
+  }
 }

--- a/src/core/kube/nested_resource_ref.ts
+++ b/src/core/kube/nested_resource_ref.ts
@@ -1,0 +1,38 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {type ResourceRef} from './resource_ref.js';
+import {type ResourceName} from './resource_name.js';
+import {MissingParentResourceRefError} from './errors/missing_parent_resource_error.js';
+import {MissingResourceNameError} from './errors/missing_resource_name_error.js';
+
+export abstract class NestedResourceRef<P extends ResourceRef<any>, T extends ResourceName> {
+  protected constructor(
+    public readonly parentRef: P,
+    public readonly name: T,
+  ) {
+    if (!parentRef) {
+      throw new MissingParentResourceRefError();
+    }
+    if (!name) {
+      throw new MissingResourceNameError();
+    }
+  }
+
+  /**
+   * Compares this instance with another NestedResourceRef.
+   * @param other The other NestedResourceRef instance.
+   * @returns true if both instances have the same parent reference and name.
+   */
+  public equals(other: NestedResourceRef<P, T>): boolean {
+    return other instanceof NestedResourceRef && this.parentRef.equals(other.parentRef) && this.name.equals(other.name);
+  }
+
+  /**
+   * Allows implicit conversion to a string.
+   * @returns The nested resource reference as a string.
+   */
+  public toString(): string {
+    return `{parentRef: ${this.parentRef.toString()}, name: ${this.name}}`;
+  }
+}

--- a/src/core/kube/pod_name.ts
+++ b/src/core/kube/pod_name.ts
@@ -1,19 +1,17 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-import {isDns1123Label} from './kube_validation.js';
-import {PodNameInvalidError} from './errors/namespace_name_invalid_error.js';
+import {ResourceName} from './resource_name.js';
+import {ResourceType} from './resource_type.js';
 
 /**
  * Represents a Kubernetes pod name. A Kubernetes pod name must be a valid RFC-1123 DNS label.
  *
  * @include DNS_1123_LABEL
  */
-export class PodName {
-  private constructor(public readonly name: string) {
-    if (!this.isValid()) {
-      throw new PodNameInvalidError(name);
-    }
+export class PodName extends ResourceName {
+  private constructor(name: string) {
+    super(ResourceType.POD, name);
   }
 
   /**
@@ -23,53 +21,9 @@ export class PodName {
    *
    * @param name The name of the pod.
    * @returns An instance of PodName.
-   * @throws PodNameInvalidError if the pod name is invalid.
+   * @throws InvalidResourceNameError if the pod name is invalid.
    */
   public static of(name: string): PodName {
     return new PodName(name);
-  }
-
-  /**
-   * Returns true if the pod name is valid.  A Kubernetes pod name must be a valid RFC-1123 DNS label.
-   *
-   * @include DNS_1123_LABEL
-   *
-   * @returns true if the pod name is valid.
-   * @throws PodNameInvalidError if the pod name is invalid.
-   */
-  private isValid(): boolean {
-    return isDns1123Label(this.name);
-  }
-
-  /**
-   * Compares this instance with another PodName.
-   * @param other The other PodName instance.
-   * @returns true if both instances have the same name.
-   */
-  public equals(other: PodName): boolean {
-    return other instanceof PodName && this.name === other.name;
-  }
-
-  /**
-   * Allows implicit conversion to a string.
-   * @returns The pod name as a string.
-   */
-  public toString(): string {
-    return this.name;
-  }
-
-  /**
-   * Allows `PodName` to be used as a primitive string in operations.
-   */
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  public [Symbol.toPrimitive](hint: string): string {
-    return this.name;
-  }
-
-  /**
-   * Returns the primitive value of the object.
-   */
-  public valueOf(): string {
-    return this.name;
   }
 }

--- a/src/core/kube/pod_ref.ts
+++ b/src/core/kube/pod_ref.ts
@@ -3,22 +3,14 @@
  */
 import {type PodName} from './pod_name.js';
 import {type NamespaceName} from './namespace_name.js';
-import {MissingNamespaceNameError, MissingPodNameError} from './errors/namespace_name_invalid_error.js';
+import {ResourceRef} from './resource_ref.js';
 
 /**
  * Represents a Kubernetes pod reference which includes the namespace name and pod name.
  */
-export class PodRef {
-  private constructor(
-    public readonly namespaceName: NamespaceName,
-    public readonly podName: PodName,
-  ) {
-    if (!namespaceName) {
-      throw new MissingNamespaceNameError();
-    }
-    if (!podName) {
-      throw new MissingPodNameError();
-    }
+export class PodRef extends ResourceRef<PodName> {
+  private constructor(namespace: NamespaceName, name: PodName) {
+    super(namespace, name);
   }
 
   /**
@@ -28,24 +20,5 @@ export class PodRef {
    */
   public static of(namespace: NamespaceName, podName: PodName): PodRef {
     return new PodRef(namespace, podName);
-  }
-
-  /**
-   * Compares this instance with another PodRef.
-   * @param other The other PodRef instance.
-   * @returns true if both instances have the same namespace name and pod name.
-   */
-  public equals(other: PodRef): boolean {
-    return (
-      other instanceof PodRef && this.namespaceName.equals(other.namespaceName) && this.podName.equals(other.podName)
-    );
-  }
-
-  /**
-   * Allows implicit conversion to a string.
-   * @returns The pod reference as a string.
-   */
-  public toString(): string {
-    return `{namespaceName: ${this.namespaceName}, podName: ${this.podName}}`;
   }
 }

--- a/src/core/kube/resource_name.ts
+++ b/src/core/kube/resource_name.ts
@@ -1,0 +1,61 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {isDns1123Label} from './kube_validation.js';
+import {InvalidResourceNameError} from './errors/invalid_resource_name_error.js';
+import {type ResourceType} from './resource_type.js';
+
+export abstract class ResourceName {
+  protected constructor(
+    type: ResourceType,
+    public readonly name: string,
+  ) {
+    if (!this.isValid()) {
+      throw new InvalidResourceNameError(name, type);
+    }
+  }
+
+  /**
+   * Returns true if the pod name is valid.  A Kubernetes pod name must be a valid RFC-1123 DNS label.
+   *
+   * @include DNS_1123_LABEL
+   *
+   * @returns true if the pod name is valid.
+   * @throws InvalidResourceNameError if the pod name is invalid.
+   */
+  private isValid(): boolean {
+    return isDns1123Label(this.name);
+  }
+
+  /**
+   * Compares this instance with another PodName.
+   * @param other The other PodName instance.
+   * @returns true if both instances have the same name.
+   */
+  public equals(other: ResourceName): boolean {
+    return other instanceof ResourceName && this.name === other.name;
+  }
+
+  /**
+   * Allows implicit conversion to a string.
+   * @returns The pod name as a string.
+   */
+  public toString(): string {
+    return this.name;
+  }
+
+  /**
+   * Allows `PodName` to be used as a primitive string in operations.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public [Symbol.toPrimitive](hint: string): string {
+    return this.name;
+  }
+
+  /**
+   * Returns the primitive value of the object.
+   */
+  public valueOf(): string {
+    return this.name;
+  }
+}

--- a/src/core/kube/resource_ref.ts
+++ b/src/core/kube/resource_ref.ts
@@ -1,0 +1,38 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {type NamespaceName} from './namespace_name.js';
+import {type ResourceName} from './resource_name.js';
+import {MissingNamespaceError} from './errors/missing_namespace_error.js';
+import {MissingResourceNameError} from './errors/missing_resource_name_error.js';
+
+export abstract class ResourceRef<T extends ResourceName> {
+  protected constructor(
+    public readonly namespace: NamespaceName,
+    public readonly name: T,
+  ) {
+    if (!namespace) {
+      throw new MissingNamespaceError();
+    }
+    if (!name) {
+      throw new MissingResourceNameError();
+    }
+  }
+
+  /**
+   * Compares this instance with another PodRef.
+   * @param other The other PodRef instance.
+   * @returns true if both instances have the same namespace name and pod name.
+   */
+  public equals(other: ResourceRef<T>): boolean {
+    return other instanceof ResourceRef && this.namespace.equals(other.namespace) && this.name.equals(other.name);
+  }
+
+  /**
+   * Allows implicit conversion to a string.
+   * @returns The pod reference as a string.
+   */
+  public toString(): string {
+    return `{namespace: ${this.namespace}, name: ${this.name}}`;
+  }
+}

--- a/src/core/kube/resource_type.ts
+++ b/src/core/kube/resource_type.ts
@@ -23,4 +23,5 @@ export enum ResourceType {
   CLUSTER_ROLE = 'ClusterRole',
   CLUSTER_ROLE_BINDING = 'ClusterRoleBinding',
   CLUSTER = 'Cluster',
+  CONTAINER = 'Container',
 }

--- a/src/core/kube/secrets.ts
+++ b/src/core/kube/secrets.ts
@@ -12,7 +12,6 @@ export interface Secrets {
    * @param secretType - the secret type
    * @param data - the secret, any values of a key:value pair must be base64 encoded
    * @param labels - the label to use for future label selector queries
-   * @param recreate - if we should first run delete in the case that there the secret exists from a previous install
    * @returns whether the secret was created successfully
    */
   create(
@@ -21,8 +20,25 @@ export interface Secrets {
     secretType: string,
     data: Record<string, string>,
     labels: Optional<Record<string, string>>,
-    recreate: boolean,
   ): Promise<boolean>; // TODO was createSecret
+
+  createOrReplace(
+    namespace: NamespaceName,
+    name: string,
+    secretType: string,
+    data: Record<string, string>,
+    labels: Optional<Record<string, string>>,
+  ): Promise<boolean>;
+
+  replace(
+    namespace: NamespaceName,
+    name: string,
+    secretType: string,
+    data: Record<string, string>,
+    labels: Optional<Record<string, string>>,
+  ): Promise<boolean>;
+
+  read(namespace: NamespaceName, name: string): Promise<object>; // TODO was getSecret
 
   /**
    * Delete a secret from the namespace
@@ -38,7 +54,20 @@ export interface Secrets {
    * @param labels - list of labels
    * @returns the list of secrets that match the labels
    */
-  listByLabel(namespace: NamespaceName, labels: string[]): Promise<any>; // TODO was getSecretsByLabel(labels: string[]): Promise<any>
+  list(
+    namespace: NamespaceName,
+    labels?: string[],
+  ): Promise<
+    Array<{
+      data: Record<string, string>;
+      name: string;
+      namespace: string;
+      type: string;
+      labels: Record<string, string>;
+    }>
+  >; // TODO was getSecretsByLabel(labels: string[]): Promise<any>
   // TODO consolidate getSecret into listByLabel
   // TODO consolidate listSecretsByNamespace into listByLabel
+
+  exists(namespace: NamespaceName, name: string): Promise<boolean>; // TODO was secretExists
 }

--- a/src/core/network_nodes.ts
+++ b/src/core/network_nodes.ts
@@ -67,7 +67,7 @@ export class NetworkNodes {
       ]);
       await this.k8.execContainer(containerRef, ['bash', '-c', `sudo chmod 0755 ${HEDERA_HAPI_PATH}/${scriptName}`]);
       await this.k8.execContainer(containerRef, `${HEDERA_HAPI_PATH}/${scriptName}`);
-      await this.k8.copyFrom(containerRef, `${HEDERA_HAPI_PATH}/data/${podRef.podName.name}.zip`, targetDir);
+      await this.k8.copyFrom(containerRef, `${HEDERA_HAPI_PATH}/data/${podRef.name}.zip`, targetDir);
     } catch (e: Error | unknown) {
       // not throw error here, so we can continue to finish downloading logs from other pods
       // and also delete namespace in the end
@@ -104,13 +104,13 @@ export class NetworkNodes {
       if (!fs.existsSync(targetDir)) {
         fs.mkdirSync(targetDir, {recursive: true});
       }
-      const zipCommand = `tar -czf ${HEDERA_HAPI_PATH}/${podRef.podName.name}-state.zip -C ${HEDERA_HAPI_PATH}/data/saved .`;
+      const zipCommand = `tar -czf ${HEDERA_HAPI_PATH}/${podRef.name}-state.zip -C ${HEDERA_HAPI_PATH}/data/saved .`;
       const containerRef = ContainerRef.of(podRef, ROOT_CONTAINER);
       await this.k8.execContainer(containerRef, zipCommand);
-      await this.k8.copyFrom(containerRef, `${HEDERA_HAPI_PATH}/${podRef.podName.name}-state.zip`, targetDir);
+      await this.k8.copyFrom(containerRef, `${HEDERA_HAPI_PATH}/${podRef.name}-state.zip`, targetDir);
     } catch (e: Error | unknown) {
-      this.logger.error(`failed to download state from pod ${podRef.podName.name}`, e);
-      this.logger.showUser(`Failed to download state from pod ${podRef.podName.name}` + e);
+      this.logger.error(`failed to download state from pod ${podRef.name}`, e);
+      this.logger.showUser(`Failed to download state from pod ${podRef.name}` + e);
     }
     this.logger.debug(`getNodeState(${pod.metadata.name}): ...end`);
   }

--- a/src/core/platform_installer.ts
+++ b/src/core/platform_installer.ts
@@ -100,7 +100,7 @@ export class PlatformInstaller {
       await this.k8.execContainer(containerRef, [extractScript, tag]);
       return true;
     } catch (e: Error | any) {
-      const message = `failed to extract platform code in this pod '${podRef.podName.name}': ${e.message}`;
+      const message = `failed to extract platform code in this pod '${podRef.name}': ${e.message}`;
       this.logger.error(message, e);
       throw new SoloError(message, e);
     }
@@ -129,7 +129,7 @@ export class PlatformInstaller {
           await this.k8.mkdir(containerRef, destDir);
         }
 
-        this.logger.debug(`Copying file into ${podRef.podName.name}: ${srcPath} -> ${destDir}`);
+        this.logger.debug(`Copying file into ${podRef.name}: ${srcPath} -> ${destDir}`);
         await this.k8.copyTo(containerRef, srcPath, destDir);
 
         const fileName = path.basename(srcPath);
@@ -138,7 +138,7 @@ export class PlatformInstaller {
 
       return copiedFiles;
     } catch (e: Error | any) {
-      throw new SoloError(`failed to copy files to pod '${podRef.podName.name}': ${e.message}`, e);
+      throw new SoloError(`failed to copy files to pod '${podRef.name}': ${e.message}`, e);
     }
   }
 
@@ -266,7 +266,7 @@ export class PlatformInstaller {
 
       return true;
     } catch (e: Error | any) {
-      throw new SoloError(`failed to set permission in '${podRef.podName.name}'`, e);
+      throw new SoloError(`failed to set permission in '${podRef.name}'`, e);
     }
   }
 

--- a/test/e2e/e2e_node_util.ts
+++ b/test/e2e/e2e_node_util.ts
@@ -126,7 +126,7 @@ export function e2eNodeKeyRefreshTest(testName: string, mode: string, releaseTag
           it(`${nodeAlias} should be running`, async () => {
             try {
               // @ts-ignore to access tasks which is a private property
-              expect((await nodeCmd.tasks.checkNetworkNodePod(namespace, nodeAlias)).podName.name).to.equal(
+              expect((await nodeCmd.tasks.checkNetworkNodePod(namespace, nodeAlias)).name.toString()).to.equal(
                 `network-${nodeAlias}-0`,
               );
             } catch (e) {

--- a/test/e2e/integration/core/k8_e2e.test.ts
+++ b/test/e2e/integration/core/k8_e2e.test.ts
@@ -50,8 +50,8 @@ async function createPod(
 ): Promise<void> {
   const v1Pod = new V1Pod();
   const v1Metadata = new V1ObjectMeta();
-  v1Metadata.name = podRef.podName.name;
-  v1Metadata.namespace = podRef.namespaceName.name;
+  v1Metadata.name = podRef.name.toString();
+  v1Metadata.namespace = podRef.namespace.toString();
   v1Metadata.labels = {app: podLabelValue};
   v1Pod.metadata = v1Metadata;
   const v1Container = new V1Container();
@@ -66,7 +66,7 @@ async function createPod(
   const v1Spec = new V1PodSpec();
   v1Spec.containers = [v1Container];
   v1Pod.spec = v1Spec;
-  await k8.kubeClient.createNamespacedPod(podRef.namespaceName.name, v1Pod);
+  await k8.kubeClient.createNamespacedPod(podRef.namespace.toString(), v1Pod);
 }
 
 describe('K8', () => {


### PR DESCRIPTION
## Description

This pull request changes the following:

* Adds `K8ClientSecrets` class which implements the `Secrets` interface
* Refactors and reduces code duplication across `PodName`, `PodRef`, `ContainerRef`, and `ContainerName` classes
* Misc refactors or enhancements

### Related Issues

* Closes #1245
