### PR TITLE
feat: add support for --force-port-forward as a top level flag

### DIFF
--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -7,8 +7,9 @@ import {IllegalArgumentError, SoloError} from '../core/errors.js';
 import {Flags as flags} from './flags.js';
 import {Listr} from 'listr2';
 import * as constants from '../core/constants.js';
-import * as helpers from '../core/helpers.js';
 import {FREEZE_ADMIN_ACCOUNT} from '../core/constants.js';
+import * as helpers from '../core/helpers.js';
+import {sleep} from '../core/helpers.js';
 import {type AccountManager} from '../core/account_manager.js';
 import {type AccountId, AccountInfo, HbarUnit, NodeUpdateTransaction, PrivateKey} from '@hashgraph/sdk';
 import {ListrLease} from '../core/lease/listr_lease.js';
@@ -18,7 +19,6 @@ import {Duration} from '../core/time/duration.js';
 import {type NamespaceName} from '../core/kube/resources/namespace/namespace_name.js';
 import {type DeploymentName} from '../core/config/remote/types.js';
 import {Templates} from '../core/templates.js';
-import {sleep} from '../core/helpers.js';
 import {SecretType} from '../core/kube/resources/secret/secret_type.js';
 import {Base64} from 'js-base64';
 
@@ -189,6 +189,7 @@ export class AccountCommand extends BaseCommand {
               ctx.config.namespace,
               self.getClusterRefs(),
               self.configManager.getFlag<DeploymentName>(flags.deployment),
+              self.configManager.getFlag<boolean>(flags.forcePortForward),
             );
           },
         },
@@ -409,6 +410,7 @@ export class AccountCommand extends BaseCommand {
               ctx.config.namespace,
               self.getClusterRefs(),
               self.configManager.getFlag<DeploymentName>(flags.deployment),
+              self.configManager.getFlag<boolean>(flags.forcePortForward),
             );
 
             return ListrLease.newAcquireLeaseTask(lease, task);
@@ -489,6 +491,7 @@ export class AccountCommand extends BaseCommand {
               config.namespace,
               self.getClusterRefs(),
               self.configManager.getFlag<DeploymentName>(flags.deployment),
+              self.configManager.getFlag<boolean>(flags.forcePortForward),
             );
 
             self.logger.debug('Initialized config', {config});
@@ -575,6 +578,7 @@ export class AccountCommand extends BaseCommand {
               config.namespace,
               self.getClusterRefs(),
               self.configManager.getFlag<DeploymentName>(flags.deployment),
+              self.configManager.getFlag<boolean>(flags.forcePortForward),
             );
 
             self.logger.debug('Initialized config', {config});

--- a/src/commands/flags.ts
+++ b/src/commands/flags.ts
@@ -112,6 +112,17 @@ export class Flags {
     prompt: undefined,
   };
 
