### PR TITLE
feat(multi-cluster): make remote config validation compatible with multi-cluster K8 implementation

### DIFF
--- a/src/core/config/remote/remote_config_manager.ts
+++ b/src/core/config/remote/remote_config_manager.ts
@@ -181,6 +181,7 @@ export class RemoteConfigManager {
         this.configManager.getFlag(flags.namespace),
         this.remoteConfig.components,
         this.k8Factory,
+        this.localConfig,
       );
     } catch {
       throw new SoloError(ErrorMessages.REMOTE_CONFIG_IS_INVALID(this.k8Factory.default().clusters().readCurrent()));
@@ -233,6 +234,7 @@ export class RemoteConfigManager {
       this.configManager.getFlag(flags.namespace),
       self.remoteConfig.components,
       self.k8Factory,
+      this.localConfig,
     );
 
     const additionalCommandData = `Executed by ${self.localConfig.userEmailAddress}: `;
@@ -357,7 +359,7 @@ export class RemoteConfigManager {
         .default()
         .configMaps()
         .read(this.getNamespace(), constants.SOLO_REMOTE_CONFIGMAP_NAME);
-    } catch (error: any) {
+    } catch (error) {
       if (!(error instanceof ResourceNotFoundError)) {
         throw new SoloError('Failed to read remote config from cluster', error);
       }

--- a/src/core/config/remote/remote_config_validator.ts
+++ b/src/core/config/remote/remote_config_validator.ts
@@ -3,13 +3,14 @@
  */
 import * as constants from '../../constants.js';
 import {SoloError} from '../../errors.js';
+import {ConsensusNodeStates} from './enumerations.js';
 
 import {type K8Factory} from '../../kube/k8_factory.js';
 import {type ComponentsDataWrapper} from './components_data_wrapper.js';
 import {type BaseComponent} from './components/base_component.js';
 import {type NamespaceName} from '../../kube/resources/namespace/namespace_name.js';
 import {type V1Pod} from '@kubernetes/client-node';
-import {ConsensusNodeStates} from './enumerations.js';
+import {type LocalConfig} from '../local_config.js';
 
 /**
  * Static class is used to validate that components in the remote config
@@ -17,25 +18,26 @@ import {ConsensusNodeStates} from './enumerations.js';
  */
 export class RemoteConfigValidator {
   /**
-   * Gathers together and handles validation of all components.
+   * Gathers and handles validation of all components.
    *
    * @param namespace - namespace to validate the components in.
-   * @param components - components which to validate.
+   * @param components - components to validate.
    * @param k8Factory - to validate the elements.
-   * TODO: Make compatible with multi-cluster K8 implementation
+   * @param localConfig - to get the context from cluster
    */
   public static async validateComponents(
     namespace: NamespaceName,
     components: ComponentsDataWrapper,
     k8Factory: K8Factory,
+    localConfig: LocalConfig,
   ): Promise<void> {
     await Promise.all([
-      ...RemoteConfigValidator.validateRelays(namespace, components, k8Factory),
-      ...RemoteConfigValidator.validateHaProxies(namespace, components, k8Factory),
-      ...RemoteConfigValidator.validateMirrorNodes(namespace, components, k8Factory),
-      ...RemoteConfigValidator.validateEnvoyProxies(namespace, components, k8Factory),
-      ...RemoteConfigValidator.validateConsensusNodes(namespace, components, k8Factory),
-      ...RemoteConfigValidator.validateMirrorNodeExplorers(namespace, components, k8Factory),
+      ...RemoteConfigValidator.validateRelays(namespace, components, k8Factory, localConfig),
+      ...RemoteConfigValidator.validateHaProxies(namespace, components, k8Factory, localConfig),
+      ...RemoteConfigValidator.validateMirrorNodes(namespace, components, k8Factory, localConfig),
+      ...RemoteConfigValidator.validateEnvoyProxies(namespace, components, k8Factory, localConfig),
+      ...RemoteConfigValidator.validateConsensusNodes(namespace, components, k8Factory, localConfig),
+      ...RemoteConfigValidator.validateMirrorNodeExplorers(namespace, components, k8Factory, localConfig),
     ]);
   }
 
@@ -43,13 +45,15 @@ export class RemoteConfigValidator {
     namespace: NamespaceName,
     components: ComponentsDataWrapper,
     k8Factory: K8Factory,
+    localConfig: LocalConfig,
   ): Promise<void>[] {
     return Object.values(components.relays).map(async component => {
+      const context = localConfig.clusterRefs[component.cluster];
+      const labels = [constants.SOLO_RELAY_LABEL];
       try {
-        const pods: V1Pod[] = await k8Factory.default().pods().list(namespace, [constants.SOLO_RELAY_LABEL]);
+        const pods: V1Pod[] = await k8Factory.getK8(context).pods().list(namespace, labels);
 
-        // to return the generic error message
-        if (!pods.length) throw new Error('Pod not found');
+        if (!pods.length) throw new Error('Pod not found'); // to return the generic error message
       } catch (e) {
         RemoteConfigValidator.throwValidationError('Relay', component, e);
       }
@@ -60,16 +64,15 @@ export class RemoteConfigValidator {
     namespace: NamespaceName,
     components: ComponentsDataWrapper,
     k8Factory: K8Factory,
+    localConfig: LocalConfig,
   ): Promise<void>[] {
     return Object.values(components.haProxies).map(async component => {
+      const context = localConfig.clusterRefs[component.cluster];
+      const labels = [`app=${component.name}`];
       try {
-        const pods: V1Pod[] = await k8Factory
-          .default()
-          .pods()
-          .list(namespace, [`app=${component.name}`]);
+        const pods: V1Pod[] = await k8Factory.getK8(context).pods().list(namespace, labels);
 
-        // to return the generic error message
-        if (!pods.length) throw new Error('Pod not found');
+        if (!pods.length) throw new Error('Pod not found'); // to return the generic error message
       } catch (e) {
         RemoteConfigValidator.throwValidationError('HaProxy', component, e);
       }
@@ -80,13 +83,15 @@ export class RemoteConfigValidator {
     namespace: NamespaceName,
     components: ComponentsDataWrapper,
     k8Factory: K8Factory,
+    localConfig: LocalConfig,
   ): Promise<void>[] {
     return Object.values(components.mirrorNodes).map(async component => {
+      const context = localConfig.clusterRefs[component.cluster];
+      const labels = constants.SOLO_HEDERA_MIRROR_IMPORTER;
       try {
-        const pods: V1Pod[] = await k8Factory.default().pods().list(namespace, constants.SOLO_HEDERA_MIRROR_IMPORTER);
+        const pods: V1Pod[] = await k8Factory.getK8(context).pods().list(namespace, labels);
 
-        // to return the generic error message
-        if (!pods.length) throw new Error('Pod not found');
+        if (!pods.length) throw new Error('Pod not found'); // to return the generic error message
       } catch (e) {
         RemoteConfigValidator.throwValidationError('Mirror node', component, e);
       }
@@ -97,16 +102,15 @@ export class RemoteConfigValidator {
     namespace: NamespaceName,
     components: ComponentsDataWrapper,
     k8Factory: K8Factory,
+    localConfig: LocalConfig,
   ): Promise<void>[] {
     return Object.values(components.envoyProxies).map(async component => {
+      const context = localConfig.clusterRefs[component.cluster];
+      const labels = [`app=${component.name}`];
       try {
-        const pods: V1Pod[] = await k8Factory
-          .default()
-          .pods()
-          .list(namespace, [`app=${component.name}`]);
+        const pods: V1Pod[] = await k8Factory.getK8(context).pods().list(namespace, labels);
 
-        // to return the generic error message
-        if (!pods.length) throw new Error('Pod not found');
+        if (!pods.length) throw new Error('Pod not found'); // to return the generic error message
       } catch (e) {
         RemoteConfigValidator.throwValidationError('Envoy proxy', component, e);
       }
@@ -117,17 +121,17 @@ export class RemoteConfigValidator {
     namespace: NamespaceName,
     components: ComponentsDataWrapper,
     k8Factory: K8Factory,
+    localConfig: LocalConfig,
   ): Promise<void>[] {
     return Object.values(components.consensusNodes).map(async component => {
-      try {
-        if (component.state === ConsensusNodeStates.REQUESTED) return;
-        const pods: V1Pod[] = await k8Factory
-          .default()
-          .pods()
-          .list(namespace, [`app=network-${component.name}`]);
+      if (component.state === ConsensusNodeStates.REQUESTED) return;
 
-        // to return the generic error message
-        if (!pods.length) throw new Error('Pod not found');
+      const context = localConfig.clusterRefs[component.cluster];
+      const labels = [`app=network-${component.name}`];
+      try {
+        const pods: V1Pod[] = await k8Factory.getK8(context).pods().list(namespace, labels);
+
+        if (!pods.length) throw new Error('Pod not found'); // to return the generic error message
       } catch (e) {
         RemoteConfigValidator.throwValidationError('Consensus node', component, e);
       }
@@ -138,13 +142,15 @@ export class RemoteConfigValidator {
     namespace: NamespaceName,
     components: ComponentsDataWrapper,
     k8Factory: K8Factory,
+    localConfig: LocalConfig,
   ): Promise<void>[] {
     return Object.values(components.mirrorNodeExplorers).map(async component => {
+      const context = localConfig.clusterRefs[component.cluster];
+      const labels = [constants.SOLO_HEDERA_EXPLORER_LABEL];
       try {
-        const pods: V1Pod[] = await k8Factory.default().pods().list(namespace, [constants.SOLO_HEDERA_EXPLORER_LABEL]);
+        const pods: V1Pod[] = await k8Factory.getK8(context).pods().list(namespace, labels);
 
-        // to return the generic error message
-        if (!pods.length) throw new Error('Pod not found');
+        if (!pods.length) throw new Error('Pod not found'); // to return the generic error message
       } catch (e) {
         RemoteConfigValidator.throwValidationError('Mirror node explorer', component, e);
       }

--- a/test/e2e/integration/core/remote_config_validator.test.ts
+++ b/test/e2e/integration/core/remote_config_validator.test.ts
@@ -27,17 +27,22 @@ import {PodName} from '../../../../src/core/kube/resources/pod/pod_name.js';
 import {ContainerName} from '../../../../src/core/kube/resources/container/container_name.js';
 import {InjectTokens} from '../../../../src/core/dependency_injection/inject_tokens.js';
 import {type K8Factory} from '../../../../src/core/kube/k8_factory.js';
+import {LocalConfig} from '../../../../src/core/config/local_config.js';
+import {getTestCacheDir} from '../../../test_util.js';
 
 describe('RemoteConfigValidator', () => {
   const namespace = NamespaceName.of('remote-config-validator');
 
   let configManager: ConfigManager;
   let k8Factory: K8Factory;
+  let localConfig: LocalConfig;
+  const filePath = `${getTestCacheDir('LocalConfig')}/localConfig.yaml`;
 
   before(async () => {
     configManager = container.resolve(InjectTokens.ConfigManager);
     configManager.update({[flags.namespace.name]: namespace});
     k8Factory = container.resolve(InjectTokens.K8Factory);
+    localConfig = new LocalConfig(filePath);
     await k8Factory.default().namespaces().create(namespace);
   });
 
@@ -57,7 +62,7 @@ describe('RemoteConfigValidator', () => {
 
   const consensusNodeAliases = [nodeAlias] as NodeAliases;
 
-  // @ts-ignore
+  // @ts-expect-error - TS2673: Constructor of class ComponentsDataWrapper is private
   const components = new ComponentsDataWrapper(
     {[relayName]: new RelayComponent(relayName, cluster, namespace.name, consensusNodeAliases)},
     {[haProxyName]: new HaProxyComponent(haProxyName, cluster, namespace.name)},
@@ -97,8 +102,8 @@ describe('RemoteConfigValidator', () => {
   describe('Relays validation', () => {
     it('should fail if component is not present', async () => {
       try {
-        // @ts-ignore
-        await Promise.all(RemoteConfigValidator.validateRelays(namespace, components, k8Factory));
+        // @ts-expect-error - TS2341: Property is private
+        await Promise.all(RemoteConfigValidator.validateRelays(namespace, components, k8Factory, localConfig));
         throw new Error();
       } catch (e) {
         expect(e).to.be.instanceOf(SoloError);
@@ -109,16 +114,16 @@ describe('RemoteConfigValidator', () => {
       const [key, value] = constants.SOLO_RELAY_LABEL.split('=');
       await createPod(relayName, {[key]: value});
 
-      // @ts-ignore
-      await Promise.all(RemoteConfigValidator.validateRelays(namespace, components, k8Factory));
+      // @ts-expect-error - TS2341: Property is private
+      await Promise.all(RemoteConfigValidator.validateRelays(namespace, components, k8Factory, localConfig));
     });
   });
 
   describe('HaProxies validation', () => {
     it('should fail if component is not present', async () => {
       try {
-        // @ts-ignore
-        await Promise.all(RemoteConfigValidator.validateHaProxies(namespace, components, k8Factory));
+        // @ts-expect-error - TS2341: Property is private
+        await Promise.all(RemoteConfigValidator.validateHaProxies(namespace, components, k8Factory, localConfig));
         throw new Error();
       } catch (e) {
         expect(e).to.be.instanceOf(SoloError);
@@ -128,16 +133,16 @@ describe('RemoteConfigValidator', () => {
     it('should succeed if component is present', async () => {
       await createPod(haProxyName, {app: haProxyName});
 
-      // @ts-ignore
-      await Promise.all(RemoteConfigValidator.validateHaProxies(namespace, components, k8Factory));
+      // @ts-expect-error - TS2341: Property is private
+      await Promise.all(RemoteConfigValidator.validateHaProxies(namespace, components, k8Factory, localConfig));
     });
   });
 
   describe('Mirror Node Components validation', () => {
     it('should fail if component is not present', async () => {
       try {
-        // @ts-ignore
-        await Promise.all(RemoteConfigValidator.validateMirrorNodes(namespace, components, k8Factory));
+        // @ts-expect-error - TS2341: Property is private
+        await Promise.all(RemoteConfigValidator.validateMirrorNodes(namespace, components, k8Factory, localConfig));
         throw new Error();
       } catch (e) {
         expect(e).to.be.instanceOf(SoloError);
@@ -149,16 +154,16 @@ describe('RemoteConfigValidator', () => {
       const [key2, value2] = constants.SOLO_HEDERA_MIRROR_IMPORTER[1].split('=');
       await createPod(mirrorNodeName, {[key1]: value1, [key2]: value2});
 
-      // @ts-ignore
-      await Promise.all(RemoteConfigValidator.validateMirrorNodes(namespace, components, k8Factory));
+      // @ts-expect-error - TS2341: Property is private
+      await Promise.all(RemoteConfigValidator.validateMirrorNodes(namespace, components, k8Factory, localConfig));
     });
   });
 
   describe('Envoy Proxies validation', () => {
     it('should fail if component is not present', async () => {
       try {
-        // @ts-ignore
-        await Promise.all(RemoteConfigValidator.validateEnvoyProxies(namespace, components, k8Factory));
+        // @ts-expect-error - TS2341: Property is private
+        await Promise.all(RemoteConfigValidator.validateEnvoyProxies(namespace, components, k8Factory, localConfig));
         throw new Error();
       } catch (e) {
         expect(e).to.be.instanceOf(SoloError);
@@ -168,16 +173,16 @@ describe('RemoteConfigValidator', () => {
     it('should succeed if component is present', async () => {
       await createPod(envoyProxyName, {app: envoyProxyName});
 
-      // @ts-ignore
-      await Promise.all(RemoteConfigValidator.validateEnvoyProxies(namespace, components, k8Factory));
+      // @ts-expect-error - TS2341: Property is private
+      await Promise.all(RemoteConfigValidator.validateEnvoyProxies(namespace, components, k8Factory, localConfig));
     });
   });
 
   describe('Consensus Nodes validation', () => {
     it('should fail if component is not present', async () => {
       try {
-        // @ts-ignore
-        await Promise.all(RemoteConfigValidator.validateConsensusNodes(namespace, components, k8Factory));
+        // @ts-expect-error - TS2341: Property is private
+        await Promise.all(RemoteConfigValidator.validateConsensusNodes(namespace, components, k8Factory, localConfig));
         throw new Error();
       } catch (e) {
         expect(e).to.be.instanceOf(SoloError);
@@ -187,16 +192,18 @@ describe('RemoteConfigValidator', () => {
     it('should succeed if component is present', async () => {
       await createPod(nodeAlias, {app: `network-${nodeAlias}`});
 
-      // @ts-ignore
-      await Promise.all(RemoteConfigValidator.validateConsensusNodes(namespace, components, k8Factory));
+      // @ts-expect-error - TS2341: Property is private
+      await Promise.all(RemoteConfigValidator.validateConsensusNodes(namespace, components, k8Factory, localConfig));
     });
   });
 
   describe('Mirror Node Explorers validation', () => {
     it('should fail if component is not present', async () => {
       try {
-        // @ts-ignore
-        await Promise.all(RemoteConfigValidator.validateMirrorNodeExplorers(namespace, components, k8Factory));
+        await Promise.all(
+          // @ts-expect-error - TS2341: Property is private
+          RemoteConfigValidator.validateMirrorNodeExplorers(namespace, components, k8Factory, localConfig),
+        );
         throw new Error();
       } catch (e) {
         expect(e).to.be.instanceOf(SoloError);
@@ -207,8 +214,10 @@ describe('RemoteConfigValidator', () => {
       const [key, value] = constants.SOLO_HEDERA_EXPLORER_LABEL.split('=');
       await createPod(mirrorNodeExplorerName, {[key]: value});
 
-      // @ts-ignore
-      await Promise.all(RemoteConfigValidator.validateMirrorNodeExplorers(namespace, components, k8Factory));
+      await Promise.all(
+        // @ts-expect-error - TS2341: Property is private
+        RemoteConfigValidator.validateMirrorNodeExplorers(namespace, components, k8Factory, localConfig),
+      );
     });
   });
 });


### PR DESCRIPTION
## Description

Add support for multi-cluster for `RemoteConfigValidator`:
* pass local config to get the `context` from the component's `cluster` property

### Related Issues

* Closes # https://github.com/hashgraph/solo/issues/1406
