### PR TITLE
chore(middlewares): move the yargs middlewares inside their own class 'Middlewares'

### DIFF
--- a/src/commands/deployment.ts
+++ b/src/commands/deployment.ts
@@ -289,5 +289,8 @@ export class DeploymentCommand extends BaseCommand {
     };
   }
 
-  async close() {}
+  close(): Promise<void> {
+    // no-op
+    return Promise.resolve();
+  }
 }

--- a/src/commands/deployment.ts
+++ b/src/commands/deployment.ts
@@ -11,7 +11,6 @@ import {ListrRemoteConfig} from '../core/config/remote/listr_config_tasks.js';
 import {ClusterCommandTasks} from './cluster/tasks.js';
 import {type ClusterRef, type DeploymentName, type NamespaceNameAsString} from '../core/config/remote/types.js';
 import {type CommandFlag} from '../types/flag_types.js';
-import {type CommandBuilder} from '../types/aliases.js';
 import {type SoloListrTask} from '../types/index.js';
 import {ErrorMessages} from '../core/error_messages.js';
 import {splitFlagInput} from '../core/helpers.js';
@@ -97,7 +96,7 @@ export class DeploymentCommand extends BaseCommand {
         this.localConfig.promptLocalConfigTask(self.k8Factory),
         {
           title: 'Add new deployment to local config',
-          task: async (ctx, task) => {
+          task: async ctx => {
             const {deployments} = this.localConfig;
             const {deployment, namespace: configNamespace, deploymentClusters} = ctx.config;
             deployments[deployment] = {
@@ -236,7 +235,7 @@ export class DeploymentCommand extends BaseCommand {
     return true;
   }
 
-  public getCommandDefinition(): {command: string; desc: string; builder: CommandBuilder} {
+  public getCommandDefinition() {
     const self = this;
     return {
       command: 'deployment',
@@ -290,8 +289,5 @@ export class DeploymentCommand extends BaseCommand {
     };
   }
 
-  close(): Promise<void> {
-    // no-op
-    return Promise.resolve();
-  }
+  async close() {}
 }

--- a/src/core/middlewares.ts
+++ b/src/core/middlewares.ts
@@ -1,0 +1,123 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {Flags as flags} from '../commands/flags.js';
+import chalk from 'chalk';
+
+import {type NamespaceName} from './kube/resources/namespace/namespace_name.js';
+import {type Opts} from '../commands/base.js';
+import {type ConfigManager} from './config_manager.js';
+import {type K8Factory} from './kube/k8_factory.js';
+import {type SoloLogger} from './logging.js';
+import {type AnyObject} from '../types/aliases.js';
+import {type RemoteConfigManager} from './config/remote/remote_config_manager.js';
+import {type ClusterRef} from './config/remote/types.js';
+
+export class Middlewares {
+  private readonly remoteConfigManager: RemoteConfigManager;
+  private readonly configManager: ConfigManager;
+  private readonly k8Factory: K8Factory;
+  private readonly logger: SoloLogger;
+
+  constructor(opts: Opts) {
+    this.configManager = opts.configManager;
+    this.remoteConfigManager = opts.remoteConfigManager;
+    this.k8Factory = opts.k8Factory;
+    this.logger = opts.logger;
+  }
+
+  /**
+   * Processes the Argv and display the command header
+   *
+   * @returns callback function to be executed from listr
+   */
+  public processArgumentsAndDisplayHeader() {
+    const k8Factory = this.k8Factory;
+    const configManager = this.configManager;
+    const logger = this.logger;
+
+    /**
+     * @param argv - listr Argv
+     * @param yargs - listr Yargs
+     */
+    return (argv: any, yargs: any): AnyObject => {
+      // set cluster and namespace in the global configManager from kubernetes context
+      // so that we don't need to prompt the user
+      const k8 = k8Factory.default();
+      const contextNamespace: NamespaceName = k8.contexts().readCurrentNamespace();
+      const currentClusterName: string = k8.clusters().readCurrent();
+      const contextName: string = k8.contexts().readCurrent();
+
+      // reset config on `solo init` command
+      if (argv._[0] === 'init') {
+        configManager.reset();
+      }
+
+      const clusterName = configManager.getFlag<ClusterRef>(flags.clusterRef) || currentClusterName;
+
+      // Set namespace if not provided
+      if (contextNamespace?.name) {
+        configManager.setFlag(flags.namespace, contextNamespace);
+      }
+
+      // apply precedence for flags
+      argv = configManager.applyPrecedence(argv, yargs.parsed.aliases);
+
+      // update config manager
+      configManager.update(argv);
+
+      // Build data to be displayed
+      const currentCommand: string = argv._.join(' ');
+      const commandArguments: string = flags.stringifyArgv(argv);
+      const commandData: string = (currentCommand + ' ' + commandArguments).trim();
+
+      // Display command header
+      logger.showUser(
+        chalk.cyan('\n******************************* Solo *********************************************'),
+      );
+      logger.showUser(chalk.cyan('Version\t\t\t:'), chalk.yellow(configManager.getVersion()));
+      logger.showUser(chalk.cyan('Kubernetes Context\t:'), chalk.yellow(contextName));
+      logger.showUser(chalk.cyan('Kubernetes Cluster\t:'), chalk.yellow(clusterName));
+      logger.showUser(chalk.cyan('Current Command\t\t:'), chalk.yellow(commandData));
+      if (configManager.getFlag<NamespaceName>(flags.namespace)?.name) {
+        logger.showUser(chalk.cyan('Kubernetes Namespace\t:'), chalk.yellow(configManager.getFlag(flags.namespace)));
+      }
+      logger.showUser(chalk.cyan('**********************************************************************************'));
+
+      return argv;
+    };
+  }
+
+  /**
+   * Handles loading remote config if the command access the cluster
+   *
+   * @returns callback function to be executed from listr
+   */
+  public loadRemoteConfig() {
+    const remoteConfigManager = this.remoteConfigManager;
+
+    /**
+     * @param argv - listr Argv
+     */
+    return async (argv: any): Promise<AnyObject> => {
+      const command = argv._[0];
+      const subCommand = argv._[1];
+      const skip =
+        command === 'init' ||
+        (command === 'node' && subCommand === 'keys') ||
+        (command === 'cluster' && subCommand === 'connect') ||
+        (command === 'cluster' && subCommand === 'info') ||
+        (command === 'cluster' && subCommand === 'list') ||
+        (command === 'cluster' && subCommand === 'setup') ||
+        (command === 'deployment' && subCommand === 'create') ||
+        (command === 'deployment' && subCommand === 'list');
+
+      if (!skip) {
+        await remoteConfigManager.loadAndValidate(argv);
+      }
+
+      return argv;
+    };
+  }
+}


### PR DESCRIPTION
## Description

* Added new class `Middlewares` and used it inside root `index.ts`

### Related Issues

* Closes # https://github.com/hashgraph/solo/issues/1473
