### PR TITLE
feat: add support for multi-cluster testing via KinD

### DIFF
--- a/.github/workflows/flow-gcs-test.yaml
+++ b/.github/workflows/flow-gcs-test.yaml
@@ -89,9 +89,9 @@ jobs:
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
           install_only: true
-          node_image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
-          version: v0.21.0
-          kubectl_version: v1.28.6
+          node_image: kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30
+          version: v0.26.0
+          kubectl_version: v1.31.4
           verbosity: 3
           wait: 120s
 

--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -91,7 +91,7 @@ jobs:
           - { name: "Node Delete - Separate commands", npm-test-script: "test-${{ needs.env-vars.outputs.e2e-node-delete-separate-commands-test-subdir }}", coverage-subdirectory: "${{ needs.env-vars.outputs.e2e-node-delete-separate-commands-test-subdir }}", coverage-report-name: "${{ needs.env-vars.outputs.e2e-node-delete-separate-commands-coverage-report }}", cluster-name: "${{ needs.env-vars.outputs.e2e-node-delete-separate-commands-test-subdir }}-${{ github.run_id }}-${{ github.run_attempt }}" }
           - { name: "Node Add - Separate commands", npm-test-script: "test-${{ needs.env-vars.outputs.e2e-node-add-separate-commands-test-subdir }}", coverage-subdirectory: "${{ needs.env-vars.outputs.e2e-node-add-separate-commands-test-subdir }}", coverage-report-name: "${{ needs.env-vars.outputs.e2e-node-add-separate-commands-coverage-report }}", cluster-name: "${{ needs.env-vars.outputs.e2e-node-add-separate-commands-test-subdir }}-${{ github.run_id }}-${{ github.run_attempt }}" }
           - { name: "Node Upgrade - Separate commands", npm-test-script: "test-${{ needs.env-vars.outputs.e2e-node-upgrade-separate-commands-test-subdir }}", coverage-subdirectory: "${{ needs.env-vars.outputs.e2e-node-upgrade-separate-commands-test-subdir }}", coverage-report-name: "${{ needs.env-vars.outputs.e2e-node-upgrade-separate-commands-coverage-report }}", cluster-name: "${{ needs.env-vars.outputs.e2e-node-upgrade-separate-commands-test-subdir }}-${{ github.run_id }}-${{ github.run_attempt }}" }
-      max-parallel: 3
+      max-parallel: 5
     with:
       custom-job-label: ${{ matrix.e2e-test-type.name }}
       npm-test-script: ${{ matrix.e2e-test-type.npm-test-script }}

--- a/.github/workflows/flow-task-test.yaml
+++ b/.github/workflows/flow-task-test.yaml
@@ -67,9 +67,9 @@ jobs:
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
           install_only: true
-          node_image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
-          version: v0.21.0
-          kubectl_version: v1.28.6
+          node_image: kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30
+          version: v0.26.0
+          kubectl_version: v1.31.4
           verbosity: 3
           wait: 120s
 

--- a/.github/workflows/script/solo_smoke_test.sh
+++ b/.github/workflows/script/solo_smoke_test.sh
@@ -89,10 +89,17 @@ function start_sdk_test ()
 function check_monitor_log()
 {
   # get the logs of mirror-monitor
-  kubectl get pods -n solo-e2e | grep mirror-monitor | awk '{print $1}' | xargs kubectl logs -n solo-e2e > mirror-monitor.log
+  kubectl get pods -n solo-e2e | grep mirror-monitor | awk '{print $1}' | xargs -IPOD kubectl logs -n solo-e2e POD > mirror-monitor.log
 
   if grep -q "ERROR" mirror-monitor.log; then
     echo "mirror-monitor.log contains ERROR"
+
+    echo "------- BEGIN LOG DUMP -------"
+    echo
+    cat mirror-monitor.log
+    echo
+    echo "------- END LOG DUMP -------"
+
     exit 1
   fi
 
@@ -118,7 +125,7 @@ function check_importer_log()
     cat mirror-importer.log
     echo
     echo "------- END LOG DUMP -------"
-    
+
     exit 1
   fi
 }

