### PR TITLE
fix(network-command): wrong value passed to addDebugOptions inside the 'network' command

### DIFF
--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -384,8 +384,8 @@ export class NetworkCommand extends BaseCommand {
     // add debug options to the debug node
     config.consensusNodes.filter(consensusNode => {
       if (consensusNode.name === config.debugNodeAlias) {
-        config.consensusNodes[consensusNode.cluster] = addDebugOptions(
-          config.consensusNodes[consensusNode.cluster],
+        valuesArgs[consensusNode.cluster] = addDebugOptions(
+          valuesArgs[consensusNode.cluster],
           config.debugNodeAlias,
           extraEnvIndex,
         );


### PR DESCRIPTION
## Description

For values arg instead of `config.consensusNodes[consensusNode.cluster]` pass `valuesArgs[consensusNode.cluster]` as well as the return value assign it to the valuesArgs

### Related Issues

* Closes # https://github.com/hashgraph/solo/issues/1414
