### PR TITLE
feat(external-database): add ability to pass readonly user to the external database

### DIFF
--- a/Taskfile.helper.yml
+++ b/Taskfile.helper.yml
@@ -506,4 +506,4 @@ tasks:
         cmd: |
           kubectl exec -it {{.postgres_container_name}} \
           -n {{.postgres_database_namespace}} \
-          -- /bin/bash /tmp/init.sh "{{.postgres_username}}" "{{.postgres_password}}"
+          -- /bin/bash /tmp/init.sh "{{.postgres_username}}" "{{.postgres_readonly_username}}" "{{.postgres_readonly_password}}"

--- a/examples/external-database-test/Taskfile.yml
+++ b/examples/external-database-test/Taskfile.yml
@@ -6,19 +6,30 @@ includes:
 vars:
   use_port_forwards: "true"
   postgres_username: "postgres"
-  postgres_password: "XXXXXXXXX"
+  postgres_password: "XXXXXXXX"
+
+  postgres_readonly_username: "readonlyuser"
+  postgres_readonly_password: "XXXXXXXX"
+
+  postgres_mirror_node_database_name: "mirror_node"
+
   postgres_name: "my-postgresql"
+  postgres_database_namespace: "database"
   postgres_container_name: "{{.postgres_name}}-0"
   postgres_host_fqdn: "{{.postgres_name}}.database.svc.cluster.local"
   postgres_container_fdqn: "{{.postgres_container_name}}.database.svc.cluster.local"
-  postgres_mirror_node_database_name: "mirror_node"
-  postgres_database_namespace: "database"
 env:
   SOLO_NETWORK_SIZE: "1"
   SOLO_DEPLOYMENT: "solo-e2e"
   SOLO_NAMESPACE: "solo-e2e"
   SOLO_CLUSTER_NAME: "solo-e2e"
-  MIRROR_NODE_DEPLOY_EXTRA_FLAGS: "--use-external-database --external-database-host {{.postgres_host_fqdn}} --external-database-owner-username {{.postgres_username}} --external-database-owner-password {{.postgres_password}}"
+  MIRROR_NODE_DEPLOY_EXTRA_FLAGS: |
+    --use-external-database 
+    --external-database-host {{.postgres_host_fqdn}} 
+    --external-database-owner-username {{.postgres_username}} 
+    --external-database-owner-password {{.postgres_password}}
+    --external-database-read-username {{.postgres_readonly_username}}
+    --external-database-read-password {{.postgres_readonly_password}}
 tasks:
   default:
     silent: true

--- a/examples/external-database-test/scripts/init.sh
+++ b/examples/external-database-test/scripts/init.sh
@@ -3,7 +3,9 @@ set -e
 
 export HEDERA_MIRROR_DATABASE_NAME="mirror_node"
 HEDERA_MIRROR_OWNER="$1"
-HEDERA_MIRROR_OWNER_PASSWORD="$2"
+HEDERA_MIRROR_READ="$2"
+HEDERA_MIRROR_READ_PASSWORD="$3"
+
 
 export HEDERA_MIRROR_GRPC_DB_HOST="localhost"
 
@@ -26,7 +28,9 @@ psql -d "user=postgres connect_timeout=3" \
   --set "dbName=${HEDERA_MIRROR_IMPORTER_DB_NAME}" \
   --set "dbSchema=${HEDERA_MIRROR_IMPORTER_DB_SCHEMA}" \
   --set "ownerUsername=${HEDERA_MIRROR_IMPORTER_DB_OWNER}" \
-  --set "tempSchema=${HEDERA_MIRROR_IMPORTER_DB_TEMPSCHEMA}" <<__SQL__
+  --set "tempSchema=${HEDERA_MIRROR_IMPORTER_DB_TEMPSCHEMA}" \
+  --set "readUsername=${HEDERA_MIRROR_READ}" \
+  --set "readPassword=${HEDERA_MIRROR_READ_PASSWORD}" <<__SQL__
 
 -- Create database & owner
 create database :dbName with owner :ownerUsername;
@@ -58,6 +62,10 @@ revoke create on schema :dbSchema from public;
 create schema if not exists :tempSchema authorization temporary_admin;
 grant usage on schema :tempSchema to public;
 revoke create on schema :tempSchema from public;