--- a/.github/workflows/script/solo_smoke_test.sh
+++ b/.github/workflows/script/solo_smoke_test.sh
@@ -109,9 +109,16 @@ function check_monitor_log()
 
 function check_importer_log()
 {
-  kubectl get pods -n solo-e2e | grep mirror-importer | awk '{print $1}' | xargs kubectl logs -n solo-e2e > mirror-importer.log
+  kubectl get pods -n solo-e2e | grep mirror-importer | awk '{print $1}' | xargs -IPOD kubectl logs -n solo-e2e POD > mirror-importer.log
   if grep -q "ERROR" mirror-importer.log; then
     echo "mirror-importer.log contains ERROR"
+
+    echo "------- BEGIN LOG DUMP -------"
+    echo
+    cat mirror-importer.log
+    echo
+    echo "------- END LOG DUMP -------"
+    
     exit 1
   fi
 }

--- a/.github/workflows/script/write_diag_script.sh
+++ b/.github/workflows/script/write_diag_script.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+SCRIPT_PATH=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+readonly SCRIPT_PATH
+
+readonly DIAG_SCRIPT_PATH="${HOME}/diagnostics.sh"
+
+cat <<EOF >"${DIAG_SCRIPT_PATH}"
+#!/usr/bin/env bash
+set -eo pipefail
+export PATH="${PATH}"
+export KUBECONFIG="${KUBECONFIG}"
+export GITHUB_WORKSPACE="${GITHUB_WORKSPACE}"
+export JAVA_HOME="${JAVA_HOME}"
+cd "${HOME}"
+
+# Install the necessary tools
+wget https://github.com/derailed/k9s/releases/download/v0.32.7/k9s_linux_amd64.deb
+apt update
+apt install -y ./k9s_linux_amd64.deb
+rm -f ./k9s_linux_amd64.deb
+
+EOF
+
+sudo chmod +x "${DIAG_SCRIPT_PATH}"
+echo "Wrote diagnostics script: ${DIAG_SCRIPT_PATH}"

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -69,7 +69,7 @@ permissions:
 
 env:
   #CG_EXEC: export R_UID=$(id -u); CGROUP_LOGLEVEL=DEBUG cgexec -g cpu,memory:user.slice/user-${R_UID}.slice/user@${R_UID}.service/e2e-${{ github.run_id }} --sticky ionice -c 2 -n 2 nice -n 19
-  CG_EXEC: ""
+  CG_EXEC: "ionice -c 2 -n 2 nice -n 19"
 
 jobs:
   e2e-test:
@@ -182,12 +182,16 @@ jobs:
         run: | 
           npm link
           echo "SOLO_TEST_CLUSTER=${{ inputs.cluster-name }}"
-          ${{ env.CG_EXEC }} SOLO_TEST_CLUSTER=${{ inputs.cluster-name }} ./test/e2e/setup-e2e.sh
+          ${{ env.CG_EXEC }} SOLO_TEST_CLUSTER=${{ inputs.cluster-name }} ./test/e2e/dual-cluster/setup-dual-e2e.sh
 
       - name: Run E2E Tests
         run: |
           echo "SOLO_TEST_CLUSTER=${{ inputs.cluster-name }}"
           ${{ env.CG_EXEC }} SOLO_TEST_CLUSTER=${{ inputs.cluster-name }} npm run ${{ inputs.npm-test-script }}
+
+      - name: Sleep on Failure
+        if: ${{ failure() }}
+        run: sleep 3600
 
       - name: Upload E2E Logs to GitHub
         if: ${{ !cancelled() }}

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -139,9 +139,9 @@ jobs:
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
           install_only: true
-          node_image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
-          version: v0.21.0
-          kubectl_version: v1.28.6
+          node_image: kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30
+          version: v0.26.0
+          kubectl_version: v1.31.4
           verbosity: 3
           wait: 120s
 
@@ -153,7 +153,7 @@ jobs:
         run: npm run build
 
       - name: Pull Kind Docker Image
