### PR TITLE
refactor: add ConfigMaps.list()+listForAllNamespaces(), Pods.create(), and rename of k8 client fluent methods to conform to pattern

### DIFF
--- a/src/core/cluster_checks.ts
+++ b/src/core/cluster_checks.ts
@@ -10,6 +10,7 @@ import {type K8} from './kube/k8.js';
 import {type K8Client} from './kube/k8_client.js';
 import {type Pod} from './kube/pod.js';
 import {type IngressClass} from './kube/ingress_class.js';
+import {type V1Pod, type V1ConfigMap} from '@kubernetes/client-node';
 
 /**
  * Class to check if certain components are installed in the cluster.
@@ -47,16 +48,9 @@ export class ClusterChecks {
   public async isMinioInstalled(namespace: NamespaceName): Promise<boolean> {
     try {
       // TODO DETECT THE OPERATOR
-      const pods = await (this.k8 as K8Client).kubeClient.listNamespacedPod(
-        namespace.name,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        'app=minio',
-      );
+      const pods: V1Pod[] = await this.k8.pods().list(namespace, ['app=minio']);
 
-      return pods.body.items.length > 0;
+      return pods.length > 0;
     } catch (e) {
       this.logger.error('Failed to find minio:', e);
 
@@ -86,14 +80,11 @@ export class ClusterChecks {
    */
   public async isRemoteConfigPresentInAnyNamespace() {
     try {
-      const configmaps = await (this.k8 as K8Client).kubeClient.listConfigMapForAllNamespaces(
-        undefined,
-        undefined,
-        undefined,
-        constants.SOLO_REMOTE_CONFIGMAP_LABEL_SELECTOR,
-      );
+      const configmaps: V1ConfigMap[] = await this.k8
+        .configMaps()
+        .listForAllNamespaces([constants.SOLO_REMOTE_CONFIGMAP_LABEL_SELECTOR]);
 
-      return configmaps.body.items.length > 0;
+      return configmaps.length > 0;
     } catch (e) {
       this.logger.error('Failed to find remote config:', e);
 
@@ -108,16 +99,9 @@ export class ClusterChecks {
    */
   public async isPrometheusInstalled(namespace: NamespaceName) {
     try {
-      const pods = await (this.k8 as K8Client).kubeClient.listNamespacedPod(
-        namespace.name,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        'app.kubernetes.io/name=prometheus',
-      );
+      const pods: V1Pod[] = await this.k8.pods().list(namespace, ['app.kubernetes.io/name=prometheus']);
 
-      return pods.body.items.length > 0;
+      return pods.length > 0;
     } catch (e) {
       this.logger.error('Failed to find prometheus:', e);
 
@@ -133,16 +117,11 @@ export class ClusterChecks {
    */
   public async isRemoteConfigPresentInNamespace(namespace: NamespaceName): Promise<boolean> {
     try {
-      const configmaps = await (this.k8 as K8Client).kubeClient.listNamespacedConfigMap(
-        namespace.name,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        constants.SOLO_REMOTE_CONFIGMAP_LABEL_SELECTOR,
-      );
+      const configmaps: V1ConfigMap[] = await this.k8
+        .configMaps()
+        .list(namespace, [constants.SOLO_REMOTE_CONFIGMAP_LABEL_SELECTOR]);
 
-      return configmaps.body.items.length > 0;
+      return configmaps.length > 0;
     } catch (e) {
       this.logger.error('Failed to find remote config:', e);
 

--- a/src/core/cluster_checks.ts
+++ b/src/core/cluster_checks.ts
@@ -7,7 +7,6 @@ import {patchInject} from './container_helper.js';
 import {SoloLogger} from './logging.js';
 import {inject, injectable} from 'tsyringe-neo';
 import {type K8} from './kube/k8.js';
-import {type K8Client} from './kube/k8_client.js';
 import {type Pod} from './kube/pod.js';
 import {type IngressClass} from './kube/ingress_class.js';
 import {type V1Pod, type V1ConfigMap} from '@kubernetes/client-node';

--- a/src/core/kube/config_maps.ts
+++ b/src/core/kube/config_maps.ts
@@ -74,4 +74,21 @@ export interface ConfigMaps {
    * @param name - for the config name
    */
   exists(namespace: NamespaceName, name: string): Promise<boolean>;
+
+  /**
+   * List all config maps in a namespace for the given labels
+   * @param namespace - for the config maps
+   * @param labels - for the config maps
+   * @returns list of config maps
+   * @throws SoloError if the list operation fails
+   */
+  list(namespace: NamespaceName, labels: string[]): Promise<V1ConfigMap[]>;
+
+  /**
+   * List all config maps in all namespaces for the given labels
+   * @param labels - for the config maps
+   * @returns list of config maps
+   * @throws SoloError if the list operation fails
+   */
+  listForAllNamespaces(labels: string[]): Promise<V1ConfigMap[]>;
 }

--- a/src/core/kube/k8_client.ts
+++ b/src/core/kube/k8_client.ts
@@ -174,11 +174,11 @@ export class K8Client extends K8ClientBase implements K8 {
   }
 
   public async getPodByName(podRef: PodRef): Promise<k8s.V1Pod> {
-    return this.pods().readByName(podRef);
+    return this.pods().read(podRef);
   }
 
   public async getPodsByLabel(labels: string[] = []) {
-    return this.pods().readManyByLabel(this.getNamespace(), labels);
+    return this.pods().list(this.getNamespace(), labels);
   }
 
   public async getSecretsByLabel(labels: string[] = [], namespace?: NamespaceName) {

--- a/src/core/kube/k8_client/k8_client_config_maps.ts
+++ b/src/core/kube/k8_client/k8_client_config_maps.ts
@@ -122,9 +122,11 @@ export class K8ClientConfigMaps implements ConfigMaps {
   }
 
   public async list(namespace: NamespaceName, labels: string[]): Promise<V1ConfigMap[]> {
+    const labelsSelector: string = labels.join(',');
+
+    let results: {response: any; body: any};
     try {
-      const labelsSelector = labels.join(',');
-      const results = await this.kubeClient.listNamespacedConfigMap(
+      results = await this.kubeClient.listNamespacedConfigMap(
         namespace.name,
         undefined,
         undefined,
@@ -132,26 +134,25 @@ export class K8ClientConfigMaps implements ConfigMaps {
         undefined,
         labelsSelector,
       );
-      KubeApiResponse.check(results.response, ResourceOperation.LIST, ResourceType.CONFIG_MAP, namespace, '');
-      return results?.body?.items || [];
     } catch (e) {
       throw new SoloError('Failed to list config maps', e);
     }
+
+    KubeApiResponse.check(results.response, ResourceOperation.LIST, ResourceType.CONFIG_MAP, namespace, '');
+    return results?.body?.items || [];
   }
 
   public async listForAllNamespaces(labels: string[]): Promise<V1ConfigMap[]> {
+    const labelsSelector = labels.join(',');
+
+    let results: {response: any; body: any};
     try {
-      const labelsSelector = labels.join(',');
-      const results = await this.kubeClient.listConfigMapForAllNamespaces(
-        undefined,
-        undefined,
-        undefined,
-        labelsSelector,
-      );
-      KubeApiResponse.check(results.response, ResourceOperation.LIST, ResourceType.CONFIG_MAP, undefined, '');
-      return results?.body?.items || [];
+      results = await this.kubeClient.listConfigMapForAllNamespaces(undefined, undefined, undefined, labelsSelector);
     } catch (e) {
       throw new SoloError('Failed to list config maps for all namespaces', e);
     }
+
+    KubeApiResponse.check(results.response, ResourceOperation.LIST, ResourceType.CONFIG_MAP, undefined, '');
+    return results?.body?.items || [];
   }
 }

--- a/src/core/kube/k8_client/k8_client_config_maps.ts
+++ b/src/core/kube/k8_client/k8_client_config_maps.ts
@@ -132,7 +132,7 @@ export class K8ClientConfigMaps implements ConfigMaps {
         undefined,
         labelsSelector,
       );
-      // TODO - use KubeApiResponse
+      KubeApiResponse.check(results.response, ResourceOperation.LIST, ResourceType.CONFIG_MAP, namespace, '');
       return results?.body?.items || [];
     } catch (e) {
       throw new SoloError('Failed to list config maps', e);
@@ -148,7 +148,7 @@ export class K8ClientConfigMaps implements ConfigMaps {
         undefined,
         labelsSelector,
       );
-      // TODO - use KubeApiResponse
+      KubeApiResponse.check(results.response, ResourceOperation.LIST, ResourceType.CONFIG_MAP, undefined, '');
       return results?.body?.items || [];
     } catch (e) {
       throw new SoloError('Failed to list config maps for all namespaces', e);

--- a/src/core/kube/k8_client/k8_client_pod.ts
+++ b/src/core/kube/k8_client/k8_client_pod.ts
@@ -45,7 +45,7 @@ export class K8ClientPod implements Pod {
 
       let podExists = true;
       while (podExists) {
-        const pod = await this.pods.readByName(this.podRef);
+        const pod = await this.pods.read(this.podRef);
 
         if (!pod?.metadata?.deletionTimestamp) {
           podExists = false;

--- a/src/core/kube/k8_client/k8_client_pods.ts
+++ b/src/core/kube/k8_client/k8_client_pods.ts
@@ -247,8 +247,8 @@ export class K8ClientPods extends K8ClientBase implements Pods {
     startupProbeCommand: string[],
   ): Promise<Pod> {
     const v1Metadata = new V1ObjectMeta();
-    v1Metadata.name = podRef.podName.name;
-    v1Metadata.namespace = podRef.namespaceName.name;
+    v1Metadata.name = podRef.name.toString();
+    v1Metadata.namespace = podRef.namespace.toString();
     v1Metadata.labels = labels;
 
     const v1ExecAction = new V1ExecAction();
@@ -271,7 +271,7 @@ export class K8ClientPods extends K8ClientBase implements Pods {
     v1Pod.spec = v1Spec;
 
     try {
-      const result = await this.kubeClient.createNamespacedPod(podRef.namespaceName.name, v1Pod);
+      const result = await this.kubeClient.createNamespacedPod(podRef.namespace.toString(), v1Pod);
 
       // TODO - use KubeApiResponse
       if (result?.body) {

--- a/src/core/kube/pods.ts
+++ b/src/core/kube/pods.ts
@@ -5,6 +5,7 @@ import {type V1Pod} from '@kubernetes/client-node';
 import {type NamespaceName} from './namespace_name.js';
 import {type PodRef} from './pod_ref.js';
 import {type Pod} from './pod.js';
+import {type ContainerName} from './container_name.js';
 
 export interface Pods {
   /**
@@ -19,7 +20,7 @@ export interface Pods {
    * @returns V1Pod - pod object
    * @param podRef - the reference to the pod
    */
-  readByName(podRef: PodRef): Promise<V1Pod>; // TODO was getPodByName
+  read(podRef: PodRef): Promise<V1Pod>; // TODO was getPodByName
 
   /**
    * Get pods by labels
@@ -27,7 +28,7 @@ export interface Pods {
    * @param labels - list of labels
    * @returns V1Pod[] - list of pod objects
    */
-  readManyByLabel(namespace: NamespaceName, labels: string[]): Promise<V1Pod[]>; // TODO was getPodsByLabel
+  list(namespace: NamespaceName, labels: string[]): Promise<V1Pod[]>; // TODO was getPodsByLabel
 
   /**
    * Check if pod's ready status is true
@@ -42,7 +43,6 @@ export interface Pods {
    * Check if pod's phase is running
    * @param namespace - namespace
    * @param labels - pod labels
-   * @param podCount - number of pod expected
    * @param maxAttempts - maximum attempts to check
    * @param delay - delay between checks in milliseconds
    * @param [podItemPredicate] - pod item predicate
@@ -61,4 +61,23 @@ export interface Pods {
    * @returns list of pods
    */
   listForAllNamespaces(labels: string[]): Promise<Pod[]>;
+
+  /**
+   * Create a pod
+   * @param podRef - the reference to the pod
+   * @param labels - list of label records where the key is the label name and the value is the label value
+   * @param containerName - the name of the container
+   * @param containerImage - the image of the container
+   * @param containerCommand - the command to run in the container
+   * @param startupProbeCommand - the command to run in the startup probe
+   * @returns the pod that was created
+   */
+  create(
+    podRef: PodRef,
+    labels: Record<string, string>,
+    containerName: ContainerName,
+    containerImage: string,
+    containerCommand: string[],
+    startupProbeCommand: string[],
+  ): Promise<Pod>;
 }

--- a/test/e2e/integration/core/k8_e2e.test.ts
+++ b/test/e2e/integration/core/k8_e2e.test.ts
@@ -17,14 +17,9 @@ import {ConfigManager} from '../../../../src/core/config_manager.js';
 import * as logging from '../../../../src/core/logging.js';
 import {Flags as flags} from '../../../../src/commands/flags.js';
 import {
-  V1Container,
-  V1ExecAction,
   V1ObjectMeta,
   V1PersistentVolumeClaim,
   V1PersistentVolumeClaimSpec,
-  V1Pod,
-  V1PodSpec,
-  V1Probe,
   V1Service,
   V1ServicePort,
   V1ServiceSpec,
@@ -48,25 +43,16 @@ async function createPod(
   podLabelValue: string,
   k8: K8Client,
 ): Promise<void> {
-  const v1Pod = new V1Pod();
-  const v1Metadata = new V1ObjectMeta();
-  v1Metadata.name = podRef.name.toString();
-  v1Metadata.namespace = podRef.namespace.toString();
-  v1Metadata.labels = {app: podLabelValue};
-  v1Pod.metadata = v1Metadata;
-  const v1Container = new V1Container();
-  v1Container.name = containerName.name;
-  v1Container.image = 'alpine:latest';
-  v1Container.command = ['/bin/sh', '-c', 'apk update && apk upgrade && apk add --update bash && sleep 7200'];
-  const v1Probe = new V1Probe();
-  const v1ExecAction = new V1ExecAction();
-  v1ExecAction.command = ['bash', '-c', 'exit 0'];
-  v1Probe.exec = v1ExecAction;
-  v1Container.startupProbe = v1Probe;
-  const v1Spec = new V1PodSpec();
-  v1Spec.containers = [v1Container];
-  v1Pod.spec = v1Spec;
-  await k8.kubeClient.createNamespacedPod(podRef.namespace.toString(), v1Pod);
+  await k8
+    .pods()
+    .create(
+      podRef,
+      {app: podLabelValue},
+      containerName,
+      'alpine:latest',
+      ['/bin/sh', '-c', 'apk update && apk upgrade && apk add --update bash && sleep 7200'],
+      ['bash', '-c', 'exit 0'],
+    );
 }
 
 describe('K8', () => {


### PR DESCRIPTION
## Description

This pull request changes the following:

* add ConfigMaps.list()+listForAllNamespaces()
* rename of k8 client fluent methods to conform to pattern
* add Pods.create()

### Related Issues

* Closes #1259
* Closes #1264
* Closes #1311 
