### PR TITLE
fix: update RemoteConfig to handle multi-cluster networking

### DIFF
--- a/src/commands/deployment.ts
+++ b/src/commands/deployment.ts
@@ -9,7 +9,7 @@ import * as constants from '../core/constants.js';
 import chalk from 'chalk';
 import {ListrRemoteConfig} from '../core/config/remote/listr_config_tasks.js';
 import {ClusterCommandTasks} from './cluster/tasks.js';
-import {type DeploymentName, type NamespaceNameAsString, type Cluster} from '../core/config/remote/types.js';
+import {type DeploymentName, type NamespaceNameAsString, type ClusterRef} from '../core/config/remote/types.js';
 import {type CommandFlag} from '../types/flag_types.js';
 import {type CommandBuilder} from '../types/aliases.js';
 import {type SoloListrTask} from '../types/index.js';
@@ -168,7 +168,7 @@ export class DeploymentCommand extends BaseCommand {
     const self = this;
 
     interface Config {
-      clusterName: Cluster;
+      clusterName: ClusterRef;
     }
 
     interface Context {
@@ -186,7 +186,7 @@ export class DeploymentCommand extends BaseCommand {
             await self.configManager.executePrompt(task, [flags.clusterName]);
 
             ctx.config = {
-              clusterName: self.configManager.getFlag<Cluster>(flags.clusterName),
+              clusterName: self.configManager.getFlag<ClusterRef>(flags.clusterName),
             } as Config;
 
             self.logger.debug('Prepared config', {config: ctx.config, cachedConfig: self.configManager.config});

--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -964,7 +964,13 @@ export class NetworkCommand extends BaseCommand {
           for (const nodeAlias of nodeAliases) {
             remoteConfig.components.add(
               nodeAlias,
-              new ConsensusNodeComponent(nodeAlias, cluster, namespace.name, ConsensusNodeStates.INITIALIZED),
+              new ConsensusNodeComponent(
+                nodeAlias,
+                cluster,
+                namespace.name,
+                ConsensusNodeStates.INITIALIZED,
+                Templates.nodeIdFromNodeAlias(nodeAlias),
+              ),
             );
 
             remoteConfig.components.add(

--- a/src/commands/node/handlers.ts
+++ b/src/commands/node/handlers.ts
@@ -40,8 +40,8 @@ import {type Listr, type ListrTask} from 'listr2';
 import chalk from 'chalk';
 import {type ComponentsDataWrapper} from '../../core/config/remote/components_data_wrapper.js';
 import {type Optional} from '../../types/index.js';
-import {type NamespaceNameAsString} from '../../core/config/remote/types.js';
 import {type NamespaceName} from '../../core/kube/resources/namespace/namespace_name.js';
+import {Templates} from '../../core/templates.js';
 
 export class NodeCommandHandlers implements CommandHandlers {
   private readonly accountManager: AccountManager;
@@ -879,7 +879,13 @@ export class NodeCommandHandlers implements CommandHandlers {
           for (const nodeAlias of nodeAliases) {
             remoteConfig.components.edit(
               nodeAlias,
-              new ConsensusNodeComponent(nodeAlias, cluster, namespace.name, state),
+              new ConsensusNodeComponent(
+                nodeAlias,
+                cluster,
+                namespace.name,
+                state,
+                Templates.nodeIdFromNodeAlias(nodeAlias),
+              ),
             );
           }
         });

--- a/src/core/config/local_config_data.ts
+++ b/src/core/config/local_config_data.ts
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import {
-  type Cluster,
+  type ClusterRef,
   type Context,
   type EmailAddress,
   type NamespaceNameAsString,
@@ -11,11 +11,11 @@ import {
 
 export interface DeploymentStructure {
   // A list of clusters on which the deployment is deployed
-  clusters: Cluster[];
+  clusters: ClusterRef[];
   namespace: NamespaceNameAsString;
 }
 
-export type ClusterContextMapping = Record<Cluster, Context>;
+export type ClusterContextMapping = Record<ClusterRef, Context>;
 
 export type Deployments = Record<DeploymentName, DeploymentStructure>;
 

--- a/src/core/config/remote/cluster.ts
+++ b/src/core/config/remote/cluster.ts
@@ -1,0 +1,91 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {type ToObject} from '../../../types/index.js';
+import {type ClusterRef, type ICluster, type NamespaceNameAsString} from './types.js';
+import {SoloError} from '../../errors.js';
+
+export class Cluster implements ICluster, ToObject<ICluster> {
+  private readonly _name: string;
+  private readonly _namespace: string;
+  private readonly _dnsBaseDomain: string = 'cluster.local'; // example: 'us-west-2.gcp.charlie.sphere'`
+  private readonly _dnsConsensusNodePattern: string = 'network-${nodeAlias}-svc.${namespace}.svc'; // example: '${nodeId}.consensus.prod'`
+
+  public constructor(
+    name: string,
+    namespace: NamespaceNameAsString,
+    dnsBaseDomain?: string,
+    dnsConsensusNodePattern?: string,
+  ) {
+    if (!name) {
+      throw new SoloError('name is required');
+    }
+
+    if (typeof name !== 'string') {
+      throw new SoloError(`Invalid type for name: ${typeof name}`);
+    }
+
+    if (!namespace) {
+      throw new SoloError('namespace is required');
+    }
+
+    if (typeof namespace !== 'string') {
+      throw new SoloError(`Invalid type for namespace: ${typeof namespace}`);
+    }
+
+    this._name = name;
+    this._namespace = namespace;
+
+    if (dnsBaseDomain) {
+      this._dnsBaseDomain = dnsBaseDomain;
+    }
+
+    if (dnsConsensusNodePattern) {
+      this._dnsConsensusNodePattern = dnsConsensusNodePattern;
+    }
+  }
+
+  public get name(): string {
+    return this._name;
+  }
+
+  public get namespace(): string {
+    return this._namespace;
+  }
+
+  public get dnsBaseDomain(): string {
+    return this._dnsBaseDomain;
+  }
+
+  public get dnsConsensusNodePattern(): string {
+    return this._dnsConsensusNodePattern;
+  }
+
+  public toObject(): ICluster {
+    return {
+      name: this.name,
+      namespace: this.namespace,
+      dnsBaseDomain: this.dnsBaseDomain,
+      dnsConsensusNodePattern: this.dnsConsensusNodePattern,
+    };
+  }
+
+  public static fromObject(cluster: ICluster) {
+    return new Cluster(cluster.name, cluster.namespace, cluster.dnsBaseDomain, cluster.dnsConsensusNodePattern);
+  }
+
+  public static toClustersMapObject(clustersMap: Record<ClusterRef, Cluster>) {
+    const entries = Object.entries(clustersMap).map(([ref, cluster]) => [ref, cluster.toObject()]);
+    return Object.fromEntries(entries);
+  }
+
+  public static fromClustersMapObject(obj: any): Record<ClusterRef, Cluster> {
+    const clusters: Record<ClusterRef, Cluster> = {};
+
+    for (const [ref, cluster] of Object.entries(obj)) {
+      clusters[ref] = Cluster.fromObject(cluster as ICluster);
+    }
+
+    return clusters;
+  }
+}

--- a/src/core/config/remote/components/base_component.ts
+++ b/src/core/config/remote/components/base_component.ts
@@ -3,7 +3,7 @@
  */
 import {ComponentType} from '../enumerations.js';
 import {SoloError} from '../../../errors.js';
-import {type Cluster, type Component, type ComponentName, type NamespaceNameAsString} from '../types.js';
+import {type ClusterRef, type Component, type ComponentName, type NamespaceNameAsString} from '../types.js';
 import {type ToObject, type Validate} from '../../../../types/index.js';
 
 /**
@@ -20,7 +20,7 @@ export abstract class BaseComponent implements Component, Validate, ToObject<Com
   protected constructor(
     public readonly type: ComponentType,
     public readonly name: ComponentName,
-    public readonly cluster: Cluster,
+    public readonly cluster: ClusterRef,
     public readonly namespace: NamespaceNameAsString,
   ) {}
 

--- a/src/core/config/remote/components/consensus_node_component.ts
+++ b/src/core/config/remote/components/consensus_node_component.ts
@@ -4,7 +4,12 @@
 import {ComponentType, ConsensusNodeStates} from '../enumerations.js';
 import {BaseComponent} from './base_component.js';
 import {SoloError} from '../../../errors.js';
-import {type Cluster, type IConsensusNodeComponent, type ComponentName, type NamespaceNameAsString} from '../types.js';
+import {
+  type ClusterRef,
+  type ComponentName,
+  type IConsensusNodeComponent,
+  type NamespaceNameAsString,
+} from '../types.js';
 import {type ToObject} from '../../../../types/index.js';
 
 /**
@@ -19,15 +24,17 @@ export class ConsensusNodeComponent
 {
   /**
    * @param name - the name to distinguish components.
+   * @param nodeId - node id of the consensus node
    * @param cluster - associated to component
    * @param namespace - associated to component
    * @param state - of the consensus node
    */
   public constructor(
     name: ComponentName,
-    cluster: Cluster,
+    cluster: ClusterRef,
     namespace: NamespaceNameAsString,
     public readonly state: ConsensusNodeStates,
+    public readonly nodeId: number,
   ) {
     super(ComponentType.ConsensusNode, name, cluster, namespace);
 
@@ -38,8 +45,8 @@ export class ConsensusNodeComponent
 
   /** Handles creating instance of the class from plain object. */
   public static fromObject(component: IConsensusNodeComponent): ConsensusNodeComponent {
-    const {name, cluster, namespace, state} = component;
-    return new ConsensusNodeComponent(name, cluster, namespace, state);
+    const {name, cluster, namespace, state, nodeId} = component;
+    return new ConsensusNodeComponent(name, cluster, namespace, state, nodeId);
   }
 
   public validate(): void {
@@ -48,12 +55,21 @@ export class ConsensusNodeComponent
     if (!Object.values(ConsensusNodeStates).includes(this.state)) {
       throw new SoloError(`Invalid consensus node state: ${this.state}`);
     }
+
+    if (typeof this.nodeId !== 'number') {
+      throw new SoloError(`Invalid node id. It must be a number: ${this.nodeId}`);
+    }
+
+    if (this.nodeId < 0) {
+      throw new SoloError(`Invalid node id. It cannot be negative: ${this.nodeId}`);
+    }
   }
 
   public toObject(): IConsensusNodeComponent {
     return {
       ...super.toObject(),
       state: this.state,
+      nodeId: this.nodeId,
     };
   }
 }

--- a/src/core/config/remote/enumerations.ts
+++ b/src/core/config/remote/enumerations.ts
@@ -12,7 +12,7 @@ export enum ComponentType {
   EnvoyProxy = 'envoyProxies',
   MirrorNode = 'mirrorNodes',
   MirrorNodeExplorer = 'mirrorNodeExplorers',
-  Relay = 'replays',
+  Relay = 'relays',
 }
 
 /**

--- a/src/core/config/remote/listr_config_tasks.ts
+++ b/src/core/config/remote/listr_config_tasks.ts
@@ -3,7 +3,7 @@
  */
 import chalk from 'chalk';
 import {type BaseCommand} from '../../../commands/base.js';
-import {type Cluster, type Context} from './types.js';
+import {type ClusterRef, type Context} from './types.js';
 import {type SoloListrTask} from '../../../types/index.js';
 import {type AnyObject} from '../../../types/aliases.js';
 import {type NamespaceName} from '../../kube/resources/namespace/namespace_name.js';
@@ -41,15 +41,15 @@ export class ListrRemoteConfig {
    */
   public static createRemoteConfig(
     command: BaseCommand,
-    cluster: Cluster,
+    clusterRef: ClusterRef,
     context: Context,
     namespace: NamespaceName,
     argv: AnyObject,
   ): SoloListrTask<any> {
     return {
-      title: `Create remote config in cluster: ${chalk.cyan(cluster)}`,
+      title: `Create remote config in cluster: ${chalk.cyan(clusterRef)}`,
       task: async (): Promise<void> => {
-        await command.getRemoteConfigManager().createAndValidate(cluster, context, namespace.name, argv);
+        await command.getRemoteConfigManager().createAndValidate(clusterRef, context, namespace.name, argv);
       },
     };
   }
@@ -66,11 +66,11 @@ export class ListrRemoteConfig {
       task: async (ctx, task) => {
         const subTasks: SoloListrTask<Context>[] = [];
 
-        for (const cluster of command.localConfig.deployments[ctx.config.deployment].clusters) {
-          const context = command.localConfig.clusterContextMapping?.[cluster];
+        for (const clusterRef of command.localConfig.deployments[ctx.config.deployment].clusters) {
+          const context = command.localConfig.clusterContextMapping?.[clusterRef];
           if (!context) continue;
 
-          subTasks.push(ListrRemoteConfig.createRemoteConfig(command, cluster, context, ctx.config.namespace, argv));
+          subTasks.push(ListrRemoteConfig.createRemoteConfig(command, clusterRef, context, ctx.config.namespace, argv));
         }
 
         return task.newListr(subTasks, {

--- a/src/core/config/remote/remote_config_data.ts
+++ b/src/core/config/remote/remote_config_data.ts
@@ -4,11 +4,12 @@
 import {type RemoteConfigMetadata} from './metadata.js';
 import {type ComponentsDataWrapper} from './components_data_wrapper.js';
 import {type CommonFlagsDataWrapper} from './common_flags_data_wrapper.js';
-import {type Cluster, type NamespaceNameAsString} from './types.js';
+import {type ClusterRef} from './types.js';
+import {type Cluster} from './cluster.js';
 
 export interface RemoteConfigData {
   metadata: RemoteConfigMetadata;
-  clusters: Record<Cluster, NamespaceNameAsString>;
+  clusters: Record<ClusterRef, Cluster>;
   components: ComponentsDataWrapper;
   lastExecutedCommand: string;
   commandHistory: string[];

--- a/src/core/config/remote/types.ts
+++ b/src/core/config/remote/types.ts
@@ -9,7 +9,7 @@ export type Version = string;
 /// TODO - see if we can use NamespaceName and use some annotations and overrides to covert to strings
 export type NamespaceNameAsString = string;
 export type DeploymentName = string;
-export type Cluster = string;
+export type ClusterRef = string;
 export type Context = string;
 export type ComponentName = string;
 
@@ -21,7 +21,7 @@ export interface IMigration {
 
 export interface Component {
   name: ComponentName;
-  cluster: Cluster;
+  cluster: ClusterRef;
   namespace: NamespaceNameAsString;
 }
 
@@ -30,7 +30,15 @@ export interface IRelayComponent extends Component {
 }
 
 export interface IConsensusNodeComponent extends Component {
+  nodeId: number;
   state: ConsensusNodeStates;
+}
+
+export interface ICluster {
+  name: string;
+  namespace: string;
+  dnsBaseDomain: string;
+  dnsConsensusNodePattern: string;
 }
 
 export type ComponentsDataStructure = Record<ComponentType, Record<ComponentName, Component>>;
@@ -48,7 +56,7 @@ export type RemoteConfigCommonFlagsStruct = {
 export interface RemoteConfigDataStructure {
   metadata: RemoteConfigMetadataStructure;
   version: Version;
-  clusters: Record<Cluster, NamespaceNameAsString>;
+  clusters: Record<ClusterRef, ICluster>;
   components: ComponentsDataStructure;
   commandHistory: string[];
   lastExecutedCommand: string;

--- a/test/e2e/integration/core/remote_config_validator.test.ts
+++ b/test/e2e/integration/core/remote_config_validator.test.ts
@@ -63,7 +63,15 @@ describe('RemoteConfigValidator', () => {
     {[haProxyName]: new HaProxyComponent(haProxyName, cluster, namespace.name)},
     {[mirrorNodeName]: new MirrorNodeComponent(mirrorNodeName, cluster, namespace.name)},
     {[envoyProxyName]: new EnvoyProxyComponent(envoyProxyName, cluster, namespace.name)},
-    {[nodeAlias]: new ConsensusNodeComponent(nodeAlias, cluster, namespace.name, state)},
+    {
+      [nodeAlias]: new ConsensusNodeComponent(
+        nodeAlias,
+        cluster,
+        namespace.name,
+        state,
+        Templates.nodeIdFromNodeAlias(nodeAlias),
+      ),
+    },
     {[mirrorNodeExplorerName]: new MirrorNodeExplorerComponent(mirrorNodeExplorerName, cluster, namespace.name)},
   );
 

--- a/test/unit/core/config/remote/cluster.test.ts
+++ b/test/unit/core/config/remote/cluster.test.ts
@@ -1,0 +1,66 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {it} from 'mocha';
+import {expect} from 'chai';
+import {SoloError} from '../../../../../src/core/errors.js';
+import {Cluster} from '../../../../../src/core/config/remote/cluster.js';
+import {type ClusterRef} from '../../../../../src/core/config/remote/types.js';
+
+describe('Cluster', () => {
+  it('should fail if name is not provided', () => {
+    expect(() => new Cluster(null, 'valid')).to.throw(SoloError, 'name is required');
+    expect(() => new Cluster('', 'valid')).to.throw(SoloError, 'name is required');
+  });
+
+  it('should fail if name is not a string', () => {
+    const name = 1; // @ts-ignore
+    expect(() => new Cluster(name, 'valid')).to.throw(SoloError, 'Invalid type for name: number');
+  });
+
+  it('should fail if namespace is not provided', () => {
+    expect(() => new Cluster('valid', null)).to.throw(SoloError, 'namespace is required');
+    expect(() => new Cluster('valid', '')).to.throw(SoloError, 'namespace is required');
+  });
+
+  it('should fail if namespace is not a string', () => {
+    const namespace = 1; // @ts-ignore
+    expect(() => new Cluster('valid', namespace)).to.throw(SoloError, 'Invalid type for namespace: number');
+  });
+
+  it('should convert to an object', () => {
+    const c = new Cluster('name', 'namespace', 'cluster.world', 'network.svc');
+    const o = c.toObject();
+    expect(o.name).to.equal('name');
+    expect(o.namespace).to.equal('namespace');
+    expect(o.dnsBaseDomain).to.equal('cluster.world');
+    expect(o.dnsConsensusNodePattern).to.equal('network.svc');
+  });
+
+  it('should convert clusters map to an object', () => {
+    const map1: Record<ClusterRef, Cluster> = {
+      cluster1: new Cluster('name1', 'namespace1', 'cluster1.world', 'network1.svc'),
+      cluster2: new Cluster('name2', 'namespace2', 'cluster2.world', 'network2.svc'),
+    };
+
+    const o = Cluster.toClustersMapObject(map1);
+    expect(o.cluster1.name).to.equal('name1');
+    expect(o.cluster1.namespace).to.equal('namespace1');
+    expect(o.cluster1.dnsBaseDomain).to.equal('cluster1.world');
+    expect(o.cluster1.dnsConsensusNodePattern).to.equal('network1.svc');
+    expect(o.cluster2.name).to.equal('name2');
+    expect(o.cluster2.namespace).to.equal('namespace2');
+    expect(o.cluster2.dnsBaseDomain).to.equal('cluster2.world');
+    expect(o.cluster2.dnsConsensusNodePattern).to.equal('network2.svc');
+
+    const map2 = Cluster.fromClustersMapObject(o);
+    expect(map2.cluster1.name).to.equal(map1.cluster1.name);
+    expect(map2.cluster1.namespace).to.equal(map1.cluster1.namespace);
+    expect(map2.cluster1.dnsBaseDomain).to.equal(map1.cluster1.dnsBaseDomain);
+    expect(map2.cluster1.dnsConsensusNodePattern).to.equal(map1.cluster1.dnsConsensusNodePattern);
+    expect(map2.cluster2.name).to.equal(map1.cluster2.name);
+    expect(map2.cluster2.namespace).to.equal(map1.cluster2.namespace);
+    expect(map2.cluster2.dnsBaseDomain).to.equal(map1.cluster2.dnsBaseDomain);
+    expect(map2.cluster2.dnsConsensusNodePattern).to.equal(map1.cluster2.dnsConsensusNodePattern);
+  });
+});

--- a/test/unit/core/config/remote/components/components.test.ts
+++ b/test/unit/core/config/remote/components/components.test.ts
@@ -4,16 +4,17 @@
 import {expect} from 'chai';
 import {describe, it} from 'mocha';
 
-import {RelayComponent} from '../../../../src/core/config/remote/components/relay_component.js';
-import {BaseComponent} from '../../../../src/core/config/remote/components/base_component.js';
-import {ConsensusNodeComponent} from '../../../../src/core/config/remote/components/consensus_node_component.js';
-import {HaProxyComponent} from '../../../../src/core/config/remote/components/ha_proxy_component.js';
-import {EnvoyProxyComponent} from '../../../../src/core/config/remote/components/envoy_proxy_component.js';
-import {MirrorNodeComponent} from '../../../../src/core/config/remote/components/mirror_node_component.js';
-import {MirrorNodeExplorerComponent} from '../../../../src/core/config/remote/components/mirror_node_explorer_component.js';
-import {SoloError} from '../../../../src/core/errors.js';
-import {ConsensusNodeStates} from '../../../../src/core/config/remote/enumerations.js';
-import {type NodeAliases} from '../../../../src/types/aliases.js';
+import {RelayComponent} from '../../../../../../src/core/config/remote/components/relay_component.js';
+import {BaseComponent} from '../../../../../../src/core/config/remote/components/base_component.js';
+import {ConsensusNodeComponent} from '../../../../../../src/core/config/remote/components/consensus_node_component.js';
+import {HaProxyComponent} from '../../../../../../src/core/config/remote/components/ha_proxy_component.js';
+import {EnvoyProxyComponent} from '../../../../../../src/core/config/remote/components/envoy_proxy_component.js';
+import {MirrorNodeComponent} from '../../../../../../src/core/config/remote/components/mirror_node_component.js';
+import {MirrorNodeExplorerComponent} from '../../../../../../src/core/config/remote/components/mirror_node_explorer_component.js';
+import {SoloError} from '../../../../../../src/core/errors.js';
+import {ConsensusNodeStates} from '../../../../../../src/core/config/remote/enumerations.js';
+import {type NodeAliases} from '../../../../../../src/types/aliases.js';
+import {Templates} from '../../../../../../src/core/templates.js';
 
 function testBaseComponentData(classComponent: any) {
   const validNamespace = 'valid';
@@ -164,15 +165,15 @@ describe('RelayComponent', () => {
 describe('ConsensusNodeComponent', () => {
   it('should fail if name is not provided', () => {
     const name = '';
-    expect(() => new ConsensusNodeComponent(name, 'valid', 'valid', ConsensusNodeStates.STARTED)).to.throw(
+    expect(() => new ConsensusNodeComponent(name, 'valid', 'valid', ConsensusNodeStates.STARTED, 0)).to.throw(
       SoloError,
       `Invalid name: ${name}`,
     );
   });
 
-  it('should fail if name is string', () => {
+  it('should fail if name is not a string', () => {
     const name = 1; // @ts-ignore
-    expect(() => new ConsensusNodeComponent(name, 'valid', 'valid', ConsensusNodeStates.STARTED)).to.throw(
+    expect(() => new ConsensusNodeComponent(name, 'valid', 'valid', ConsensusNodeStates.STARTED, 0)).to.throw(
       SoloError,
       `Invalid name: ${name}`,
     );
@@ -180,15 +181,15 @@ describe('ConsensusNodeComponent', () => {
 
   it('should fail if cluster is not provided', () => {
     const cluster = '';
-    expect(() => new ConsensusNodeComponent('valid', cluster, 'valid', ConsensusNodeStates.STARTED)).to.throw(
+    expect(() => new ConsensusNodeComponent('valid', cluster, 'valid', ConsensusNodeStates.STARTED, 0)).to.throw(
       SoloError,
       `Invalid cluster: ${cluster}`,
     );
   });
 
-  it('should fail if cluster is string', () => {
+  it('should fail if cluster is not a string', () => {
     const cluster = 1; // @ts-ignore
-    expect(() => new ConsensusNodeComponent('valid', cluster, 'valid', ConsensusNodeStates.STARTED)).to.throw(
+    expect(() => new ConsensusNodeComponent('valid', cluster, 'valid', ConsensusNodeStates.STARTED, 0)).to.throw(
       SoloError,
       `Invalid cluster: ${cluster}`,
     );
@@ -196,15 +197,15 @@ describe('ConsensusNodeComponent', () => {
 
   it('should fail if namespace is not provided', () => {
     const namespace = null;
-    expect(() => new ConsensusNodeComponent('valid', 'valid', namespace, ConsensusNodeStates.STARTED)).to.throw(
+    expect(() => new ConsensusNodeComponent('valid', 'valid', namespace, ConsensusNodeStates.STARTED, 0)).to.throw(
       SoloError,
       `Invalid namespace: ${namespace}`,
     );
   });
 
-  it('should fail if namespace is string', () => {
+  it('should fail if namespace is not a string', () => {
     const namespace = 1; // @ts-ignore
-    expect(() => new ConsensusNodeComponent('valid', 'valid', namespace, ConsensusNodeStates.STARTED)).to.throw(
+    expect(() => new ConsensusNodeComponent('valid', 'valid', namespace, ConsensusNodeStates.STARTED, 0)).to.throw(
       SoloError,
       `Invalid namespace: ${namespace}`,
     );
@@ -212,30 +213,49 @@ describe('ConsensusNodeComponent', () => {
 
   it('should fail if state is not valid', () => {
     const state = 'invalid' as ConsensusNodeStates.STARTED;
-    expect(() => new ConsensusNodeComponent('valid', 'valid', 'valid', state)).to.throw(
+    expect(() => new ConsensusNodeComponent('valid', 'valid', 'valid', state, 0)).to.throw(
       SoloError,
       `Invalid consensus node state: ${state}`,
     );
   });
 
+  it('should fail if nodeId is not a number', () => {
+    const nodeId = 'invalid'; // @ts-ignore
+    expect(() => new ConsensusNodeComponent('valid', 'valid', 'valid', ConsensusNodeStates.STARTED, nodeId)).to.throw(
+      SoloError,
+      `Invalid node id. It must be a number: ${nodeId}`,
+    );
+  });
+
+  it('should fail if nodeId is negative', () => {
+    const nodeId = -1; // @ts-ignore
+    expect(() => new ConsensusNodeComponent('valid', 'valid', 'valid', ConsensusNodeStates.STARTED, nodeId)).to.throw(
+      SoloError,
+      `Invalid node id. It cannot be negative: ${nodeId}`,
+    );
+  });
+
   it('should successfully create ', () => {
-    new ConsensusNodeComponent('valid', 'valid', 'valid', ConsensusNodeStates.STARTED);
+    new ConsensusNodeComponent('valid', 'valid', 'valid', ConsensusNodeStates.STARTED, 0);
   });
 
   it('should be an instance of BaseComponent', () => {
-    const component = new ConsensusNodeComponent('valid', 'valid', 'valid', ConsensusNodeStates.STARTED);
+    const component = new ConsensusNodeComponent('valid', 'valid', 'valid', ConsensusNodeStates.STARTED, 0);
     expect(component).to.be.instanceOf(BaseComponent);
   });
 
   it('calling toObject() should return a valid data', () => {
-    const {name, cluster, namespace, state} = {
-      name: 'name',
+    const nodeAlias = 'node1';
+    const nodeInfo = {
+      name: nodeAlias,
       cluster: 'cluster',
       namespace: 'namespace',
       state: ConsensusNodeStates.STARTED,
+      nodeId: Templates.nodeIdFromNodeAlias(nodeAlias),
     };
 
-    const component = new ConsensusNodeComponent(name, cluster, namespace, state);
-    expect(component.toObject()).to.deep.equal({name, cluster, namespace, state});
+    const {name, cluster, namespace, state, nodeId} = nodeInfo;
+    const component = new ConsensusNodeComponent(name, cluster, namespace, state, nodeId);
+    expect(component.toObject()).to.deep.equal(nodeInfo);
   });
 });

--- a/test/unit/core/config/remote/components_data_wrapper.test.ts
+++ b/test/unit/core/config/remote/components_data_wrapper.test.ts
@@ -4,16 +4,16 @@
 import {expect} from 'chai';
 import {describe, it} from 'mocha';
 
-import {ComponentsDataWrapper} from '../../../../src/core/config/remote/components_data_wrapper.js';
-import {HaProxyComponent} from '../../../../src/core/config/remote/components/ha_proxy_component.js';
-import {MirrorNodeComponent} from '../../../../src/core/config/remote/components/mirror_node_component.js';
-import {EnvoyProxyComponent} from '../../../../src/core/config/remote/components/envoy_proxy_component.js';
-import {ConsensusNodeComponent} from '../../../../src/core/config/remote/components/consensus_node_component.js';
-import {MirrorNodeExplorerComponent} from '../../../../src/core/config/remote/components/mirror_node_explorer_component.js';
-import {RelayComponent} from '../../../../src/core/config/remote/components/relay_component.js';
-import {ComponentType, ConsensusNodeStates} from '../../../../src/core/config/remote/enumerations.js';
-import {SoloError} from '../../../../src/core/errors.js';
-import {type NodeAliases} from '../../../../src/types/aliases.js';
+import {ComponentsDataWrapper} from '../../../../../src/core/config/remote/components_data_wrapper.js';
+import {HaProxyComponent} from '../../../../../src/core/config/remote/components/ha_proxy_component.js';
+import {MirrorNodeComponent} from '../../../../../src/core/config/remote/components/mirror_node_component.js';
+import {EnvoyProxyComponent} from '../../../../../src/core/config/remote/components/envoy_proxy_component.js';
+import {ConsensusNodeComponent} from '../../../../../src/core/config/remote/components/consensus_node_component.js';
+import {MirrorNodeExplorerComponent} from '../../../../../src/core/config/remote/components/mirror_node_explorer_component.js';
+import {RelayComponent} from '../../../../../src/core/config/remote/components/relay_component.js';
+import {ComponentType, ConsensusNodeStates} from '../../../../../src/core/config/remote/enumerations.js';
+import {SoloError} from '../../../../../src/core/errors.js';
+import {type NodeAliases} from '../../../../../src/types/aliases.js';
 
 export function createComponentsDataWrapper() {
   const serviceName = 'serviceName';
@@ -28,7 +28,7 @@ export function createComponentsDataWrapper() {
   const haProxies = {[serviceName]: new HaProxyComponent(name, cluster, namespace)};
   const mirrorNodes = {[serviceName]: new MirrorNodeComponent(name, cluster, namespace)};
   const envoyProxies = {[serviceName]: new EnvoyProxyComponent(name, cluster, namespace)};
-  const consensusNodes = {[serviceName]: new ConsensusNodeComponent(name, cluster, namespace, state)};
+  const consensusNodes = {[serviceName]: new ConsensusNodeComponent(name, cluster, namespace, state, 1)};
   const mirrorNodeExplorers = {[serviceName]: new MirrorNodeExplorerComponent(name, cluster, namespace)};
 
   // @ts-ignore
@@ -41,14 +41,14 @@ export function createComponentsDataWrapper() {
     mirrorNodeExplorers,
   );
   /*
-  ? The class after calling the toObject() method
-  * RELAY: { serviceName: { name: 'name', cluster: 'cluster', namespace: 'namespace' consensusNodeAliases: ['node1', 'node2'] } },
-  * HAPROXY: { serviceName: { name: 'name', cluster: 'cluster', namespace: 'namespace' } },
-  * MIRROR_NODE: { serviceName: { name: 'name', cluster: 'cluster', namespace: 'namespace' } },
-  * ENVOY_PROXY: { serviceName: { name: 'name', cluster: 'cluster', namespace: 'namespace' } },
-  * CONSENSUS_NODE: { serviceName: { state: 'started', name: 'name', cluster: 'cluster', namespace: 'namespace'} },
-  * MIRROR_NODE_EXPLORER: { serviceName: { name: 'name', cluster: 'cluster', namespace: 'namespace' } },
-  */
+    ? The class after calling the toObject() method
+    * RELAY: { serviceName: { name: 'name', cluster: 'cluster', namespace: 'namespace' consensusNodeAliases: ['node1', 'node2'] } },
+    * HAPROXY: { serviceName: { name: 'name', cluster: 'cluster', namespace: 'namespace' } },
+    * MIRROR_NODE: { serviceName: { name: 'name', cluster: 'cluster', namespace: 'namespace' } },
+    * ENVOY_PROXY: { serviceName: { name: 'name', cluster: 'cluster', namespace: 'namespace' } },
+    * CONSENSUS_NODE: { serviceName: { state: 'started', name: 'name', cluster: 'cluster', namespace: 'namespace'} },
+    * MIRROR_NODE_EXPLORER: { serviceName: { name: 'name', cluster: 'cluster', namespace: 'namespace' } },
+    */
   return {
     values: {name, cluster, namespace, state, consensusNodeAliases},
     components: {consensusNodes, haProxies, envoyProxies, mirrorNodes, mirrorNodeExplorers, relays},

--- a/test/unit/core/config/remote/metadata.test.ts
+++ b/test/unit/core/config/remote/metadata.test.ts
@@ -3,10 +3,10 @@
  */
 import {expect} from 'chai';
 import {describe, it} from 'mocha';
-import {Migration} from '../../../../src/core/config/remote/migration.js';
-import {SoloError} from '../../../../src/core/errors.js';
-import {RemoteConfigMetadata} from '../../../../src/core/config/remote/metadata.js';
-import {type EmailAddress, type NamespaceNameAsString} from '../../../../src/core/config/remote/types.js';
+import {Migration} from '../../../../../src/core/config/remote/migration.js';
+import {SoloError} from '../../../../../src/core/errors.js';
+import {RemoteConfigMetadata} from '../../../../../src/core/config/remote/metadata.js';
+import {type EmailAddress, type NamespaceNameAsString} from '../../../../../src/core/config/remote/types.js';
 
 export function createMetadata() {
   const name: NamespaceNameAsString = 'namespace';

--- a/test/unit/core/config/remote/migration.test.ts
+++ b/test/unit/core/config/remote/migration.test.ts
@@ -3,9 +3,9 @@
  */
 import {expect} from 'chai';
 import {describe, it} from 'mocha';
-import {Migration} from '../../../../src/core/config/remote/migration.js';
-import {type EmailAddress, type Version} from '../../../../src/core/config/remote/types.js';
-import {SoloError} from '../../../../src/core/errors.js';
+import {Migration} from '../../../../../src/core/config/remote/migration.js';
+import {type EmailAddress, type Version} from '../../../../../src/core/config/remote/types.js';
+import {SoloError} from '../../../../../src/core/errors.js';
 
 function createMigration() {
   const migratedAt = new Date();

--- a/test/unit/core/config/remote/remote_config_data_wrapper.test.ts
+++ b/test/unit/core/config/remote/remote_config_data_wrapper.test.ts
@@ -5,13 +5,13 @@ import {expect} from 'chai';
 import {describe, it} from 'mocha';
 
 import * as yaml from 'yaml';
-import {RemoteConfigDataWrapper} from '../../../../src/core/config/remote/remote_config_data_wrapper.js';
+import {RemoteConfigDataWrapper} from '../../../../../src/core/config/remote/remote_config_data_wrapper.js';
 import {createMetadata} from './metadata.test.js';
 import {createComponentsDataWrapper} from './components_data_wrapper.test.js';
-import {SoloError} from '../../../../src/core/errors.js';
-import * as constants from '../../../../src/core/constants.js';
-import {CommonFlagsDataWrapper} from '../../../../src/core/config/remote/common_flags_data_wrapper.js';
-import {NamespaceName} from '../../../../src/core/kube/resources/namespace/namespace_name.js';
+import {SoloError} from '../../../../../src/core/errors.js';
+import * as constants from '../../../../../src/core/constants.js';
+import {CommonFlagsDataWrapper} from '../../../../../src/core/config/remote/common_flags_data_wrapper.js';
+import {Cluster} from '../../../../../src/core/config/remote/cluster.js';
 
 const configManagerMock = {
   update: (...args: any) => true,
@@ -113,6 +113,6 @@ describe('RemoteConfigDataWrapper', async () => {
 
     expect(() => (dataWrapper.clusters = {null: null})).to.throw(SoloError);
     expect(() => (dataWrapper.clusters = {namespace: null})).to.throw(SoloError);
-    expect(() => (dataWrapper.clusters = {null: 'namespace'})).to.throw(SoloError);
+    expect(() => (dataWrapper.clusters = {null: new Cluster('cluster', 'namespace')})).to.throw(SoloError);
   });
 });


### PR DESCRIPTION
## Description

This pull request changes the following:

* add support for new data types `ClusterRef` and `Cluster`
* update RemoteConfig to handle multi-cluster networking
* fix typo: `replays` -> `relays`

### Related Issues

* Closes #1345 


## Screenshots
<img width="717" alt="Screenshot 2025-02-11 at 7 26 15 PM" src="https://github.com/user-attachments/assets/cb3b1818-9497-4250-b5ca-620572317821" />