+
+-- Create readonly user with password and grant privileges
+create user :readUsername with password :'readPassword';
+grant readonly to :readUsername;
 
 -- Grant readonly privileges
 grant connect on database :dbName to readonly;

--- a/src/commands/flags.ts
+++ b/src/commands/flags.ts
@@ -1567,6 +1567,8 @@ export class Flags {
     prompt: undefined,
   };
 
+  //* ----------------- External Mirror Node PostgreSQL Database Related Flags ------------------ *//
+
   static readonly externalDatabaseHost: CommandFlag = {
     constName: 'externalDatabaseHost',
     name: 'external-database-host',
@@ -1627,6 +1629,49 @@ export class Flags {
       );
     },
   };
+
+  static readonly externalDatabaseReadonlyUsername: CommandFlag = {
+    constName: 'externalDatabaseReadonlyUsername',
+    name: 'external-database-read-username',
+    definition: {
+      describe: `Use to provide the external database readonly user's username if the '--${Flags.useExternalDatabase.name}' is passed`,
+      defaultValue: '',
+      type: 'string',
+    },
+    prompt: async function promptGrpcWebTlsKeyPath(task: ListrTaskWrapper<any, any, any>, input: any) {
+      return await Flags.promptText(
+        task,
+        input,
+        Flags.externalDatabaseReadonlyUsername.definition.defaultValue,
+        'Enter username of the external database readonly user',
+        null,
+        Flags.externalDatabaseReadonlyUsername.name,
+      );
+    },
+  };
+
+  static readonly externalDatabaseReadonlyPassword: CommandFlag = {
+    constName: 'externalDatabaseReadonlyPassword',
+    name: 'external-database-read-password',
+    definition: {
+      describe: `Use to provide the external database readonly user's password if the '--${Flags.useExternalDatabase.name}' is passed`,
+      defaultValue: '',
+      type: 'string',
+      dataMask: constants.STANDARD_DATAMASK,
+    },
+    prompt: async function promptGrpcWebTlsKeyPath(task: ListrTaskWrapper<any, any, any>, input: any) {
+      return await Flags.promptText(
+        task,
+        input,
+        Flags.externalDatabaseReadonlyPassword.definition.defaultValue,
+        'Enter password of the external database readonly user',
+        null,
+        Flags.externalDatabaseReadonlyPassword.name,
+      );
+    },
+  };
+
+  //* ------------------------------------------------------------------------------------------- *//
 
   static readonly grpcTlsKeyPath: CommandFlag = {
     constName: 'grpcTlsKeyPath',
@@ -1918,6 +1963,8 @@ export class Flags {
     Flags.externalDatabaseHost,
     Flags.externalDatabaseOwnerUsername,
     Flags.externalDatabaseOwnerPassword,
+    Flags.externalDatabaseReadonlyUsername,
+    Flags.externalDatabaseReadonlyPassword,
   ];
 
   /** Resets the definition.disablePrompt for all flags */

--- a/test/e2e/commands/mirror_node.test.ts
+++ b/test/e2e/commands/mirror_node.test.ts
@@ -98,6 +98,8 @@ e2eTestSuite(testName, argv, undefined, undefined, undefined, undefined, undefin
         flags.externalDatabaseHost.constName,
         flags.externalDatabaseOwnerUsername.constName,
         flags.externalDatabaseOwnerPassword.constName,
+        flags.externalDatabaseReadonlyUsername.constName,
+        flags.externalDatabaseReadonlyPassword.constName,
       ]);
       expect(explorerCommand.getUnusedConfigs(MirrorNodeCommand.DEPLOY_CONFIGS_NAME)).to.deep.equal([
         flags.hederaExplorerTlsHostName.constName,


### PR DESCRIPTION
## Description

Added the ability to provide a readonly user name and password for the external database. 

New flags:
* `--external-database-read-username` - PostgreSQL readonly user's username.
* `--external-database-read-password` - PostgreSQL readonly user's password.

  the owner is set as the owner inside the mirror-node helm chart and the mirror node importer,
  all of the other services use the readonly user - gRPC, restJava, web3, rest...

### Related Issues

* Closes [#1349](https://github.com/hashgraph/solo/issues/1349)