-        run: docker image pull kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
+        run: docker image pull kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30
 
       - name: Setup Java
         if: ${{ runner.os == 'linux' && (inputs.npm-test-script == 'test-e2e-node-local-hedera' || inputs.npm-test-script == 'test-e2e-node-local-ptt' || inputs.npm-test-script == 'test-e2e-node-add-local') && !cancelled() && !failure() }}

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -70,6 +70,7 @@ permissions:
 env:
   #CG_EXEC: export R_UID=$(id -u); CGROUP_LOGLEVEL=DEBUG cgexec -g cpu,memory:user.slice/user-${R_UID}.slice/user@${R_UID}.service/e2e-${{ github.run_id }} --sticky ionice -c 2 -n 2 nice -n 19
   CG_EXEC: "ionice -c 2 -n 2 nice -n 19"
+  SOLO_CLUSTER_DUALITY: 1
 
 jobs:
   e2e-test:
@@ -175,6 +176,13 @@ jobs:
         with:
           cache-read-only: false
 
+      - name: Create Diagnostic Script
+        env:
+          WRITE_DIAG_SCRIPT: ${{ github.workspace }}/.github/workflows/script/write_diag_script.sh
+        run: |
+          sudo chmod +x "${WRITE_DIAG_SCRIPT}"
+          ${WRITE_DIAG_SCRIPT}
+
       - name: Build Hedera code locally
         if: ${{ runner.os == 'linux' && (inputs.npm-test-script == 'test-e2e-node-local-hedera' || inputs.npm-test-script == 'test-e2e-node-local-ptt' || inputs.npm-test-script == 'test-e2e-node-add-local') && !cancelled() && !failure() }}
         run: |
@@ -196,9 +204,9 @@ jobs:
           echo "SOLO_TEST_CLUSTER=${{ inputs.cluster-name }}"
           SOLO_TEST_CLUSTER=${{ inputs.cluster-name }} ${{ env.CG_EXEC }} npm run ${{ inputs.npm-test-script }}
 
-      - name: Sleep on Failure
-        if: ${{ failure() }}
-        run: sleep 3600
+#      - name: Sleep on Failure
+#        if: ${{ failure() }}
+#        run: sleep 3600
 
       - name: Upload E2E Logs to GitHub
         if: ${{ !cancelled() }}

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -147,6 +147,11 @@ jobs:
           verbosity: 3
           wait: 120s
 
+      - name: Setup Helm
+        uses: azure/setup-helm@fe7b79cd5ee1e45176fcad797de68ecaf3ca4814 # v4.2.0
+        with:
+          version: "v3.17.1" # helm version
+
       - name: Install Dependencies
         id: npm-deps
         run: npm ci

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -132,8 +132,10 @@ jobs:
 
       - name: Install wget
         run: |
-          sudo apt-get update
-          sudo apt-get install -y wget
+          if ! command -v wget >/dev/null 2>&1; then
+            sudo apt-get update
+            sudo apt-get install -y wget
+          fi
 
       - name: Setup Kind
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
@@ -182,12 +184,12 @@ jobs:
         run: | 
           npm link
           echo "SOLO_TEST_CLUSTER=${{ inputs.cluster-name }}"
-          ${{ env.CG_EXEC }} SOLO_TEST_CLUSTER=${{ inputs.cluster-name }} ./test/e2e/dual-cluster/setup-dual-e2e.sh
+          SOLO_TEST_CLUSTER=${{ inputs.cluster-name }} ${{ env.CG_EXEC }} ./test/e2e/dual-cluster/setup-dual-e2e.sh
 
       - name: Run E2E Tests
         run: |
           echo "SOLO_TEST_CLUSTER=${{ inputs.cluster-name }}"
-          ${{ env.CG_EXEC }} SOLO_TEST_CLUSTER=${{ inputs.cluster-name }} npm run ${{ inputs.npm-test-script }}
+          SOLO_TEST_CLUSTER=${{ inputs.cluster-name }} ${{ env.CG_EXEC }} npm run ${{ inputs.npm-test-script }}
 
       - name: Sleep on Failure
         if: ${{ failure() }}

