### PR TITLE
fix: Resolve `cannot read properties of undefined `error thrown during `solo network deploy`

### DIFF
--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -850,13 +850,14 @@ export class NetworkCommand extends BaseCommand {
                         `solo.hedera.com/node-id=${consensusNode.nodeId},solo.hedera.com/type=network-node-svc`,
                       ]);
 
-                    if (svc && svc.length > 0 && svc[0].status.loadBalancer.ingress.length > 0) {
+                    if (svc && svc.length > 0 && svc[0].status?.loadBalancer?.ingress?.length > 0) {
                       return;
                     }
 
                     attempts++;
                     await helpers.sleep(Duration.ofSeconds(2));
                   }
+                  throw new SoloError('Load balancer not found');
                 },
               });
             }

--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -851,12 +851,18 @@ export class NetworkCommand extends BaseCommand {
                       ]);
 
                     if (svc && svc.length > 0 && svc[0].status?.loadBalancer?.ingress?.length > 0) {
+                      let shouldContinue = false;
                       for (let i = 0; i < svc.status.loadBalancer.ingress.length; i++) {
                         const ingress = svc.status.loadBalancer.ingress[i];
-                        if (ingress.hostname || ingress.ip) {
-                          return;
+                        if (!ingress.hostname && !ingress.ip) {
+                          shouldContinue = true; // try again if there is neither a hostname nor an ip
+                          break;
                         }
                       }
+                      if (shouldContinue) {
+                        continue;
+                      }
+                      return;
                     }
 
                     attempts++;

--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -851,7 +851,12 @@ export class NetworkCommand extends BaseCommand {
                       ]);
 
                     if (svc && svc.length > 0 && svc[0].status?.loadBalancer?.ingress?.length > 0) {
-                      return;
+                      for (let i = 0; i < svc.status.loadBalancer.ingress.length; i++) {
+                        const ingress = svc.status.loadBalancer.ingress[i];
+                        if (ingress.hostname || ingress.ip) {
+                          return;
+                        }
+                      }
                     }
 
                     attempts++;

--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -852,8 +852,8 @@ export class NetworkCommand extends BaseCommand {
 
                     if (svc && svc.length > 0 && svc[0].status?.loadBalancer?.ingress?.length > 0) {
                       let shouldContinue = false;
-                      for (let i = 0; i < svc.status.loadBalancer.ingress.length; i++) {
-                        const ingress = svc.status.loadBalancer.ingress[i];
+                      for (let i = 0; i < svc[0].status.loadBalancer.ingress.length; i++) {
+                        const ingress = svc[0].status.loadBalancer.ingress[i];
                         if (!ingress.hostname && !ingress.ip) {
                           shouldContinue = true; // try again if there is neither a hostname nor an ip
                           break;


### PR DESCRIPTION
## Description

The error is thrown when `svc[0].status.loadBalancer.ingress` comes in as `undefined`. This PR adds an additional check for this case and gives time to the load balancer to be loaded. However it is possible that the actual issue is that no `ingress` configuration is given when the network has been deployed.

### Related Issues

* Closes #1409 
