### PR TITLE
fix: increase load balancer check waiting time and make values configurable via env

### DIFF
--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -842,7 +842,7 @@ export class NetworkCommand extends BaseCommand {
                   let attempts = 0;
                   let svc = null;
 
-                  while (attempts < 30) {
+                  while (attempts < constants.LOAD_BALANCER_CHECK_MAX_ATTEMPTS) {
                     svc = await self.k8Factory
                       .getK8(consensusNode.context)
                       .services()
@@ -866,7 +866,7 @@ export class NetworkCommand extends BaseCommand {
                     }
 
                     attempts++;
-                    await helpers.sleep(Duration.ofSeconds(2));
+                    await helpers.sleep(Duration.ofSeconds(constants.LOAD_BALANCER_CHECK_DELAY_SECS));
                   }
                   throw new SoloError('Load balancer not found');
                 },

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -204,6 +204,9 @@ export const RELAY_PODS_READY_DELAY = +process.env.RELAY_PODS_READY_DELAY || 1_0
 export const GRPC_PORT = +process.env.GRPC_PORT || 50_211;
 export const LOCAL_BUILD_COPY_RETRY = +process.env.LOCAL_BUILD_COPY_RETRY || 3;
 
+export const LOAD_BALANCER_CHECK_DELAY_SECS = +process.env.LOAD_BALANCER_CHECK_DELAY_SECS || 5;
+export const LOAD_BALANCER_CHECK_MAX_ATTEMPTS = +process.env.LOAD_BALANCER_CHECK_MAX_ATTEMPTS || 60;
+
 export const NETWORK_DESTROY_WAIT_TIMEOUT = +process.env.NETWORK_DESTROY_WAIT_TIMEOUT || 120;
 
 export const DEFAULT_LOCAL_CONFIG_FILE = 'local-config.yaml';


### PR DESCRIPTION
## Description

This pull request changes the following:

* Increases default max attempts from `30` to `60` for the load balancer availability check
* Increases default check delay from `2s` to `5s` for the load balancer availability check
* Makes both the check delay and max attempts configurable via environment variables

### Related Issues

* Closes #1460 

