### PR TITLE
chore(cli): replace usages of @listr2/prompt-adapter-enquirer with @listr2/prompt-adapter-inquirer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@hashgraph/sdk": "^2.59.0",
         "@inquirer/prompts": "^7.3.2",
         "@kubernetes/client-node": "^0.22.3",
-        "@listr2/prompt-adapter-enquirer": "^2.0.12",
+        "@listr2/prompt-adapter-inquirer": "^2.0.18",
         "@peculiar/x509": "^1.12.3",
         "adm-zip": "^0.5.16",
         "chalk": "^5.4.1",
@@ -1792,15 +1792,40 @@
         "openid-client": "^6.1.3"
       }
     },
-    "node_modules/@listr2/prompt-adapter-enquirer": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/@listr2/prompt-adapter-enquirer/-/prompt-adapter-enquirer-2.0.12.tgz",
-      "integrity": "sha512-WR1RvaiRuSOQ8i8Hr6CLlPXFsL2u9xwoADKYD2GeUsk7EBOx7cb9GFvJhHnlVUZq4LaPvY1U1NtrgXoslteaVA==",
+    "node_modules/@listr2/prompt-adapter-inquirer": {
+      "version": "2.0.18",
+      "resolved": "https://registry.npmjs.org/@listr2/prompt-adapter-inquirer/-/prompt-adapter-inquirer-2.0.18.tgz",
+      "integrity": "sha512-0hz44rAcrphyXcA8IS7EJ2SCoaBZD2u5goE8S/e+q/DL+dOGpqpcLidVOFeLG3VgML62SXmfRLAhWt0zL1oW4Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@inquirer/type": "^1.5.5"
+      },
       "engines": {
         "node": ">=18.0.0"
       },
       "peerDependencies": {
-        "enquirer": ">= 2.3.0 < 3"
+        "@inquirer/prompts": ">= 3 < 8"
+      }
+    },
+    "node_modules/@listr2/prompt-adapter-inquirer/node_modules/@inquirer/type": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@inquirer/type/-/type-1.5.5.tgz",
+      "integrity": "sha512-MzICLu4yS7V8AA61sANROZ9vT1H3ooca5dSmI1FjZkzq7o/koMsRfQSzRtFo+F3Ao4Sf1C0bpLKejpKB/+j6MA==",
+      "license": "MIT",
+      "dependencies": {
+        "mute-stream": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@listr2/prompt-adapter-inquirer/node_modules/mute-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-1.0.0.tgz",
+      "integrity": "sha512-avsJQhyd+680gKXyG/sQc0nXaC6rBkPOfyHYcFb9+hdkqQkR9bdnkJ0AMZhke0oesPqIO+mFFJ+IdBc7mst4IA==",
+      "license": "ISC",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/@microsoft/tsdoc": {
@@ -3230,6 +3255,7 @@
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-4.1.3.tgz",
       "integrity": "sha512-/6w/C21Pm1A7aZitlI5Ni/2J6FFQN8i1Cvz3kHABAAbw93v/NlvKdVOqz7CCWz/3iv/JplRSEEZ83XION15ovw==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -4878,19 +4904,6 @@
       },
       "engines": {
         "node": ">=10.13.0"
-      }
-    },
-    "node_modules/enquirer": {
-      "version": "2.4.1",
-      "resolved": "https://registry.npmjs.org/enquirer/-/enquirer-2.4.1.tgz",
-      "integrity": "sha512-rRqJg/6gd538VHvR3PSrdRBb/1Vy2YfzHqzvbhGIQpDRKIa4FgV/54b5Q1xYSxOOwKvjXweS26E0Q+nAMwp2pQ==",
-      "peer": true,
-      "dependencies": {
-        "ansi-colors": "^4.1.1",
-        "strip-ansi": "^6.0.1"
-      },
-      "engines": {
-        "node": ">=8.6"
       }
     },
     "node_modules/entities": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "@hashgraph/sdk": "^2.59.0",
     "@inquirer/prompts": "^7.3.2",
     "@kubernetes/client-node": "^0.22.3",
-    "@listr2/prompt-adapter-enquirer": "^2.0.12",
+    "@listr2/prompt-adapter-inquirer": "^2.0.18",
     "@peculiar/x509": "^1.12.3",
     "adm-zip": "^0.5.16",
     "chalk": "^5.4.1",

--- a/src/commands/cluster/configs.ts
+++ b/src/commands/cluster/configs.ts
@@ -5,7 +5,8 @@
 import {type NodeAlias} from '../../types/aliases.js';
 import {Flags as flags} from '../flags.js';
 import * as constants from '../../core/constants.js';