+  static readonly forcePortForward: CommandFlag = {
+    constName: 'forcePortForward',
+    name: 'force-port-forward',
+    definition: {
+      describe: 'Force port forward to access the network services',
+      defaultValue: true, // always use local port-forwarding by default
+      type: 'boolean',
+    },
+    prompt: undefined,
+  };
+
   // list of common flags across commands. command specific flags are defined in the command's module.
   static readonly clusterRef: CommandFlag = {
     constName: 'clusterRef',
@@ -2059,6 +2070,7 @@ export class Flags {
     Flags.enableTimeout,
     Flags.endpointType,
     Flags.envoyIps,
+    Flags.forcePortForward,
     Flags.generateEcdsaKey,
     Flags.generateGossipKeys,
     Flags.generateTlsKeys,

--- a/src/commands/mirror_node.ts
+++ b/src/commands/mirror_node.ts
@@ -256,6 +256,7 @@ export class MirrorNodeCommand extends BaseCommand {
               ctx.config.namespace,
               self.getClusterRefs(),
               self.configManager.getFlag<DeploymentName>(flags.deployment),
+              self.configManager.getFlag<boolean>(flags.forcePortForward),
               ctx.config.clusterContext,
             );
             if (ctx.config.pinger) {
@@ -479,23 +480,25 @@ export class MirrorNodeCommand extends BaseCommand {
                       feesFileIdNum,
                       clusterRefs,
                       deployment,
+                      this.configManager.getFlag<boolean>(flags.forcePortForward),
                     );
                     const exchangeRates = await this.accountManager.getFileContents(
                       namespace,
                       exchangeRatesFileIdNum,
                       clusterRefs,
                       deployment,
+                      this.configManager.getFlag<boolean>(flags.forcePortForward),
                     );
 
                     const importFeesQuery = `INSERT INTO public.file_data(file_data, consensus_timestamp, entity_id,
-                                                                              transaction_type)
-                                                 VALUES (decode('${fees}', 'hex'), ${timestamp + '000000'},
-                                                         ${feesFileIdNum}, 17);`;
+                                                                          transaction_type)
+                                             VALUES (decode('${fees}', 'hex'), ${timestamp + '000000'},
+                                                     ${feesFileIdNum}, 17);`;
                     const importExchangeRatesQuery = `INSERT INTO public.file_data(file_data, consensus_timestamp,
-                                                                                       entity_id, transaction_type)
-                                                          VALUES (decode('${exchangeRates}', 'hex'), ${
-                                                            timestamp + '000001'
-                                                          }, ${exchangeRatesFileIdNum}, 17);`;
+                                                                                   entity_id, transaction_type)
+                                                      VALUES (decode('${exchangeRates}', 'hex'), ${
+                                                        timestamp + '000001'
+                                                      }, ${exchangeRatesFileIdNum}, 17);`;
                     const sqlQuery = [importFeesQuery, importExchangeRatesQuery].join('\n');
 
                     // When useExternalDatabase flag is enabled, the query is not executed,
@@ -651,6 +654,7 @@ export class MirrorNodeCommand extends BaseCommand {
               ctx.config.namespace,
               self.getClusterRefs(),
               self.configManager.getFlag<DeploymentName>(flags.deployment),
+              self.configManager.getFlag<boolean>(flags.forcePortForward),
               ctx.config.clusterContext,
             );
             return ListrLease.newAcquireLeaseTask(lease, task);

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -39,6 +39,7 @@ import {IllegalArgumentError, MissingArgumentError, SoloError} from '../../core/
 import path from 'path';
 import fs from 'fs';
 import crypto from 'crypto';
+import * as helpers from '../../core/helpers.js';
 import {
   addDebugOptions,
   getNodeAccountMap,
@@ -67,7 +68,6 @@ import {PodRef} from '../../core/kube/resources/pod/pod_ref.js';
 import {ContainerRef} from '../../core/kube/resources/container/container_ref.js';
 import {NetworkNodes} from '../../core/network_nodes.js';
 import {container} from 'tsyringe-neo';
-import * as helpers from '../../core/helpers.js';
 import {type Optional} from '../../types/index.js';
 import {type DeploymentName} from '../../core/config/remote/types.js';
 import {ConsensusNode} from '../../core/model/consensus_node.js';
@@ -562,7 +562,12 @@ export class NodeCommandTasks {
   ) {
     try {
       const deploymentName = this.configManager.getFlag<DeploymentName>(flags.deployment);
-      await this.accountManager.loadNodeClient(namespace, this.parent.getClusterRefs(), deploymentName);
+      await this.accountManager.loadNodeClient(
+        namespace,
+        this.parent.getClusterRefs(),
+        deploymentName,
+        this.configManager.getFlag<boolean>(flags.forcePortForward),
+      );
       const client = this.accountManager._nodeClient;
       const treasuryKey = await this.accountManager.getTreasuryAccountKeys(namespace);
       const treasuryPrivateKey = PrivateKey.fromStringED25519(treasuryKey.privateKey);

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -261,6 +261,7 @@ export class RelayCommand extends BaseCommand {
               ctx.config.namespace,
               self.getClusterRefs(),
               self.configManager.getFlag<DeploymentName>(flags.deployment),
+              self.configManager.getFlag<boolean>(flags.forcePortForward),
               ctx.config.context,
             );
             config.valuesArg = await self.prepareValuesArg(

--- a/src/index.ts
+++ b/src/index.ts
@@ -144,23 +144,21 @@ export function main(argv: any) {
       return argv;
     };
 
-    return (
-      yargs(hideBin(argv))
-        .scriptName('')
-        .usage('Usage:\n  solo <command> [options]')
-        .alias('h', 'help')
-        .alias('v', 'version')
-        // @ts-ignore
-        .command(commands.Initialize(opts))
-        .strict()
-        // @ts-ignore
-        .option(flags.devMode.name, flags.devMode.definition)
-        .wrap(120)
-        .demand(1, 'Select a command')
-        // @ts-ignore
-        .middleware([processArguments, loadRemoteConfig], false) // applyBeforeValidate = false as otherwise middleware is called twice
-        .parse()
-    );
+    const rootCmd = yargs(hideBin(argv))
+      .scriptName('')
+      .usage('Usage:\n  solo <command> [options]')
+      .alias('h', 'help')
+      .alias('v', 'version')
+      // @ts-ignore
+      .command(commands.Initialize(opts))
+      .strict()
+      .demand(1, 'Select a command')
+      // @ts-ignore
+      .middleware([processArguments, loadRemoteConfig], false); // applyBeforeValidate = false as otherwise middleware is called twice
+
+    // set root level flags
+    flags.setCommandFlags(rootCmd, ...[flags.devMode, flags.forcePortForward]);
+    return rootCmd.parse();
   } catch (e: Error | any) {
     logger.showUserError(e);
     process.exit(1);

--- a/test/e2e/commands/account.test.ts
+++ b/test/e2e/commands/account.test.ts
@@ -41,6 +41,7 @@ const testName = 'account-cmd-e2e';
 const namespace: NamespaceName = NamespaceName.of(testName);
 const testSystemAccounts = [[3, 5]];
 const argv = getDefaultArgv(namespace);
+argv[flags.forcePortForward.name] = true;
 argv[flags.namespace.name] = namespace.name;
 argv[flags.releaseTag.name] = HEDERA_PLATFORM_VERSION_TAG;
 argv[flags.nodeAliasesUnparsed.name] = 'node1,node2';
@@ -107,7 +108,12 @@ e2eTestSuite(testName, argv, undefined, undefined, undefined, undefined, undefin
         before(async function () {
           this.timeout(Duration.ofSeconds(20).toMillis());
           const clusterRefs = accountCmd.getClusterRefs();
-          await accountManager.loadNodeClient(namespace, clusterRefs, argv[flags.deployment.name]);
+          await accountManager.loadNodeClient(
+            namespace,
+            clusterRefs,
+            argv[flags.deployment.name],
+            argv[flags.forcePortForward.name],
+          );
         });
 
         after(async function () {
@@ -298,7 +304,12 @@ e2eTestSuite(testName, argv, undefined, undefined, undefined, undefined, undefin
           );
 
           const clusterRefs = accountCmd.getClusterRefs();
-          await accountManager.loadNodeClient(namespace, clusterRefs, argv[flags.deployment.name]);
+          await accountManager.loadNodeClient(
+            namespace,
+            clusterRefs,
+            argv[flags.deployment.name],
+            argv[flags.forcePortForward.name],
+          );
           const accountAliasInfo = await accountManager.accountInfoQuery(newAccountInfo.accountAlias);
           expect(accountAliasInfo).not.to.be.null;
         } catch (e) {
@@ -325,7 +336,12 @@ e2eTestSuite(testName, argv, undefined, undefined, undefined, undefined, undefin
       it('Create new account', async () => {
         try {
           const clusterRefs = accountCmd.getClusterRefs();
-          await accountManager.loadNodeClient(namespace, clusterRefs, argv[flags.deployment.name]);
+          await accountManager.loadNodeClient(
+            namespace,
+            clusterRefs,
+            argv[flags.deployment.name],
+            argv[flags.forcePortForward.name],
+          );
           const privateKey = PrivateKey.generate();
           const amount = 100;
 

--- a/test/e2e/commands/mirror_node.test.ts
+++ b/test/e2e/commands/mirror_node.test.ts
@@ -1,7 +1,7 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-import {it, describe, after, before, afterEach} from 'mocha';
+import {after, afterEach, before, describe, it} from 'mocha';
 import {expect} from 'chai';
 
 import {Flags as flags} from '../../../src/commands/flags.js';
@@ -35,6 +35,7 @@ const namespace = NamespaceName.of(testName);
 const argv = getDefaultArgv(namespace);
 argv[flags.namespace.name] = namespace.name;
 argv[flags.releaseTag.name] = HEDERA_PLATFORM_VERSION_TAG;
+argv[flags.forcePortForward.name] = true;
 
 argv[flags.nodeAliasesUnparsed.name] = 'node1'; // use a single node to reduce resource during e2e tests
 argv[flags.generateGossipKeys.name] = true;
@@ -115,7 +116,12 @@ e2eTestSuite(testName, argv, undefined, undefined, undefined, undefined, undefin
 
     it('mirror node API should be running', async () => {
       const clusterRefs: ClusterRefs = mirrorNodeCmd.getClusterRefs();
-      await accountManager.loadNodeClient(namespace, clusterRefs, argv[flags.deployment.name]);
+      await accountManager.loadNodeClient(
+        namespace,
+        clusterRefs,
+        argv[flags.deployment.name],
+        argv[flags.forcePortForward.name],
+      );
       try {
         // find hedera explorer pod
         const pods: V1Pod[] = await k8Factory

--- a/test/e2e/commands/node_local_hedera.test.ts
+++ b/test/e2e/commands/node_local_hedera.test.ts
@@ -24,6 +24,7 @@ import {type ClusterRefs} from '../../../src/core/config/remote/types.js';
 
 const namespace = NamespaceName.of('local-hedera-app');
 const argv = getDefaultArgv(namespace);
+argv[flags.forcePortForward.name] = true;
 argv[flags.nodeAliasesUnparsed.name] = 'node1,node2';
 argv[flags.generateGossipKeys.name] = true;
 argv[flags.generateTlsKeys.name] = true;
@@ -64,7 +65,12 @@ e2eTestSuite(
       it('save the state and restart the node with saved state', async () => {
         // create an account so later we can verify its balance after restart
         const clusterRefs: ClusterRefs = nodeCmd.getClusterRefs();
-        await accountManager.loadNodeClient(namespace, clusterRefs, argv[flags.deployment.name]);
+        await accountManager.loadNodeClient(
+          namespace,
+          clusterRefs,
+          argv[flags.deployment.name],
+          argv[flags.forcePortForward.name],
+        );
         const privateKey = PrivateKey.generate();
         // get random integer between 100 and 1000
         const amount = Math.floor(Math.random() * (1000 - 100) + 100);
@@ -95,7 +101,12 @@ e2eTestSuite(
         await nodeCmd.handlers.start(argv);
 
         // check balance of accountInfo.accountId
-        await accountManager.loadNodeClient(namespace, clusterRefs, argv[flags.deployment.name]);
+        await accountManager.loadNodeClient(
+          namespace,
+          clusterRefs,
+          argv[flags.deployment.name],
+          argv[flags.forcePortForward.name],
+        );
         const balance = await new AccountBalanceQuery()
           .setAccountId(accountInfo.accountId)
           .execute(accountManager._nodeClient);


### PR DESCRIPTION
## Description

This pull request changes the following:

* feat: add support for --force-port-forward as the top level flag
* by default the flag is set to true to allow Solo to **always** use port forwards for everything it needs to do regardless of what is used for the external address (NodePort/ClusterIP/LoadBalancer)
* It is added as the top-level flag, similar to devMode, to make it common for all commands

### Related Issues

* Closes #1403 
