### PR TITLE
chore(security): update the 'ConfigManager.update()' logging to mask sensitive data

### DIFF
--- a/src/core/config_manager.ts
+++ b/src/core/config_manager.ts
@@ -9,11 +9,12 @@ import * as paths from 'path';
 import * as helpers from './helpers.js';
 import type * as yargs from 'yargs';
 import {type CommandFlag} from '../types/flag_types.js';
-import {type ListrTaskWrapper} from 'listr2';
 import {patchInject} from './dependency_injection/container_helper.js';
 import * as constants from '../core/constants.js';
 import {NamespaceName} from './kube/resources/namespace/namespace_name.js';
 import {InjectTokens} from './dependency_injection/inject_tokens.js';
+import {type AnyArgv, type AnyListrContext, type AnyObject, type AnyYargs} from '../types/aliases.js';
+import {type Optional, type SoloListrTaskWrapper} from '../types/index.js';
 
 /**
  * ConfigManager cache command flag values so that user doesn't need to enter the same values repeatedly.
@@ -23,16 +24,17 @@ import {InjectTokens} from './dependency_injection/inject_tokens.js';
  */
 @injectable()
 export class ConfigManager {
-  config!: Record<string, any>;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  public config!: Record<string, any>;
 
-  constructor(@inject(InjectTokens.SoloLogger) private readonly logger?: SoloLogger) {
+  public constructor(@inject(InjectTokens.SoloLogger) private readonly logger?: SoloLogger) {
     this.logger = patchInject(logger, InjectTokens.SoloLogger, this.constructor.name);
 
     this.reset();
   }
 
   /** Reset config */
-  reset() {
+  public reset(): void {
     this.config = {
       flags: {},
       version: helpers.getSoloVersion(),
@@ -47,18 +49,15 @@ export class ConfigManager {
    *  1. User input of the command flag
    *  2. Default value of the command flag if the command is not 'init'.
    */
-  applyPrecedence(argv: yargs.Argv<any>, aliases: any): yargs.Argv<any> {
+  public applyPrecedence(argv: yargs.Argv<AnyYargs>, aliases: AnyObject): yargs.Argv<AnyYargs> {
     for (const key of Object.keys(aliases)) {
       const flag = flags.allFlagsMap.get(key);
       if (flag) {
-        // @ts-ignore
         if (argv[key] !== undefined) {
           // argv takes precedence, nothing to do
         } else if (this.hasFlag(flag)) {
-          // @ts-ignore
           argv[key] = this.getFlag(flag);
         } else {
-          // @ts-ignore
           argv[key] = flag.definition.defaultValue;
         }
       }
@@ -68,81 +67,84 @@ export class ConfigManager {
   }
 
   /** Update the config using the argv */
-  update(argv: object | any = {}) {
-    if (argv && Object.keys(argv).length > 0) {
-      for (const flag of flags.allFlags) {
-        if (argv[flag.name] !== undefined) {
-          let val = argv[flag.name];
-          switch (flag.definition.type) {
-            case 'string':
-              if (val && (flag.name === flags.chartDirectory.name || flag.name === flags.cacheDir.name)) {
-                this.logger.debug(
-                  `Resolving directory path for '${flag.name}': ${val}, to: ${paths.resolve(val)}, note: ~/ is not supported`,
-                );
-                val = paths.resolve(val);
-              }
-              // if it is a namespace flag then convert it to NamespaceName
-              else if (val && (flag.name === flags.namespace.name || flag.name === flags.clusterSetupNamespace.name)) {
-                if (val instanceof NamespaceName) {
-                  this.config.flags[flag.name] = val;
-                  break;
-                }
-                this.config.flags[flag.name] = NamespaceName.of(val);
-                break;
-              }
-              this.config.flags[flag.name] = `${val}`; // force convert to string
-              break;
+  public update(argv: AnyArgv = {}): void {
+    if (!argv || Object.keys(argv).length === 0) return;
 
-            case 'number':
-              try {
-                if (flags.integerFlags.has(flag.name)) {
-                  this.config.flags[flag.name] = Number.parseInt(val);
-                } else {
-                  this.config.flags[flag.name] = Number.parseFloat(val);
-                }
-              } catch (e: Error | any) {
-                throw new SoloError(`invalid number value '${val}': ${e.message}`, e);
-              }
-              break;
+    for (const flag of flags.allFlags) {
+      if (argv[flag.name] === undefined) continue;
 
-            case 'boolean':
-              this.config.flags[flag.name] = val === true || val === 'true'; // use comparison to enforce boolean value
-              break;
-
-            case 'StorageType':
-              // @ts-ignore
-              if (!Object.values(constants.StorageType).includes(`${val}`)) {
-                throw new SoloError(`Invalid storage type value '${val}'`);
-              } else {
-                this.config.flags[flag.name] = val;
-              }
-              break;
-            default:
-              throw new SoloError(`Unsupported field type for flag '${flag.name}': ${flag.definition.type}`);
+      let val = argv[flag.name];
+      switch (flag.definition.type) {
+        case 'string':
+          if (val && (flag.name === flags.chartDirectory.name || flag.name === flags.cacheDir.name)) {
+            this.logger.debug(
+              `Resolving directory path for '${flag.name}': ${val}, to: ${paths.resolve(val)}, note: ~/ is not supported`,
+            );
+            val = paths.resolve(val);
           }
-        }
-      }
+          // if it is a namespace flag then convert it to NamespaceName
+          else if (val && (flag.name === flags.namespace.name || flag.name === flags.clusterSetupNamespace.name)) {
+            if (val instanceof NamespaceName) {
+              this.config.flags[flag.name] = val;
+            } else {
+              this.config.flags[flag.name] = NamespaceName.of(val);
+            }
+            break;
+          }
+          this.config.flags[flag.name] = `${val}`; // force convert to string
+          break;
 
-      // store last command that was run
-      if (argv._) {
-        this.config.lastCommand = argv._;
-      }
+        case 'number':
+          try {
+            if (flags.integerFlags.has(flag.name)) {
+              this.config.flags[flag.name] = Number.parseInt(val);
+            } else {
+              this.config.flags[flag.name] = Number.parseFloat(val);
+            }
+          } catch (e) {
+            throw new SoloError(`invalid number value '${val}': ${e.message}`, e);
+          }
+          break;
 
-      this.config.updatedAt = new Date().toISOString();
-      let flagMessage = '';
-      for (const key of Object.keys(this.config.flags)) {
-        if (this.config.flags[key]) {
-          flagMessage += `${key}=${this.config.flags[key]}, `;
-        }
-      }
-      if (flagMessage) {
-        this.logger.debug(`Updated config with flags: ${flagMessage}`);
+        case 'boolean':
+          this.config.flags[flag.name] = val === true || val === 'true'; // use comparison to enforce boolean value
+          break;
+
+        case 'StorageType':
+          // @ts-expect-error: TS2475: const enums can only be used in property or index access expressions
+          if (!Object.values(constants.StorageType).includes(`${val}`)) {
+            throw new SoloError(`Invalid storage type value '${val}'`);
+          } else {
+            this.config.flags[flag.name] = val;
+          }
+          break;
+        default:
+          throw new SoloError(`Unsupported field type for flag '${flag.name}': ${flag.definition.type}`);
       }
     }
+
+    // store last command that was run
+    if (argv._) {
+      this.config.lastCommand = argv._;
+    }
+
+    this.config.updatedAt = new Date().toISOString();
+
+    const flagMessage = Object.entries(this.config.flags)
+      .filter(entries => entries[1] !== undefined && entries[1] !== null)
+      .map(([key, value]) => {
+        const flag = flags.allFlagsMap.get(key);
+        const dataMask: Optional<string> = flag.definition.dataMask;
+
+        return `${key}=${dataMask ? dataMask : value}`;
+      })
+      .join(', ');
+
+    if (flagMessage) this.logger.debug(`Updated config with flags: ${flagMessage}`);
   }
 
   /** Check if a flag value is set */
-  hasFlag(flag: CommandFlag) {
+  public hasFlag(flag: CommandFlag): boolean {
     return this.config.flags[flag.name] !== undefined;
   }
 
@@ -150,16 +152,12 @@ export class ConfigManager {
    * Return the value of the given flag
    * @returns value of the flag or undefined if flag value is not available
    */
-  getFlag<T>(flag: CommandFlag): undefined | T {
-    if (this.config.flags[flag.name] !== undefined) {
-      return this.config.flags[flag.name];
-    }
-
-    return undefined;
+  public getFlag<T = string>(flag: CommandFlag): T {
+    return this.config.flags[flag.name] !== undefined ? this.config.flags[flag.name] : undefined;
   }
 
   /** Set value for the flag */
-  setFlag<T>(flag: CommandFlag, value: T) {
+  public setFlag<T>(flag: CommandFlag, value: T): void {
     if (!flag || !flag.name) throw new MissingArgumentError('flag must have a name');
     // if it is a namespace then convert it to NamespaceName
     if (flag.name === flags.namespace.name || flag.name === flags.clusterSetupNamespace.name) {
@@ -175,7 +173,7 @@ export class ConfigManager {
   }
 
   /** Get package version */
-  getVersion(): string {
+  public getVersion(): string {
     return this.config.version;
   }
 
@@ -184,7 +182,7 @@ export class ConfigManager {
    * @param task task object from listr2
    * @param flagList list of flag objects
    */
-  async executePrompt(task: ListrTaskWrapper<any, any, any>, flagList: CommandFlag[] = []) {
+  public async executePrompt(task: SoloListrTaskWrapper<AnyListrContext>, flagList: CommandFlag[] = []): Promise<void> {
     for (const flag of flagList) {
       if (flag.definition.disablePrompt || flag.prompt === undefined) {
         continue;

--- a/src/types/aliases.ts
+++ b/src/types/aliases.ts
@@ -39,5 +39,6 @@ export type DirPath = string;
 export type AnyObject = Record<any, any>;
 export type AnyArgv = any;
 export type AnyYargs = any;
+export type AnyListrContext = any;
 
 export type SdkNetworkEndpoint = `${string}:${number}`;


### PR DESCRIPTION
## Description

- added data masking for debug log
- fixed lint warnings
- added access modifiers
- simplified code for ConfigManager

### Related Issues

* Closes # https://github.com/hashgraph/solo/issues/1527
