### PR TITLE
refactor: remove legacy k8 services methods

### DIFF
--- a/src/core/account_manager.ts
+++ b/src/core/account_manager.ts
@@ -418,7 +418,7 @@ export class AccountManager {
     const serviceBuilderMap = new Map<NodeAlias, NetworkNodeServicesBuilder>();
 
     try {
-      const serviceList = await this.k8.listSvcs(namespace, [labelSelector]);
+      const serviceList = await this.k8.services().list(namespace, [labelSelector]);
 
       let nodeId = '0';
       // retrieve the list of services and build custom objects for the attributes we need

--- a/src/core/kube/k8.ts
+++ b/src/core/kube/k8.ts
@@ -130,14 +130,6 @@ export interface K8 {
   getSecretsByLabel(labels: string[], namespace?: NamespaceName): Promise<any>;
 
   /**
-   * Get a svc by name
-   * @param name - svc name
-   */
-  getSvcByName(name: string): Promise<Service>;
-
-  listSvcs(namespace: NamespaceName, labels: string[]): Promise<Service[]>;
-
-  /**
    * List files and directories in a container
    *
    * It runs ls -la on the specified path and returns a list of object containing the entries.

--- a/src/core/kube/k8_client.ts
+++ b/src/core/kube/k8_client.ts
@@ -185,10 +185,6 @@ export class K8Client extends K8ClientBase implements K8 {
     return this.secrets().list(namespace || this.getNamespace(), labels);
   }
 
-  public async getSvcByName(name: string): Promise<Service> {
-    return this.services().read(this.getNamespace(), name);
-  }
-
   public async listDir(containerRef: ContainerRef, destPath: string) {
     return this.containers().readByRef(containerRef).listDir(destPath);
   }
@@ -348,10 +344,6 @@ export class K8Client extends K8ClientBase implements K8 {
 
   public async killPod(podRef: PodRef) {
     return this.pods().readByRef(podRef).killPod();
-  }
-
-  public async listSvcs(namespace: NamespaceName, labels: string[]): Promise<Service[]> {
-    return this.services().list(namespace, labels);
   }
 
   public async patchIngress(namespace: NamespaceName, ingressName: string, patch: object) {


### PR DESCRIPTION
## Description

This pull request changes the following:

* Removes the legacy `*Svcs*` methods and replaces their usages with the new fluent `services()` methods.

### Related Issues

* Closes #1270 