-import {ListrEnquirerPromptAdapter} from '@listr2/prompt-adapter-enquirer';
+import {ListrInquirerPromptAdapter} from '@listr2/prompt-adapter-inquirer';
+import {confirm as confirmPrompt} from '@inquirer/prompts';
 import {SoloError} from '../../core/errors.js';
 import {type NamespaceName} from '../../core/kube/resources/namespace/namespace_name.js';
 import {type DeploymentName} from '../../core/config/remote/types.js';
@@ -57,13 +58,12 @@ export const setupConfigBuilder = async function (argv, ctx, task) {
 
 export const resetConfigBuilder = async function (argv, ctx, task) {
   if (!argv[flags.force.name]) {
-    const confirm = await task.prompt(ListrEnquirerPromptAdapter).run({
-      type: 'toggle',
+    const confirmResult = await task.prompt(ListrInquirerPromptAdapter).run(confirmPrompt, {
       default: false,
       message: 'Are you sure you would like to uninstall solo-cluster-setup chart?',
     });
 
-    if (!confirm) {
+    if (!confirmResult) {
       // eslint-disable-next-line n/no-process-exit
       process.exit(0);
     }

--- a/src/commands/cluster/tasks.ts
+++ b/src/commands/cluster/tasks.ts
@@ -20,7 +20,8 @@ import {type SoloListrTask, type SoloListrTaskWrapper} from '../../types/index.j
 import {type SelectClusterContextContext} from './configs.js';
 import {type DeploymentName} from '../../core/config/remote/types.js';
 import {type LocalConfig} from '../../core/config/local_config.js';
-import {ListrEnquirerPromptAdapter} from '@listr2/prompt-adapter-enquirer';
+import {ListrInquirerPromptAdapter} from '@listr2/prompt-adapter-inquirer';
+import {confirm as confirmPrompt} from '@inquirer/prompts';
 import {type NamespaceName} from '../../core/kube/resources/namespace/namespace_name.js';
 import {type ClusterChecks} from '../../core/cluster_checks.js';
 import {container} from 'tsyringe-neo';
@@ -509,8 +510,7 @@ export class ClusterCommandTasks {
         const clusterSetupNamespace = ctx.config.clusterSetupNamespace;
 
         if (!argv.force && (await self.clusterChecks.isRemoteConfigPresentInAnyNamespace())) {
-          const confirm = await task.prompt(ListrEnquirerPromptAdapter).run({
-            type: 'toggle',
+          const confirm = await task.prompt(ListrInquirerPromptAdapter).run(confirmPrompt, {
             default: false,
             message:
               'There is remote config for one of the deployments' +

--- a/src/commands/explorer.ts
+++ b/src/commands/explorer.ts
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import {ListrInquirerPromptAdapter} from '@listr2/prompt-adapter-inquirer';
-import {confirm} from '@inquirer/confirm';
+import {confirm as confirmPrompt} from '@inquirer/prompts';
 import {Listr} from 'listr2';
 import {SoloError, MissingArgumentError} from '../core/errors.js';
 import * as constants from '../core/constants.js';
@@ -384,7 +384,7 @@ export class ExplorerCommand extends BaseCommand {
           title: 'Initialize',
           task: async (ctx, task) => {
             if (!argv.force) {
-              const confirmResult = await task.prompt(ListrInquirerPromptAdapter).run(confirm, {
+              const confirmResult = await task.prompt(ListrInquirerPromptAdapter).run(confirmPrompt, {
                 default: false,
                 message: 'Are you sure you would like to destroy the explorer?',
               });

--- a/src/commands/explorer.ts
+++ b/src/commands/explorer.ts
@@ -1,7 +1,8 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-import {ListrEnquirerPromptAdapter} from '@listr2/prompt-adapter-enquirer';
+import {ListrInquirerPromptAdapter} from '@listr2/prompt-adapter-inquirer';
+import {confirm} from '@inquirer/confirm';
 import {Listr} from 'listr2';
 import {SoloError, MissingArgumentError} from '../core/errors.js';
 import * as constants from '../core/constants.js';
@@ -383,13 +384,12 @@ export class ExplorerCommand extends BaseCommand {
           title: 'Initialize',
           task: async (ctx, task) => {
             if (!argv.force) {
-              const confirm = await task.prompt(ListrEnquirerPromptAdapter).run({
-                type: 'toggle',
+              const confirmResult = await task.prompt(ListrInquirerPromptAdapter).run(confirm, {
                 default: false,
                 message: 'Are you sure you would like to destroy the explorer?',
               });
 
-              if (!confirm) {
+              if (!confirmResult) {
                 process.exit(0);
               }
             }

--- a/src/commands/mirror_node.ts
+++ b/src/commands/mirror_node.ts
@@ -1,7 +1,8 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-import {ListrEnquirerPromptAdapter} from '@listr2/prompt-adapter-enquirer';
+import {ListrInquirerPromptAdapter} from '@listr2/prompt-adapter-inquirer';
+import {confirm as confirmPrompt} from '@inquirer/prompts';
 import {Listr} from 'listr2';
 import {IllegalArgumentError, MissingArgumentError, SoloError} from '../core/errors.js';
 import * as constants from '../core/constants.js';
@@ -632,13 +633,12 @@ export class MirrorNodeCommand extends BaseCommand {
           title: 'Initialize',
           task: async (ctx, task) => {
             if (!argv.force) {
-              const confirm = await task.prompt(ListrEnquirerPromptAdapter).run({
-                type: 'toggle',
+              const confirmResult = await task.prompt(ListrInquirerPromptAdapter).run(confirmPrompt, {
                 default: false,
                 message: 'Are you sure you would like to destroy the mirror-node components?',
               });
 
-              if (!confirm) {
+              if (!confirmResult) {
                 process.exit(0);
               }
             }

--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -1,7 +1,8 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-import {ListrEnquirerPromptAdapter} from '@listr2/prompt-adapter-enquirer';
+import {ListrInquirerPromptAdapter} from '@listr2/prompt-adapter-inquirer';
+import {confirm as confirmPrompt} from '@inquirer/prompts';
 import chalk from 'chalk';
 import {Listr} from 'listr2';
 import {IllegalArgumentError, MissingArgumentError, SoloError} from '../core/errors.js';
@@ -1117,13 +1118,12 @@ export class NetworkCommand extends BaseCommand {
           title: 'Initialize',
           task: async (ctx, task) => {
             if (!argv.force) {
-              const confirm = await task.prompt(ListrEnquirerPromptAdapter).run({
-                type: 'toggle',
+              const confirmResult = await task.prompt(ListrInquirerPromptAdapter).run(confirmPrompt, {
                 default: false,
                 message: 'Are you sure you would like to destroy the network components?',
               });
 
-              if (!confirm) {
+              if (!confirmResult) {
                 process.exit(0);
               }
             }

--- a/src/core/config/remote/common_flags_data_wrapper.ts
+++ b/src/core/config/remote/common_flags_data_wrapper.ts
@@ -7,7 +7,7 @@ import {type RemoteConfigCommonFlagsStruct} from './types.js';
 import {type ConfigManager} from '../../config_manager.js';
 import {type CommandFlag} from '../../../types/flag_types.js';
 import {type AnyObject} from '../../../types/aliases.js';
-import {select} from '@inquirer/prompts';
+import {select as selectPrompt} from '@inquirer/prompts';
 
 export class CommonFlagsDataWrapper implements ToObject<RemoteConfigCommonFlagsStruct> {
   private static readonly COMMON_FLAGS: CommandFlag[] = [
@@ -53,7 +53,7 @@ export class CommonFlagsDataWrapper implements ToObject<RemoteConfigCommonFlagsS
         // if the quiet or forced flag is passed don't prompt the user
         if (isQuiet === true || isForced === true) return;
 
-        const answer = await select<string>({
+        const answer = await selectPrompt<string>({
           message: 'Value in remote config differs with the one you are passing, choose which you want to use',
           choices: [
             {

--- a/src/core/resolvers.ts
+++ b/src/core/resolvers.ts
@@ -7,7 +7,7 @@ import {type ConfigManager} from './config_manager.js';
 import {Flags as flags} from '../commands/flags.js';
 import {NamespaceName} from './kube/resources/namespace/namespace_name.js';
 import {type Optional, type SoloListrTaskWrapper} from '../types/index.js';
-import {input} from '@inquirer/prompts';
+import {input as inputPrompt} from '@inquirer/prompts';
 import {SoloError} from './errors.js';
 
 export async function resolveNamespaceFromDeployment(
@@ -42,7 +42,7 @@ export async function promptTheUserForDeployment(
       throw new SoloError('deployment is required');
     }
 
-    const answer = await input({
+    const answer = await inputPrompt({
       message: 'Enter the name of the deployment:',
       validate: (value: string) => !!value,
     });


### PR DESCRIPTION
## Description

Replaced `@listr2/prompt-adapter-enquirer` with `@listr2/prompt-adapter-inquirer`.

### Related Issues

* Closes # https://github.com/hashgraph/solo/issues/1201
