### PR TITLE
refactor: remove legacy k8 secret methods

### DIFF
--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -3,13 +3,13 @@
  */
 import chalk from 'chalk';
 import {BaseCommand} from './base.js';
-import {SoloError, IllegalArgumentError} from '../core/errors.js';
+import {IllegalArgumentError, SoloError} from '../core/errors.js';
 import {Flags as flags} from './flags.js';
 import {Listr} from 'listr2';
 import * as constants from '../core/constants.js';
+import {FREEZE_ADMIN_ACCOUNT} from '../core/constants.js';
 import {type AccountManager} from '../core/account_manager.js';
 import {type AccountId, AccountInfo, HbarUnit, PrivateKey} from '@hashgraph/sdk';
-import {FREEZE_ADMIN_ACCOUNT} from '../core/constants.js';
 import {type Opts} from '../types/command_types.js';
 import {ListrLease} from '../core/lease/listr_lease.js';
 import {type CommandBuilder} from '../types/aliases.js';
@@ -190,7 +190,8 @@ export class AccountCommand extends BaseCommand {
                 {
                   title: 'Prepare for account key updates',
                   task: async ctx => {
-                    const secrets = await self.k8.getSecretsByLabel(['solo.hedera.com/account-id']);
+                    const namespace = await resolveNamespaceFromDeployment(this.localConfig, this.configManager, task);
+                    const secrets = await self.k8.secrets().list(namespace, ['solo.hedera.com/account-id']);
                     ctx.updateSecrets = secrets.length > 0;
 
                     ctx.accountsBatchedSet = self.accountManager.batchAccounts(this.systemAccounts);

--- a/src/core/certificate_manager.ts
+++ b/src/core/certificate_manager.ts
@@ -15,6 +15,7 @@ import {type NodeAlias} from '../types/aliases.js';
 import {inject, injectable} from 'tsyringe-neo';
 import {patchInject} from './container_helper.js';
 import {type NamespaceName} from './kube/namespace_name.js';
+import {SecretType} from './kube/secret_type.js';
 
 /**
  * Used to handle interactions with certificates data and inject it into the K8s cluster secrets
@@ -78,7 +79,7 @@ export class CertificateManager {
       const namespace = this.getNamespace();
       const labels = Templates.renderGrpcTlsCertificatesSecretLabelObject(nodeAlias, type);
 
-      const isSecretCreated = await this.k8.createSecret(name, namespace, 'Opaque', data, labels, true);
+      const isSecretCreated = await this.k8.secrets().createOrReplace(namespace, name, SecretType.OPAQUE, data, labels);
       if (!isSecretCreated) {
         throw new SoloError(`failed to create secret for TLS certificates for node '${nodeAlias}'`);
       }

--- a/src/core/kube/k8.ts
+++ b/src/core/kube/k8.ts
@@ -2,11 +2,11 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import type * as k8s from '@kubernetes/client-node';
+import {type V1Lease} from '@kubernetes/client-node';
 import {type TarCreateFilter} from '../../types/aliases.js';
 import {type PodRef} from './pod_ref.js';
-import {type ExtendedNetServer, type Optional} from '../../types/index.js';
+import {type ExtendedNetServer} from '../../types/index.js';
 import {type TDirectoryData} from './t_directory_data.js';
-import {type V1Lease} from '@kubernetes/client-node';
 import {type Namespaces} from './namespaces.js';
 import {type NamespaceName} from './namespace_name.js';
 import {type Containers} from './containers.js';
@@ -16,7 +16,6 @@ import {type ContainerRef} from './container_ref.js';
 import {type Contexts} from './contexts.js';
 import {type Pvcs} from './pvcs.js';
 import {type Services} from './services.js';
-import {type Service} from './service.js';
 import {type Pods} from './pods.js';
 import {type Leases} from './leases.js';
 import {type IngressClasses} from './ingress_classes.js';
@@ -121,13 +120,6 @@ export interface K8 {
    * @param labels - list of labels
    */
   getPodsByLabel(labels: string[]): Promise<any>;
-
-  /**
-   * Get secrets by labels
-   * @param labels - list of labels
-   * @param namespace - the namespace of the secrets to return
-   */
-  getSecretsByLabel(labels: string[], namespace?: NamespaceName): Promise<any>;
 
   /**
    * List files and directories in a container
@@ -252,65 +244,12 @@ export interface K8 {
   listPvcsByNamespace(namespace: NamespaceName, labels?: string[]): Promise<string[]>;
 
   /**
-   * Get a list of secrets for the given namespace
-   * @param namespace - the namespace of the secrets to return
-   * @param [labels] - labels
-   * @returns list of secret names
-   */
-  listSecretsByNamespace(namespace: NamespaceName, labels?: string[]): Promise<string[]>;
-
-  /**
    * Delete a persistent volume claim
    * @param name - the name of the persistent volume claim to delete
    * @param namespace - the namespace of the persistent volume claim to delete
    * @returns true if the persistent volume claim was deleted
    */
   deletePvc(name: string, namespace: NamespaceName): Promise<boolean>;
-
-  /**
-   * retrieve the secret of the given namespace and label selector, if there is more than one, it returns the first
-   * @param namespace - the namespace of the secret to search for
-   * @param labelSelector - the label selector used to fetch the Kubernetes secret
-   * @returns a custom secret object with the relevant attributes, the values of the data key:value pair
-   *   objects must be base64 decoded
-   */
-  getSecret(
-    namespace: NamespaceName,
-    labelSelector: string,
-  ): Promise<{
-    data: Record<string, string>;
-    name: string;
-    namespace: string;
-    type: string;
-    labels: Record<string, string>;
-  }>;
-
-  /**
-   * creates a new Kubernetes secret with the provided attributes
-   * @param name - the name of the new secret
-   * @param namespace - the namespace to store the secret
-   * @param secretType - the secret type
-   * @param data - the secret, any values of a key:value pair must be base64 encoded
-   * @param labels - the label to use for future label selector queries
-   * @param recreate - if we should first run delete in the case that there the secret exists from a previous install
-   * @returns whether the secret was created successfully
-   */
-  createSecret(
-    name: string,
-    namespace: NamespaceName,
-    secretType: string,
-    data: Record<string, string>,
-    labels: Optional<Record<string, string>>,
-    recreate: boolean,
-  ): Promise<boolean>;
-
-  /**
-   * Delete a secret from the namespace
-   * @param name - the name of the existing secret
-   * @param namespace - the namespace to store the secret
-   * @returns whether the secret was deleted successfully
-   */
-  deleteSecret(name: string, namespace: NamespaceName): Promise<boolean>;
 
   createNamespacedLease(
     namespace: NamespaceName,

--- a/src/core/kube/secret_type.ts
+++ b/src/core/kube/secret_type.ts
@@ -1,0 +1,12 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+export enum SecretType {
+  OPAQUE = 'Opaque',
+  DOCKER_CONFIG_JSON = 'kubernetes.io/dockerconfigjson',
+  DOCKER_CONFIG = 'kubernetes.io/dockerconfig',
+  BASIC_AUTH = 'kubernetes.io/basic-auth',
+  SSH_AUTH = 'kubernetes.io/ssh-auth',
+  TLS = 'kubernetes.io/tls',
+  BOOTSTRAP = 'bootstrap.kubernetes.io/token',
+}

--- a/src/core/kube/secrets.ts
+++ b/src/core/kube/secrets.ts
@@ -3,6 +3,7 @@
  */
 import {type Optional} from '../../types/index.js';
 import {type NamespaceName} from './namespace_name.js';
+import {type SecretType} from './secret_type.js';
 
 export interface Secrets {
   /**
@@ -17,7 +18,7 @@ export interface Secrets {
   create(
     namespace: NamespaceName,
     name: string,
-    secretType: string,
+    secretType: SecretType,
     data: Record<string, string>,
     labels: Optional<Record<string, string>>,
   ): Promise<boolean>; // TODO was createSecret
@@ -25,7 +26,7 @@ export interface Secrets {
   createOrReplace(
     namespace: NamespaceName,
     name: string,
-    secretType: string,
+    secretType: SecretType,
     data: Record<string, string>,
     labels: Optional<Record<string, string>>,
   ): Promise<boolean>;
@@ -33,12 +34,21 @@ export interface Secrets {
   replace(
     namespace: NamespaceName,
     name: string,
-    secretType: string,
+    secretType: SecretType,
     data: Record<string, string>,
     labels: Optional<Record<string, string>>,
   ): Promise<boolean>;
 
-  read(namespace: NamespaceName, name: string): Promise<object>; // TODO was getSecret
+  read(
+    namespace: NamespaceName,
+    name: string,
+  ): Promise<{
+    data: Record<string, string>;
+    name: string;
+    namespace: string;
+    type: string;
+    labels: Record<string, string>;
+  }>; // TODO was getSecret
 
   /**
    * Delete a secret from the namespace

--- a/test/e2e/commands/network.test.ts
+++ b/test/e2e/commands/network.test.ts
@@ -145,7 +145,7 @@ describe('NetworkCommand', () => {
       await expect(k8.listPvcsByNamespace(namespace)).eventually.to.have.lengthOf(0);
 
       // check if secrets are deleted
-      await expect(k8.listSecretsByNamespace(namespace)).eventually.to.have.lengthOf(0);
+      await expect(k8.secrets().list(namespace)).eventually.to.have.lengthOf(0);
     } catch (e) {
       networkCmd.logger.showUserError(e);
       expect.fail();

--- a/test/unit/core/certificate_manager.test.ts
+++ b/test/unit/core/certificate_manager.test.ts
@@ -12,12 +12,13 @@ import {Flags as flags} from '../../../src/commands/flags.js';
 import {SoloError} from '../../../src/core/errors.js';
 import {container} from 'tsyringe-neo';
 import {resetForTest} from '../../test_container.js';
+import {K8ClientSecrets} from '../../../src/core/kube/k8_client/k8_client_secrets.js';
 
 describe('Certificate Manager', () => {
   const argv = {};
   // @ts-ignore
   const k8InitSpy = jest.spyOn(K8Client.prototype, 'init').mockImplementation(() => {});
-  const k8CreateSecret = jest.spyOn(K8Client.prototype, 'createSecret').mockResolvedValue(true);
+  const k8CreateSecretSpy = jest.spyOn(K8ClientSecrets.prototype, 'create').mockResolvedValue(true);
   let certificateManager: CertificateManager;
 
   before(() => {
@@ -30,7 +31,7 @@ describe('Certificate Manager', () => {
 
   after(() => {
     k8InitSpy.mockRestore();
-    k8CreateSecret.mockRestore();
+    k8CreateSecretSpy.mockRestore();
   });
 
   it('should throw if and error if nodeAlias is not provided', async () => {


### PR DESCRIPTION
## Description

This pull request changes the following:

* Replaces all legacy `*Secret*` method usages with the new fluent interface via the `secrets()` API

### Related Issues

* Closes #1271
