### PR TITLE
ci: set unique e2e job names to prevent failure and set e2e parallel jobs to 5

### DIFF
--- a/.github/workflows/flow-build-application.yaml
+++ b/.github/workflows/flow-build-application.yaml
@@ -65,7 +65,7 @@ jobs:
       custom-job-label: Standard
 
   e2e-tests:
-    name: E2E Tests
+    name: E2E Tests (${{ matrix.name }})
     if: ${{ github.event_name == 'push' || github.event.inputs.enable-e2e-tests == 'true' }}
     uses: ./.github/workflows/zxc-e2e-test.yaml
     needs:
@@ -92,7 +92,7 @@ jobs:
           - { name: "Node Upgrade", npm-test-script: "test-${{ needs.env-vars.outputs.e2e-node-upgrade-test-subdir }}", coverage-subdirectory: "${{ needs.env-vars.outputs.e2e-node-upgrade-test-subdir }}", coverage-report-name: "${{ needs.env-vars.outputs.e2e-node-upgrade-coverage-report }}", cluster-name: "${{ needs.env-vars.outputs.e2e-node-upgrade-test-subdir }}-${{ github.run_id }}-${{ github.run_attempt }}" }
           - { name: "Node Upgrade - Separate commands", npm-test-script: "test-${{ needs.env-vars.outputs.e2e-node-upgrade-separate-commands-test-subdir }}", coverage-subdirectory: "${{ needs.env-vars.outputs.e2e-node-upgrade-separate-commands-test-subdir }}", coverage-report-name: "${{ needs.env-vars.outputs.e2e-node-upgrade-separate-commands-coverage-report }}", cluster-name: "${{ needs.env-vars.outputs.e2e-node-upgrade-separate-commands-test-subdir }}-${{ github.run_id }}-${{ github.run_attempt }}" }
           - { name: "Relay", npm-test-script: "test-${{ needs.env-vars.outputs.e2e-relay-test-subdir }}", coverage-subdirectory: "${{ needs.env-vars.outputs.e2e-relay-test-subdir }}", coverage-report-name: "${{ needs.env-vars.outputs.e2e-relay-coverage-report }}", cluster-name: "${{ needs.env-vars.outputs.e2e-relay-test-subdir }}-${{ github.run_id }}-${{ github.run_attempt }}" }
-      max-parallel: 3
+      max-parallel: 5
     with:
       custom-job-label: ${{ matrix.e2e-test-type.name }}
       npm-test-script: ${{ matrix.e2e-test-type.npm-test-script }}

--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -64,7 +64,7 @@ jobs:
       GH_ACCESS_PASSPHRASE: ${{ secrets.GH_ACCESS_PASSPHRASE }}
 
   e2e-tests:
-    name: E2E Tests
+    name: E2E Tests (${{ matrix.name }})
     if: ${{ !cancelled() && always() }}
     uses: ./.github/workflows/zxc-e2e-test.yaml
     needs:
@@ -91,7 +91,7 @@ jobs:
           - { name: "Node Upgrade", npm-test-script: "test-${{ needs.env-vars.outputs.e2e-node-upgrade-test-subdir }}", coverage-subdirectory: "${{ needs.env-vars.outputs.e2e-node-upgrade-test-subdir }}", coverage-report-name: "${{ needs.env-vars.outputs.e2e-node-upgrade-coverage-report }}", cluster-name: "${{ needs.env-vars.outputs.e2e-node-upgrade-test-subdir }}-${{ github.run_id }}-${{ github.run_attempt }}" }
           - { name: "Node Upgrade - Separate commands", npm-test-script: "test-${{ needs.env-vars.outputs.e2e-node-upgrade-separate-commands-test-subdir }}", coverage-subdirectory: "${{ needs.env-vars.outputs.e2e-node-upgrade-separate-commands-test-subdir }}", coverage-report-name: "${{ needs.env-vars.outputs.e2e-node-upgrade-separate-commands-coverage-report }}", cluster-name: "${{ needs.env-vars.outputs.e2e-node-upgrade-separate-commands-test-subdir }}-${{ github.run_id }}-${{ github.run_attempt }}" }
           - { name: "Relay", npm-test-script: "test-${{ needs.env-vars.outputs.e2e-relay-test-subdir }}", coverage-subdirectory: "${{ needs.env-vars.outputs.e2e-relay-test-subdir }}", coverage-report-name: "${{ needs.env-vars.outputs.e2e-relay-coverage-report }}", cluster-name: "${{ needs.env-vars.outputs.e2e-relay-test-subdir }}-${{ github.run_id }}-${{ github.run_attempt }}" }
-      max-parallel: 3
+      max-parallel: 5
     with:
       custom-job-label: ${{ matrix.e2e-test-type.name }}
       npm-test-script: ${{ matrix.e2e-test-type.npm-test-script }}


### PR DESCRIPTION
## Description

This pull request changes the following:

* set unique e2e job names to prevent failure
* set e2e parallel jobs to 5

### Related Issues

* Closes #
