### PR TITLE
refactor: Update LocalConfig to support multiple clusters based on the new design

### DIFF
--- a/src/commands/cluster/configs.ts
+++ b/src/commands/cluster/configs.ts
@@ -13,9 +13,7 @@ import {type DeploymentName} from '../../core/config/remote/types.js';
 export const CONNECT_CONFIGS_NAME = 'connectConfig';
 
 export const connectConfigBuilder = async function (argv, ctx, task) {
-  const config = this.getConfig(CONNECT_CONFIGS_NAME, argv.flags, [
-    'currentDeploymentName',
-  ]) as ClusterConnectConfigClass;
+  const config = this.getConfig(CONNECT_CONFIGS_NAME, argv.flags, []) as ClusterConnectConfigClass;
 
   // set config in the context for later tasks to use
   ctx.config = config;

--- a/src/commands/deployment.ts
+++ b/src/commands/deployment.ts
@@ -126,7 +126,7 @@ export class DeploymentCommand extends BaseCommand {
             const subTasks: SoloListrTask<Context>[] = [];
 
             for (const cluster of self.localConfig.deployments[ctx.config.deployment].clusters) {
-              const context = self.localConfig.clusterContextMapping?.[cluster];
+              const context = self.localConfig.clusterRefs?.[cluster];
               if (!context) continue;
 
               subTasks.push({
@@ -197,7 +197,7 @@ export class DeploymentCommand extends BaseCommand {
           task: async ctx => {
             const clusterName = ctx.config.clusterName;
 
-            const context = self.localConfig.clusterContextMapping[clusterName];
+            const context = self.localConfig.clusterRefs[clusterName];
 
             self.k8.contexts().updateCurrent(context);
 

--- a/src/core/config/local_config.ts
+++ b/src/core/config/local_config.ts
@@ -6,14 +6,14 @@ import fs from 'fs';
 import * as yaml from 'yaml';
 import {Flags as flags} from '../../commands/flags.js';
 import {
-  type ClusterContextMapping,
+  type clusterRefs,
   type Deployments,
   type DeploymentStructure,
   type LocalConfigData,
 } from './local_config_data.js';
 import {MissingArgumentError, SoloError} from '../errors.js';
 import {type SoloLogger} from '../logging.js';
-import {IsClusterContextMapping, IsDeployments} from '../validator_decorators.js';
+import {IsclusterRefs, IsDeployments} from '../validator_decorators.js';
 import {type ConfigManager} from '../config_manager.js';
 import {type DeploymentName, type EmailAddress} from './remote/types.js';
 import {ErrorMessages} from '../error_messages.js';
@@ -49,14 +49,11 @@ export class LocalConfig implements LocalConfigData {
   @IsString({
     message: ErrorMessages.LOCAL_CONFIG_CURRENT_DEPLOYMENT_DOES_NOT_EXIST,
   })
-  @IsNotEmpty()
-  currentDeploymentName: DeploymentName;
-
-  @IsClusterContextMapping({
+  @IsclusterRefs({
     message: ErrorMessages.LOCAL_CONFIG_CONTEXT_CLUSTER_MAPPING_FORMAT,
   })
   @IsNotEmpty()
-  public clusterContextMapping: ClusterContextMapping = {};
+  public clusterRefs: clusterRefs = {};
 
   private readonly skipPromptTask: boolean = false;
 
@@ -71,7 +68,7 @@ export class LocalConfig implements LocalConfigData {
 
     if (!this.filePath || this.filePath === '') throw new MissingArgumentError('a valid filePath is required');
 
-    const allowedKeys = ['userEmailAddress', 'deployments', 'currentDeploymentName', 'clusterContextMapping'];
+    const allowedKeys = ['userEmailAddress', 'deployments', 'clusterRefs'];
     if (this.configFileExists()) {
       const fileContent = fs.readFileSync(filePath, 'utf8');
       const parsedConfig = yaml.parse(fileContent);
@@ -100,11 +97,6 @@ export class LocalConfig implements LocalConfigData {
         throw new SoloError(ErrorMessages.LOCAL_CONFIG_GENERIC);
       }
     }
-
-    // Custom validations:
-    if (!this.deployments[this.currentDeploymentName]) {
-      throw new SoloError(ErrorMessages.LOCAL_CONFIG_CURRENT_DEPLOYMENT_DOES_NOT_EXIST);
-    }
   }
 
   public setUserEmailAddress(emailAddress: EmailAddress): this {
@@ -119,20 +111,10 @@ export class LocalConfig implements LocalConfigData {
     return this;
   }
 
-  public setCurrentDeployment(deploymentName: DeploymentName): this {
-    this.currentDeploymentName = deploymentName;
+  public setclusterRefs(clusterRefs: clusterRefs): this {
+    this.clusterRefs = clusterRefs;
     this.validate();
     return this;
-  }
-
-  public setClusterContextMapping(clusterContextMapping: ClusterContextMapping): this {
-    this.clusterContextMapping = clusterContextMapping;
-    this.validate();
-    return this;
-  }
-
-  public getCurrentDeployment(): DeploymentStructure {
-    return this.deployments[this.currentDeploymentName];
   }
 
   public configFileExists(): boolean {
@@ -143,8 +125,7 @@ export class LocalConfig implements LocalConfigData {
     const yamlContent = yaml.stringify({
       userEmailAddress: this.userEmailAddress,
       deployments: this.deployments,
-      currentDeploymentName: this.currentDeploymentName,
-      clusterContextMapping: this.clusterContextMapping,
+      clusterRefs: this.clusterRefs,
     });
     await fs.promises.writeFile(this.filePath, yamlContent);
 
@@ -203,7 +184,7 @@ export class LocalConfig implements LocalConfigData {
             for (const cluster of parsedClusters) {
               const kubeContexts = k8.contexts().list();
               const context: string = await flags.context.prompt(task, kubeContexts, cluster);
-              self.clusterContextMapping[cluster] = context;
+              self.clusterRefs[cluster] = context;
               promptedContexts.push(context);
 
               self.configManager.setFlag(flags.context, context);
@@ -212,14 +193,14 @@ export class LocalConfig implements LocalConfigData {
           } else {
             const context = k8.contexts().readCurrent();
             for (const cluster of parsedClusters) {
-              self.clusterContextMapping[cluster] = context;
+              self.clusterRefs[cluster] = context;
             }
             self.configManager.setFlag(flags.context, context);
           }
         } else {
           for (let i = 0; i < parsedClusters.length; i++) {
             const cluster = parsedClusters[i];
-            self.clusterContextMapping[cluster] = parsedContexts[i];
+            self.clusterRefs[cluster] = parsedContexts[i];
 
             self.configManager.setFlag(flags.context, parsedContexts[i]);
           }
@@ -227,7 +208,6 @@ export class LocalConfig implements LocalConfigData {
 
         self.userEmailAddress = userEmailAddress;
         self.deployments = deployments;
-        self.currentDeploymentName = deploymentName;
 
         self.validate();
         await self.write();

--- a/src/core/config/local_config.ts
+++ b/src/core/config/local_config.ts
@@ -46,9 +46,6 @@ export class LocalConfig implements LocalConfigData {
   })
   public deployments: Deployments;
 
-  @IsString({
-    message: ErrorMessages.LOCAL_CONFIG_CURRENT_DEPLOYMENT_DOES_NOT_EXIST,
-  })
   @IsClusterRefs({
     message: ErrorMessages.LOCAL_CONFIG_CONTEXT_CLUSTER_MAPPING_FORMAT,
   })
@@ -111,7 +108,7 @@ export class LocalConfig implements LocalConfigData {
     return this;
   }
 
-  public setclusterRefs(clusterRefs: ClusterRefs): this {
+  public setClusterRefs(clusterRefs: ClusterRefs): this {
     this.clusterRefs = clusterRefs;
     this.validate();
     return this;
@@ -167,24 +164,24 @@ export class LocalConfig implements LocalConfigData {
           self.configManager.setFlag(flags.deploymentClusters, deploymentClusters);
         }
 
-        const parsedClusters = splitFlagInput(deploymentClusters);
+        const parsedClusterRefs = splitFlagInput(deploymentClusters);
 
         const deployments: Deployments = {
           [deploymentName]: {
-            clusters: parsedClusters,
+            clusters: parsedClusterRefs,
             namespace: namespace.name,
           },
         };
 
         const parsedContexts = splitFlagInput(contexts);
 
-        if (parsedContexts.length < parsedClusters.length) {
+        if (parsedContexts.length < parsedClusterRefs.length) {
           if (!isQuiet) {
             const promptedContexts: string[] = [];
-            for (const cluster of parsedClusters) {
+            for (const clusterRef of parsedClusterRefs) {
               const kubeContexts = k8.contexts().list();
-              const context: string = await flags.context.prompt(task, kubeContexts, cluster);
-              self.clusterRefs[cluster] = context;
+              const context: string = await flags.context.prompt(task, kubeContexts, clusterRef);
+              self.clusterRefs[clusterRef] = context;
               promptedContexts.push(context);
 
               self.configManager.setFlag(flags.context, context);
@@ -192,15 +189,15 @@ export class LocalConfig implements LocalConfigData {
             self.configManager.setFlag(flags.context, promptedContexts.join(','));
           } else {
             const context = k8.contexts().readCurrent();
-            for (const cluster of parsedClusters) {
-              self.clusterRefs[cluster] = context;
+            for (const clusterRef of parsedClusterRefs) {
+              self.clusterRefs[clusterRef] = context;
             }
             self.configManager.setFlag(flags.context, context);
           }
         } else {
-          for (let i = 0; i < parsedClusters.length; i++) {
-            const cluster = parsedClusters[i];
-            self.clusterRefs[cluster] = parsedContexts[i];
+          for (let i = 0; i < parsedClusterRefs.length; i++) {
+            const clusterRef = parsedClusterRefs[i];
+            self.clusterRefs[clusterRef] = parsedContexts[i];
 
             self.configManager.setFlag(flags.context, parsedContexts[i]);
           }

--- a/src/core/config/local_config.ts
+++ b/src/core/config/local_config.ts
@@ -6,14 +6,14 @@ import fs from 'fs';
 import * as yaml from 'yaml';
 import {Flags as flags} from '../../commands/flags.js';
 import {
-  type clusterRefs,
+  type ClusterRefs,
   type Deployments,
   type DeploymentStructure,
   type LocalConfigData,
 } from './local_config_data.js';
 import {MissingArgumentError, SoloError} from '../errors.js';
 import {type SoloLogger} from '../logging.js';
-import {IsclusterRefs, IsDeployments} from '../validator_decorators.js';
+import {IsClusterRefs, IsDeployments} from '../validator_decorators.js';
 import {type ConfigManager} from '../config_manager.js';
 import {type DeploymentName, type EmailAddress} from './remote/types.js';
 import {ErrorMessages} from '../error_messages.js';
@@ -49,11 +49,11 @@ export class LocalConfig implements LocalConfigData {
   @IsString({
     message: ErrorMessages.LOCAL_CONFIG_CURRENT_DEPLOYMENT_DOES_NOT_EXIST,
   })
-  @IsclusterRefs({
+  @IsClusterRefs({
     message: ErrorMessages.LOCAL_CONFIG_CONTEXT_CLUSTER_MAPPING_FORMAT,
   })
   @IsNotEmpty()
-  public clusterRefs: clusterRefs = {};
+  public clusterRefs: ClusterRefs = {};
 
   private readonly skipPromptTask: boolean = false;
 
@@ -111,7 +111,7 @@ export class LocalConfig implements LocalConfigData {
     return this;
   }
 
-  public setclusterRefs(clusterRefs: clusterRefs): this {
+  public setclusterRefs(clusterRefs: ClusterRefs): this {
     this.clusterRefs = clusterRefs;
     this.validate();
     return this;

--- a/src/core/config/local_config_data.ts
+++ b/src/core/config/local_config_data.ts
@@ -15,7 +15,7 @@ export interface DeploymentStructure {
   namespace: NamespaceNameAsString;
 }
 
-export type ClusterContextMapping = Record<Cluster, Context>;
+export type clusterRefs = Record<Cluster, Context>;
 
 export type Deployments = Record<DeploymentName, DeploymentStructure>;
 
@@ -26,9 +26,6 @@ export interface LocalConfigData {
   // A list of all deployments
   deployments: Deployments;
 
-  // The currently selected deployment
-  currentDeploymentName: DeploymentName;
-
   // Every cluster must have a kubectl context associated to it, which is used to establish a connection.
-  clusterContextMapping: ClusterContextMapping;
+  clusterRefs: clusterRefs;
 }

--- a/src/core/config/remote/listr_config_tasks.ts
+++ b/src/core/config/remote/listr_config_tasks.ts
@@ -67,7 +67,7 @@ export class ListrRemoteConfig {
         const subTasks: SoloListrTask<Context>[] = [];
 
         for (const cluster of command.localConfig.deployments[ctx.config.deployment].clusters) {
-          const context = command.localConfig.clusterContextMapping?.[cluster];
+          const context = command.localConfig.clusterRefs?.[cluster];
           if (!context) continue;
 
           subTasks.push(ListrRemoteConfig.createRemoteConfig(command, cluster, context, ctx.config.namespace, argv));

--- a/src/core/config/remote/remote_config_manager.ts
+++ b/src/core/config/remote/remote_config_manager.ts
@@ -57,7 +57,7 @@ export class RemoteConfigManager {
   /* ---------- Getters ---------- */
 
   public get currentCluster(): Cluster {
-    return this.localConfig.currentDeploymentName as Cluster;
+    return this.k8.clusters().readCurrent() as Cluster;
   }
 
   /** @returns the components data wrapper cloned */
@@ -301,13 +301,15 @@ export class RemoteConfigManager {
   private setDefaultNamespaceIfNotSet(): void {
     if (this.configManager.hasFlag(flags.namespace)) return;
 
-    if (!this.localConfig?.currentDeploymentName) {
-      this.logger.error('Current deployment name is not set in local config', this.localConfig);
-      throw new SoloError('Current deployment name is not set in local config');
+    // TODO: Current quick fix for commands where namespace is not passed
+    const deploymentName = this.configManager.getFlag<DeploymentName>(flags.deployment);
+    const currentDeployment = this.localConfig.deployments[deploymentName];
+
+    if (!this.localConfig?.deployments[deploymentName]) {
+      this.logger.error('Selected deployment name is not set in local config', this.localConfig);
+      throw new SoloError('Selected deployment name is not set in local config');
     }
 
-    // TODO: Current quick fix for commands where namespace is not passed
-    const currentDeployment = this.localConfig.deployments[this.localConfig.currentDeploymentName];
     const namespace = currentDeployment.namespace;
 
     this.configManager.setFlag(flags.namespace, namespace);

--- a/src/core/error_messages.ts
+++ b/src/core/error_messages.ts
@@ -8,7 +8,7 @@ export const ErrorMessages = {
   LOCAL_CONFIG_GENERIC: 'Validation of local config failed',
   LOCAL_CONFIG_INVALID_EMAIL: 'Invalid email address provided',
   LOCAL_CONFIG_INVALID_DEPLOYMENTS_FORMAT: 'Wrong deployments format',
-  LOCAL_CONFIG_CONTEXT_CLUSTER_MAPPING_FORMAT: 'Wrong clusterContextMapping format',
+  LOCAL_CONFIG_CONTEXT_CLUSTER_MAPPING_FORMAT: 'Wrong clusterRefs format',
   INVALID_CONTEXT_FOR_CLUSTER: (context: string, cluster?: string) =>
     `Context ${context} is not valid for cluster ${cluster || ''}`,
   INVALID_CONTEXT_FOR_CLUSTER_DETAILED: (context: string, cluster?: string) =>

--- a/src/core/validator_decorators.ts
+++ b/src/core/validator_decorators.ts
@@ -36,10 +36,10 @@ export const IsDeployments = (validationOptions?: ValidationOptions) => {
   };
 };
 
-export const IsClusterContextMapping = (validationOptions?: ValidationOptions) => {
+export const IsclusterRefs = (validationOptions?: ValidationOptions) => {
   return function (object: any, propertyName: string) {
     registerDecorator({
-      name: 'IsClusterContextMapping',
+      name: 'IsclusterRefs',
       target: object.constructor,
       propertyName: propertyName,
       constraints: [],

--- a/src/core/validator_decorators.ts
+++ b/src/core/validator_decorators.ts
@@ -36,10 +36,10 @@ export const IsDeployments = (validationOptions?: ValidationOptions) => {
   };
 };
 
-export const IsclusterRefs = (validationOptions?: ValidationOptions) => {
+export const IsClusterRefs = (validationOptions?: ValidationOptions) => {
   return function (object: any, propertyName: string) {
     registerDecorator({
-      name: 'IsclusterRefs',
+      name: 'IsClusterRefs',
       target: object.constructor,
       propertyName: propertyName,
       constraints: [],

--- a/test/data/local-config.yaml
+++ b/test/data/local-config.yaml
@@ -4,7 +4,6 @@ deployments:
     clusters:
       - cluster-1
     namespace: solo-e2e
-currentDeploymentName: deployment
-clusterContextMapping:
+clusterRefs:
   cluster-1: context-1
   cluster-2: context-2

--- a/test/e2e/integration/core/remote_config_manager.test.ts
+++ b/test/e2e/integration/core/remote_config_manager.test.ts
@@ -69,7 +69,6 @@ e2eTestSuite(
 
         localConfig.userEmailAddress = email;
         localConfig.deployments = {[deploymentName]: {clusters: [`kind-${deploymentName}`], namespace: namespace.name}};
-        localConfig.currentDeploymentName = deploymentName;
 
         if (!fs.existsSync(testCacheDir)) {
           fs.mkdirSync(testCacheDir);

--- a/test/test_container.ts
+++ b/test/test_container.ts
@@ -23,7 +23,7 @@ export function resetForTest(namespace?: NamespaceNameAsString, cacheDir: string
   const parsedData = yaml.parse(localConfigData);
 
   if (namespace) {
-    parsedData.deployments[parsedData.currentDeploymentName].namespace = namespace;
+    parsedData.deployments['deployment'].namespace = namespace;
   }
 
   fs.writeFileSync(path.join(cacheDirectory, localConfigFile), yaml.stringify(parsedData));

--- a/test/test_util.ts
+++ b/test/test_util.ts
@@ -78,7 +78,7 @@ export function getDefaultArgv() {
     argv[f.name] = f.definition.defaultValue;
   }
 
-  const currentDeployment = testLocalConfigData.currentDeploymentName;
+  const currentDeployment = 'deployment';
   const cacheDir = getTestCacheDir();
   argv.cacheDir = cacheDir;
   argv[flags.cacheDir.name] = cacheDir;
@@ -471,8 +471,7 @@ export const testLocalConfigData = {
       namespace: 'solo-3',
     },
   },
-  currentDeploymentName: 'deployment',
-  clusterContextMapping: {
+  clusterRefs: {
     'cluster-1': 'context-1',
     'cluster-2': 'context-2',
   },

--- a/test/unit/commands/cluster.test.ts
+++ b/test/unit/commands/cluster.test.ts
@@ -277,15 +277,13 @@ describe('ClusterCommand unit tests', () => {
         command = await runUpdateLocalConfigTask(opts);
         localConfig = new LocalConfig(filePath);
 
-        expect(localConfig.currentDeploymentName).to.equal('deployment');
-        expect(localConfig.getCurrentDeployment().clusters).to.deep.equal(['cluster-2']);
-        expect(localConfig.clusterContextMapping).to.deep.equal({
+        expect(localConfig.clusterRefs).to.deep.equal({
           'cluster-1': 'context-1',
           'cluster-2': 'context-2',
         });
       });
 
-      xit('should update clusterContextMapping with provided context', async () => {
+      xit('should update clusterRefs with provided context', async () => {
         const remoteConfig = Object.assign({}, defaultRemoteConfig, {
           clusters: {
             'cluster-2': 'deployment',
@@ -295,15 +293,13 @@ describe('ClusterCommand unit tests', () => {
         command = await runUpdateLocalConfigTask(opts);
         localConfig = new LocalConfig(filePath);
 
-        expect(localConfig.currentDeploymentName).to.equal('deployment');
-        expect(localConfig.getCurrentDeployment().clusters).to.deep.equal(['cluster-2']);
-        expect(localConfig.clusterContextMapping).to.deep.equal({
+        expect(localConfig.clusterRefs).to.deep.equal({
           'cluster-1': 'context-1',
           'cluster-2': 'provided-context',
         });
       });
 
-      xit('should update multiple clusterContextMappings with provided contexts', async () => {
+      xit('should update multiple clusterRefss with provided contexts', async () => {
         const remoteConfig = Object.assign({}, defaultRemoteConfig, {
           clusters: {
             'cluster-2': 'deployment',
@@ -317,9 +313,7 @@ describe('ClusterCommand unit tests', () => {
         command = await runUpdateLocalConfigTask(opts);
         localConfig = new LocalConfig(filePath);
 
-        expect(localConfig.currentDeploymentName).to.equal('deployment');
-        expect(localConfig.getCurrentDeployment().clusters).to.deep.equal(['cluster-2', 'cluster-3', 'cluster-4']);
-        expect(localConfig.clusterContextMapping).to.deep.equal({
+        expect(localConfig.clusterRefs).to.deep.equal({
           'cluster-1': 'context-1',
           'cluster-2': 'provided-context-2',
           'cluster-3': 'provided-context-3',
@@ -327,7 +321,7 @@ describe('ClusterCommand unit tests', () => {
         });
       });
 
-      xit('should update multiple clusterContextMappings with default KubeConfig context if quiet=true', async () => {
+      xit('should update multiple clusterRefss with default KubeConfig context if quiet=true', async () => {
         const remoteConfig = Object.assign({}, defaultRemoteConfig, {
           clusters: {
             'cluster-2': 'deployment',
@@ -338,16 +332,14 @@ describe('ClusterCommand unit tests', () => {
         command = await runUpdateLocalConfigTask(opts);
         localConfig = new LocalConfig(filePath);
 
-        expect(localConfig.currentDeploymentName).to.equal('deployment');
-        expect(localConfig.getCurrentDeployment().clusters).to.deep.equal(['cluster-2', 'cluster-3']);
-        expect(localConfig.clusterContextMapping).to.deep.equal({
+        expect(localConfig.clusterRefs).to.deep.equal({
           'cluster-1': 'context-1',
           'cluster-2': 'context-2',
           'cluster-3': 'context-from-kubeConfig',
         });
       });
 
-      xit('should update multiple clusterContextMappings with prompted context no value was provided', async () => {
+      xit('should update multiple clusterRefss with prompted context no value was provided', async () => {
         const remoteConfig = Object.assign({}, defaultRemoteConfig, {
           clusters: {
             'cluster-2': 'deployment',
@@ -359,9 +351,7 @@ describe('ClusterCommand unit tests', () => {
         command = await runUpdateLocalConfigTask(opts);
         localConfig = new LocalConfig(filePath);
 
-        expect(localConfig.currentDeploymentName).to.equal('deployment');
-        expect(localConfig.getCurrentDeployment().clusters).to.deep.equal(['cluster-2', 'new-cluster']);
-        expect(localConfig.clusterContextMapping).to.deep.equal({
+        expect(localConfig.clusterRefs).to.deep.equal({
           'cluster-1': 'context-1',
           'cluster-2': 'context-2',
           'new-cluster': 'context-3', // prompted value

--- a/test/unit/commands/network.test.ts
+++ b/test/unit/commands/network.test.ts
@@ -24,8 +24,6 @@ import {GenesisNetworkDataConstructor} from '../../../src/core/genesis_network_m
 import {container} from 'tsyringe-neo';
 import {type SoloLogger} from '../../../src/core/logging.js';
 import {type K8} from '../../../src/core/kube/k8.js';
-import {PlatformInstaller} from '../../../src/core/platform_installer.js';
-import {CertificateManager} from '../../../src/core/certificate_manager.js';
 import {type DependencyManager} from '../../../src/core/dependency_managers/index.js';
 import {type LocalConfig} from '../../../src/core/config/local_config.js';
 import {resetForTest} from '../../test_container.js';
@@ -125,7 +123,7 @@ describe('NetworkCommand unit tests', () => {
       const networkCommand = new NetworkCommand(opts);
       await networkCommand.deploy(argv);
 
-      expect(opts.chartManager.install.args[0][0].name).to.equal(opts.localConfig.getCurrentDeployment().namespace);
+      expect(opts.chartManager.install.args[0][0].name).to.equal(constants.SOLO_TEST_CLUSTER);
       expect(opts.chartManager.install.args[0][1]).to.equal(constants.SOLO_DEPLOYMENT_CHART);
       expect(opts.chartManager.install.args[0][2]).to.equal(
         constants.SOLO_TESTING_CHART_URL + '/' + constants.SOLO_DEPLOYMENT_CHART,
@@ -139,7 +137,7 @@ describe('NetworkCommand unit tests', () => {
 
       const networkCommand = new NetworkCommand(opts);
       await networkCommand.deploy(argv);
-      expect(opts.chartManager.install.args[0][0].name).to.equal(opts.localConfig.getCurrentDeployment().namespace);
+      expect(opts.chartManager.install.args[0][0].name).to.equal(constants.SOLO_TEST_CLUSTER);
       expect(opts.chartManager.install.args[0][1]).to.equal(constants.SOLO_DEPLOYMENT_CHART);
       expect(opts.chartManager.install.args[0][2]).to.equal(
         path.join(ROOT_DIR, 'test-directory', constants.SOLO_DEPLOYMENT_CHART),

--- a/test/unit/core/local_config.test.ts
+++ b/test/unit/core/local_config.test.ts
@@ -40,8 +40,7 @@ describe('LocalConfig', () => {
   it('should load config from file', async () => {
     expect(localConfig.userEmailAddress).to.eq(config.userEmailAddress);
     expect(localConfig.deployments).to.deep.eq(config.deployments);
-    expect(localConfig.currentDeploymentName).to.eq(config.currentDeploymentName);
-    expect(localConfig.clusterContextMapping).to.deep.eq(config.clusterContextMapping);
+    expect(localConfig.clusterRefs).to.deep.eq(config.clusterRefs);
   });
 
   it('should set user email address', async () => {
@@ -111,64 +110,31 @@ describe('LocalConfig', () => {
     }
   });
 
-  it('should set clusterContextMapping', async () => {
+  it('should set clusterRefs', async () => {
     const newClusterMappings = {
       'cluster-3': 'context-3',
       'cluster-4': 'context-4',
     };
-    localConfig.setClusterContextMapping(newClusterMappings);
-    expect(localConfig.clusterContextMapping).to.eq(newClusterMappings);
+    localConfig.setclusterRefs(newClusterMappings);
+    expect(localConfig.clusterRefs).to.eq(newClusterMappings);
 
     await localConfig.write();
     const newConfig = new LocalConfig(filePath, testLogger, configManager);
-    expect(newConfig.clusterContextMapping).to.deep.eq(newClusterMappings);
+    expect(newConfig.clusterRefs).to.deep.eq(newClusterMappings);
   });
 
-  it('should not set invalid clusterContextMapping', async () => {
-    const invalidClusterContextMappings = {
+  it('should not set invalid clusterRefs', async () => {
+    const invalidclusterRefss = {
       'cluster-3': 'context-3',
       'invalid-cluster': 5,
     };
 
     try {
       // @ts-ignore
-      localConfig.setContextMappings(invalidClusterContextMappings);
+      localConfig.setContextMappings(invalidclusterRefss);
       expect.fail('expected an error to be thrown');
     } catch (error) {
       expect(error).to.be.instanceOf(TypeError);
-    }
-  });
-
-  it('should get current deployment', async () => {
-    expect(localConfig.getCurrentDeployment()).to.deep.eq(config.deployments[config.currentDeploymentName]);
-  });
-
-  it('should set current deployment', async () => {
-    const newCurrentDeployment = 'deployment-2';
-    localConfig.setCurrentDeployment(newCurrentDeployment);
-
-    expect(localConfig.currentDeploymentName).to.eq(newCurrentDeployment);
-
-    await localConfig.write();
-    const newConfig = new LocalConfig(filePath);
-    expect(newConfig.currentDeploymentName).to.eq(newCurrentDeployment);
-  });
-
-  it('should not set invalid or non-existent current deployment', async () => {
-    const invalidCurrentDeploymentName = 5;
-    try {
-      localConfig.setCurrentDeployment(invalidCurrentDeploymentName as any);
-      expect.fail('expected an error to be thrown');
-    } catch (error) {
-      expect(error).to.be.instanceOf(SoloError);
-    }
-
-    const nonExistentCurrentDeploymentName = 'non-existent-deployment';
-    try {
-      localConfig.setCurrentDeployment(nonExistentCurrentDeploymentName);
-      expect.fail('expected an error to be thrown');
-    } catch (error) {
-      expect(error).to.be.instanceOf(SoloError);
     }
   });
 
@@ -217,19 +183,11 @@ describe('LocalConfig', () => {
     expectFailedValidation(ErrorMessages.LOCAL_CONFIG_INVALID_DEPLOYMENTS_FORMAT);
   });
 
-  it('should throw a validation error if clusterContextMapping format is not correct', async () => {
-    await fs.promises.writeFile(filePath, stringify({...config, clusterContextMapping: 'foo'}));
+  it('should throw a validation error if clusterRefs format is not correct', async () => {
+    await fs.promises.writeFile(filePath, stringify({...config, clusterRefs: 'foo'}));
     expectFailedValidation(ErrorMessages.LOCAL_CONFIG_CONTEXT_CLUSTER_MAPPING_FORMAT);
 
-    await fs.promises.writeFile(filePath, stringify({...config, clusterContextMapping: ['foo', 5]}));
+    await fs.promises.writeFile(filePath, stringify({...config, clusterRefs: ['foo', 5]}));
     expectFailedValidation(ErrorMessages.LOCAL_CONFIG_CONTEXT_CLUSTER_MAPPING_FORMAT);
-  });
-
-  it('should throw a validation error if currentDeploymentName format is not correct', async () => {
-    await fs.promises.writeFile(filePath, stringify({...config, currentDeploymentName: 5}));
-    expectFailedValidation(ErrorMessages.LOCAL_CONFIG_CURRENT_DEPLOYMENT_DOES_NOT_EXIST);
-
-    await fs.promises.writeFile(filePath, stringify({...config, currentDeploymentName: ['foo', 'bar']}));
-    expectFailedValidation(ErrorMessages.LOCAL_CONFIG_CURRENT_DEPLOYMENT_DOES_NOT_EXIST);
   });
 });

--- a/test/unit/core/local_config.test.ts
+++ b/test/unit/core/local_config.test.ts
@@ -115,7 +115,7 @@ describe('LocalConfig', () => {
       'cluster-3': 'context-3',
       'cluster-4': 'context-4',
     };
-    localConfig.setclusterRefs(newClusterMappings);
+    localConfig.setClusterRefs(newClusterMappings);
     expect(localConfig.clusterRefs).to.eq(newClusterMappings);
 
     await localConfig.write();


### PR DESCRIPTION
## Description


- Removes the `currentDeploymentName` from `LocalConfig`
- Renames `clusterContextMapping` to `clusterRefs`

### Related Issues

* Closes #1346 