--- a/.github/workflows/zxc-update-readme.yaml
+++ b/.github/workflows/zxc-update-readme.yaml
@@ -83,9 +83,9 @@ jobs:
         uses: helm/kind-action@a1b0e391336a6ee6713a0583f8c6240d70863de3 # v1.12.0
         with:
           install_only: true
-          node_image: kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72
-          version: v0.21.0
-          kubectl_version: v1.28.6
+          node_image: kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30
+          version: v0.26.0
+          kubectl_version: v1.31.4
           verbosity: 3
           wait: 120s
 

--- a/test/e2e/dual-cluster/diagnostics/cluster/deploy.sh
+++ b/test/e2e/dual-cluster/diagnostics/cluster/deploy.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+SCRIPT_PATH=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+readonly SCRIPT_PATH
+
+kubectl apply -f "${SCRIPT_PATH}/manifest.yaml"

--- a/test/e2e/dual-cluster/diagnostics/cluster/manifest.yaml
+++ b/test/e2e/dual-cluster/diagnostics/cluster/manifest.yaml
@@ -1,0 +1,101 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: cluster-diagnostics
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-diagnostics-cm
+  namespace: cluster-diagnostics
+data:
+  entrypoint.sh: |
+    #!/usr/bin/env bash
+    set -eo pipefail
+    
+    uid="$(id -u)"
+    
+    SUDO=""
+    if [[ "${uid}" -ne 0 ]]; then
+      if ! command -v sudo >/dev/null 2>&1; then
+        echo "FATAL: sudo is required to run this script as a non-root user"
+        exit 1
+      fi
+      
+      SUDO="$(command -v sudo)"
+    fi
+    
+    export DEBIAN_FRONTEND=noninteractive
+    
+    ${SUDO} apt update
+    ${SUDO} apt upgrade -y
+    ${SUDO} apt install -y curl ca-certificates jq netcat-traditional \
+      dnsutils iperf3 iputils-ping iproute2 tcpdump iputils-tracepath socat
+    
+    [[ -d /app ]] || ${SUDO} mkdir -p /app
+    
+    ${SUDO} iperf3 -p 8081 -s --timestamps &
+    ${SUDO} socat -lh -lu -v TCP4-LISTEN:8080,fork EXEC:cat & 
+    exec sleep infinity
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: cluster-diagnostics-svc
+  namespace: cluster-diagnostics
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-internal: "true"
+    service.beta.kubernetes.io/aws-load-balancer-type: "nlb"
+    service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
+    networking.gke.io/load-balancer-type: "Internal"
+spec:
+  selector:
+    app: cluster-diagnostics
+  type: LoadBalancer
+  externalTrafficPolicy: Cluster
+  internalTrafficPolicy: Cluster
+  ports:
+    - name: socat
+      port: 8080
+      targetPort: 8080
+      protocol: TCP
+    - name: iperf3
+      port: 8081
+      targetPort: 8081
+      protocol: TCP
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: cluster-diagnostics
+  namespace: cluster-diagnostics
+spec:
+    replicas: 1
+    selector:
+      matchLabels:
+        app: cluster-diagnostics
+    template:
+        metadata:
+          labels:
+            app: cluster-diagnostics
+        spec:
+          containers:
+            - name: cluster-diagnostics
+              image: ubuntu:noble
+              command: ["/bin/bash", "/app/entrypoint.sh"]
+              volumeMounts:
+                - name: entrypoint
+                  mountPath: /app/entrypoint.sh
+                  subPath: entrypoint.sh
+              ports:
+                - containerPort: 8080
+                  name: socat
+                  protocol: TCP
+                - containerPort: 8081
+                  name: iperf3
+                  protocol: TCP
+          volumes:
+            - name: entrypoint
+              configMap:
+                name: cluster-diagnostics-cm

