### PR TITLE
fix: update default solo helm chart version

### DIFF
--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -64,7 +64,7 @@ jobs:
       GH_ACCESS_PASSPHRASE: ${{ secrets.GH_ACCESS_PASSPHRASE }}
 
   e2e-tests:
-    name: E2E Tests (${{ matrix.name }})
+    name: E2E Tests (${{ matrix.e2e-test-type.name }})
     if: ${{ !cancelled() && always() }}
     uses: ./.github/workflows/zxc-e2e-test.yaml
     needs:

--- a/.github/workflows/zxc-unit-test.yaml
+++ b/.github/workflows/zxc-unit-test.yaml
@@ -54,7 +54,7 @@ jobs:
         os:
           - windows-2022
           - solo-linux-medium
-    name: "(${{ join(matrix.os, ', ') }})"
+    name: "${{ matrix.os }}"
     runs-on: ${{ matrix.os }}
     steps:
       - name: Harden Runner

--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -329,8 +329,8 @@ export class NetworkCommand extends BaseCommand {
     }
 
     if (config.loadBalancerEnabled) {
-      valuesArg += ' --set "defaults.haproxy.serviceType=LoadBalancer"';
-      valuesArg += ' --set "defaults.envoyProxy.serviceType=LoadBalancer"';
+      valuesArg += ' --set "defaults.haproxy.service.type=LoadBalancer"';
+      valuesArg += ' --set "defaults.envoyProxy.service.type=LoadBalancer"';
     }
 
     if (config.valuesFile) {

--- a/version.ts
+++ b/version.ts
@@ -7,7 +7,7 @@
  */
 
 export const HELM_VERSION = 'v3.14.2';
-export const SOLO_CHART_VERSION = '0.43.1';
+export const SOLO_CHART_VERSION = '0.44.0';
 export const HEDERA_PLATFORM_VERSION = 'v0.59.0-main.x5322bdc';
 export const LOCAL_HEDERA_PLATFORM_VERSION = 'v0.58.3';
 export const MIRROR_NODE_VERSION = 'v0.122';


### PR DESCRIPTION
## Description

This pull request changes the following:

* Updates the Solo helm chart version to `0.44.0` (not yet released, so this is expected to initially fail testing)
* Adapts the impacted helm `--set` statements due to the proposed change
* Fixes a small issue in the CI pipeline matrix naming scheme

### Related Issues

* Closes #1376 
