### PR TITLE
feat(multi-cluster): updated 'solo account init' to upload secrets to all clusters

### DIFF
--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -174,7 +174,7 @@ export class AccountCommand extends BaseCommand {
               contexts: this.getContexts(),
             };
 
-            if (!(await this.k8Factory.default().namespaces().has(config.namespace))) {
+            if (!(await this.k8Factory.getK8(config.contexts[0]).namespaces().has(config.namespace))) {
               throw new SoloError(`namespace ${config.namespace.name} does not exist`);
             }
 

--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -17,6 +17,7 @@ import {resolveNamespaceFromDeployment} from '../core/resolvers.js';
 import {Duration} from '../core/time/duration.js';
 import {type NamespaceName} from '../core/kube/resources/namespace/namespace_name.js';
 import {type DeploymentName} from '../core/config/remote/types.js';
+import {type SoloListrTask} from '../types/index.js';
 
 export class AccountCommand extends BaseCommand {
   private readonly accountManager: AccountManager;
@@ -151,6 +152,7 @@ export class AccountCommand extends BaseCommand {
     interface Context {
       config: {
         namespace: NamespaceName;
+        contexts: string[];
       };
       updateSecrets: boolean;
       accountsBatchedSet: number[][];
@@ -167,11 +169,13 @@ export class AccountCommand extends BaseCommand {
           title: 'Initialize',
           task: async (ctx, task) => {
             self.configManager.update(argv);
-            const namespace = await resolveNamespaceFromDeployment(this.localConfig, this.configManager, task);
-            const config = {namespace};
+            const config = {
+              namespace: await resolveNamespaceFromDeployment(this.localConfig, this.configManager, task),
+              contexts: this.getContexts(),
+            };
 
-            if (!(await this.k8Factory.default().namespaces().has(namespace))) {
-              throw new SoloError(`namespace ${namespace.name} does not exist`);
+            if (!(await this.k8Factory.default().namespaces().has(config.namespace))) {
+              throw new SoloError(`namespace ${config.namespace.name} does not exist`);
             }
 
             // set config in the context for later tasks to use
@@ -194,12 +198,11 @@ export class AccountCommand extends BaseCommand {
                 {
                   title: 'Prepare for account key updates',
                   task: async ctx => {
-                    const namespace = await resolveNamespaceFromDeployment(this.localConfig, this.configManager, task);
-                    const secrets = await self.k8Factory
+                    ctx.updateSecrets = await self.k8Factory
                       .default()
                       .secrets()
-                      .list(namespace, ['solo.hedera.com/account-id']);
-                    ctx.updateSecrets = secrets.length > 0;
+                      .list(ctx.config.namespace, ['solo.hedera.com/account-id'])
+                      .then(secrets => secrets.length > 0);
 
                     ctx.accountsBatchedSet = self.accountManager.batchAccounts(this.systemAccounts);
 
@@ -216,9 +219,10 @@ export class AccountCommand extends BaseCommand {
                 {
                   title: 'Update special account key sets',
                   task: ctx => {
-                    const subTasks: any[] = [];
+                    const subTasks: SoloListrTask<Context>[] = [];
                     const realm = constants.HEDERA_NODE_ACCOUNT_ID_START.realm;
                     const shard = constants.HEDERA_NODE_ACCOUNT_ID_START.shard;
+
                     for (const currentSet of ctx.accountsBatchedSet) {
                       const accStart = `${realm}.${shard}.${currentSet[0]}`;
                       const accEnd = `${realm}.${shard}.${currentSet[currentSet.length - 1]}`;
@@ -226,6 +230,7 @@ export class AccountCommand extends BaseCommand {
                         accStart !== accEnd
                           ? `${chalk.yellow(accStart)} to ${chalk.yellow(accEnd)}`
                           : `${chalk.yellow(accStart)}`;
+
                       subTasks.push({
                         title: `Updating accounts [${rangeStr}]`,
                         task: async (ctx: Context) => {
@@ -234,6 +239,7 @@ export class AccountCommand extends BaseCommand {
                             currentSet,
                             ctx.updateSecrets,
                             ctx.resultTracker,
+                            ctx.config.contexts,
                           );
                         },
                       });
@@ -264,6 +270,7 @@ export class AccountCommand extends BaseCommand {
                       );
                     }
                     self.logger.showUser(chalk.gray('Waiting for sockets to be closed....'));
+
                     if (ctx.resultTracker.rejectedCount > 0) {
                       throw new SoloError(
                         `Account keys updates failed for ${ctx.resultTracker.rejectedCount} accounts.`,
@@ -290,7 +297,7 @@ export class AccountCommand extends BaseCommand {
 
     try {
       await tasks.run();
-    } catch (e: Error | any) {
+    } catch (e) {
       throw new SoloError(`Error in creating account: ${e.message}`, e);
     } finally {
       await this.closeConnections();


### PR DESCRIPTION
## Description

* Changed the `AccountManager.updateAccountKeys` to create the secrets inside all available clusters.

### Related Issues

* Closes # https://github.com/hashgraph/solo/issues/1395