--- a/test/e2e/dual-cluster/kind-cluster-1.yaml
+++ b/test/e2e/dual-cluster/kind-cluster-1.yaml
@@ -1,0 +1,18 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: ClusterConfiguration
+        networking:
+          dnsDomain: "cluster1.local"
+networking:
+#  apiServerAddress: "172.19.0.2"
+#  apiServerPort: 6443
+  podSubnet: "10.10.0.0/16"
+  serviceSubnet: "10.20.0.0/16"
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+      endpoint = ["https://hub.mirror.docker.lat.ope.eng.hashgraph.io"]

--- a/test/e2e/dual-cluster/kind-cluster-1.yaml
+++ b/test/e2e/dual-cluster/kind-cluster-1.yaml
@@ -6,7 +6,7 @@ nodes:
       - |
         kind: ClusterConfiguration
         networking:
-          dnsDomain: "cluster1.local"
+          dnsDomain: "cluster.local"
 networking:
 #  apiServerAddress: "172.19.0.2"
 #  apiServerPort: 6443

--- a/test/e2e/dual-cluster/kind-cluster-2.yaml
+++ b/test/e2e/dual-cluster/kind-cluster-2.yaml
@@ -1,0 +1,18 @@
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    kubeadmConfigPatches:
+      - |
+        kind: ClusterConfiguration
+        networking:
+          dnsDomain: "cluster2.local"
+networking:
+#  apiServerAddress: "172.19.0.3"
+#  apiServerPort: 6443
+  podSubnet: "10.30.0.0/16"
+  serviceSubnet: "10.40.0.0/16"
+containerdConfigPatches:
+  - |-
+    [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
+      endpoint = ["https://hub.mirror.docker.lat.ope.eng.hashgraph.io"]

--- a/test/e2e/dual-cluster/kind-cluster-2.yaml
+++ b/test/e2e/dual-cluster/kind-cluster-2.yaml
@@ -6,7 +6,7 @@ nodes:
       - |
         kind: ClusterConfiguration
         networking:
-          dnsDomain: "cluster2.local"
+          dnsDomain: "cluster.local"
 networking:
 #  apiServerAddress: "172.19.0.3"
 #  apiServerPort: 6443

--- a/test/e2e/dual-cluster/metallb-cluster-1.yaml
+++ b/test/e2e/dual-cluster/metallb-cluster-1.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: local
+  namespace: metallb-system
+spec:
+  addresses:
+    - 172.19.1.0/24
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: local
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+    - local
+  nodeSelectors:
+    - matchLabels:
+        kubernetes.io/os: linux
+

--- a/test/e2e/dual-cluster/metallb-cluster-2.yaml
+++ b/test/e2e/dual-cluster/metallb-cluster-2.yaml
@@ -1,0 +1,22 @@
+---
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  name: local
+  namespace: metallb-system
+spec:
+  addresses:
+    - 172.19.2.0/24
+---
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: local
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+    - local
+  nodeSelectors:
+    - matchLabels:
+        kubernetes.io/os: linux
+

--- a/test/e2e/dual-cluster/setup-dual-e2e.sh
+++ b/test/e2e/dual-cluster/setup-dual-e2e.sh
@@ -39,7 +39,7 @@ for i in {1..2}; do
   fi
 
   helm upgrade --install metallb metallb/metallb \
-    --namespace metallb-system --create-namespace \
+    --namespace metallb-system --create-namespace --atomic --wait \
     --set speaker.frr.enabled=true
 
   kubectl apply -f "${SCRIPT_PATH}/metallb-cluster-${i}.yaml"

--- a/test/e2e/dual-cluster/setup-dual-e2e.sh
+++ b/test/e2e/dual-cluster/setup-dual-e2e.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+##### Setup Environment #####
+SCRIPT_PATH=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+readonly SCRIPT_PATH
+
+readonly CLUSTER_DIAGNOSTICS_PATH="${SCRIPT_PATH}/diagnostics/cluster"
+readonly KIND_IMAGE="kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30"
+
+echo "SOLO_CHARTS_DIR: ${SOLO_CHARTS_DIR}"
+export PATH=${PATH}:~/.solo/bin
+
+if [[ -n "${SOLO_TEST_CLUSTER}" ]]; then
+  SOLO_CLUSTER_NAME="${SOLO_TEST_CLUSTER}"
+elif [[ -z "${SOLO_CLUSTER_NAME}" ]]; then
+  SOLO_CLUSTER_NAME="solo-e2e"
+fi
+
+for i in {1..2}; do
+  kind delete cluster -n "${SOLO_CLUSTER_NAME}-c${i}" || true
+done
+
+docker network rm kind
+docker network create kind --scope local --subnet 172.19.0.0/16 --driver bridge
+
+# Setup Helm Repos
+helm repo add metrics-server https://kubernetes-sigs.github.io/metrics-server/
+helm repo add metallb https://metallb.github.io/metallb
+
+for i in {1..2}; do
+  kind create cluster -n "${SOLO_CLUSTER_NAME}-c${i}" --image "${KIND_IMAGE}" --config "${SCRIPT_PATH}/kind-cluster-${i}.yaml" || exit 1
+  helm upgrade --install metrics-server metrics-server/metrics-server \
+    --namespace kube-system --wait --atomic \
+    --set "args[0]=--kubelet-insecure-tls"
+
+  helm upgrade --install metallb metallb/metallb \
+    --namespace metallb-system --create-namespace --wait --atomic \
+    --set speaker.frr.enabled=true
+
+  kubectl apply -f "${SCRIPT_PATH}/metallb-cluster-${i}.yaml"
+
+  "${CLUSTER_DIAGNOSTICS_PATH}"/deploy.sh
+done
+
+# **********************************************************************************************************************
+# Warm up the cluster
+# **********************************************************************************************************************
+# source test/data/warmup-cluster.sh; download_images; load_images
+
+# **********************************************************************************************************************
+# Init and deploy a network for e2e tests in (test/e2e/core)
+# -d ${SOLO_CHARTS_DIR} is optional, if you want to use a local chart, it will be ignored if not set
+# **********************************************************************************************************************
+# SOLO_CLUSTER_SETUP_NAMESPACE=solo-setup
+# npm run build
+#npm run solo -- init || exit 1 # cache args for subsequent commands
+#npm run solo -- cluster setup -s "${SOLO_CLUSTER_SETUP_NAMESPACE}" || exit 1
+#helm list --all-namespaces
+#sleep 10 # give time for solo-setup to finish deploying

--- a/test/e2e/setup-e2e.sh
+++ b/test/e2e/setup-e2e.sh
@@ -5,7 +5,7 @@ SCRIPT_PATH=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 readonly SCRIPT_PATH
 
 readonly KIND_CONFIG_FILE="${SCRIPT_PATH}/kind-cluster.yaml"
-readonly KIND_IMAGE="kindest/node:v1.27.3@sha256:3966ac761ae0136263ffdb6cfd4db23ef8a83cba8a463690e98317add2c9ba72"
+readonly KIND_IMAGE="kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30"
 echo "SOLO_CHARTS_DIR: ${SOLO_CHARTS_DIR}"
 export PATH=${PATH}:~/.solo/bin
 

--- a/version.ts
+++ b/version.ts
@@ -8,7 +8,7 @@
 
 export const HELM_VERSION = 'v3.14.2';
 export const SOLO_CHART_VERSION = '0.44.0';
-export const HEDERA_PLATFORM_VERSION = 'v0.59.0-main.x5322bdc';
+export const HEDERA_PLATFORM_VERSION = 'v0.58.5';
 export const LOCAL_HEDERA_PLATFORM_VERSION = 'v0.58.3';
 export const MIRROR_NODE_VERSION = 'v0.122';
 export const HEDERA_EXPLORER_VERSION = '24.12.0';


### PR DESCRIPTION
## Description

This pull request changes the following:

* Adds the necessary tooling and scripts to support local multi-cluster testing
   * Does not enable multi-cluster tests in the CI pipelines 
* Must use load balancers support in Solo with this dual cluster configuration 
* Updates CI pipelines to use the new `setup-dual-e2e.sh` script with a `SOLO_CLUSTER_DUALITY=1` to mimic current behavior

### Related Issues

* Partially Resolves #1391 
