### PR TITLE
chore: fix tsdoc warnings

### DIFF
--- a/docs/site/Taskfile.yaml
+++ b/docs/site/Taskfile.yaml
@@ -76,7 +76,7 @@ tasks:
   build:typedoc:
     dir: ../..
     cmds:
-      - npx typedoc --out docs/site/public/static/Classes --entryPoints ./solo.ts --entryPoints ./src/index.ts --entryPointStrategy expand ./src
+      - npx typedoc --excludeExternals --out docs/site/public/static/Classes --entryPoints ./solo.ts --entryPoints ./src/index.ts --entryPointStrategy expand ./src
 
   build:copy:
     cmds:

--- a/docs/site/content/User/SoloCommands.md
+++ b/docs/site/content/User/SoloCommands.md
@@ -204,7 +204,7 @@ Options:
       --dev                 Enable developer mode                      [boolean]
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -i, --node-aliases        Comma separated node aliases (empty means all nodes)
                                                                         [string]
@@ -231,7 +231,7 @@ Options:
       --hbar-amount          Amount of HBAR to add                      [number]
       --create-amount        Amount of new account to create            [number]
       --ecdsa-private-key    ECDSA private key for the Hedera account   [string]
-      --deployment           The name the user will reference locally to link to
+  -d, --deployment           The name the user will reference locally to link to
                               a deployment                              [string]
       --ed25519-private-key  ED25519 private key for the Hedera account [string]
       --generate-ecdsa-key   Generate ECDSA private key for the Hedera account
@@ -260,7 +260,7 @@ Options:
                                                                        [boolean]
       --account-id           The Hedera account id, e.g.: 0.0.1001      [string]
       --hbar-amount          Amount of HBAR to add                      [number]
-      --deployment           The name the user will reference locally to link to
+  -d, --deployment           The name the user will reference locally to link to
                               a deployment                              [string]
       --ecdsa-private-key    ECDSA private key for the Hedera account   [string]
       --ed25519-private-key  ED25519 private key for the Hedera account [string]
@@ -284,7 +284,7 @@ Options:
                                                                        [boolean]
       --account-id          The Hedera account id, e.g.: 0.0.1001       [string]
       --private-key         Show private key information               [boolean]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -h, --help                Show help                                  [boolean]
   -v, --version             Show version number                        [boolean]
@@ -330,7 +330,7 @@ Options:
       --dev                 Enable developer mode                      [boolean]
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -q, --quiet-mode          Quiet mode, do not prompt for confirmation [boolean]
   -c, --cluster-ref         The cluster reference that will be used for referenc
@@ -397,7 +397,7 @@ Options:
       --dev                      Enable developer mode                 [boolean]
       --force-port-forward       Force port forward to access the network servic
                                  es                                    [boolean]
-  -d, --chart-dir                Local chart directory path (e.g. ~/solo-charts/
+      --chart-dir                Local chart directory path (e.g. ~/solo-charts/
                                  charts                                 [string]
   -c, --cluster-ref              The cluster reference that will be used for ref
                                  erencing the Kubernetes cluster and stored in t
@@ -499,7 +499,7 @@ Options:
                                    is                                   [string]
       --cache-dir                  Local cache directory                [string]
   -l, --ledger-id                  Ledger ID (a.k.a. Chain ID)          [string]
-  -d, --chart-dir                  Local chart directory path (e.g. ~/solo-chart
+      --chart-dir                  Local chart directory path (e.g. ~/solo-chart
                                    s/charts                             [string]
       --prometheus-svc-monitor     Enable prometheus service monitor for the net
                                    work nodes                          [boolean]
@@ -509,7 +509,7 @@ Options:
       --load-balancer              Enable load balancer for network node proxies
                                                                        [boolean]
       --log4j2-xml                 log4j2.xml file for node             [string]
-      --deployment                 The name the user will reference locally to l
+  -d, --deployment                 The name the user will reference locally to l
                                    ink to a deployment                  [string]
   -i, --node-aliases               Comma separated node aliases (empty means all
                                     nodes)                              [string]
@@ -586,7 +586,7 @@ Options:
       --delete-secrets      Delete the network secrets                 [boolean]
       --enable-timeout      enable time out for running a command      [boolean]
   -f, --force               Force actions even if those can be skipped [boolean]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -q, --quiet-mode          Quiet mode, do not prompt for confirmation [boolean]
   -h, --help                Show help                                  [boolean]
@@ -620,7 +620,7 @@ Options:
                                    is                                   [string]
       --cache-dir                  Local cache directory                [string]
   -l, --ledger-id                  Ledger ID (a.k.a. Chain ID)          [string]
-  -d, --chart-dir                  Local chart directory path (e.g. ~/solo-chart
+      --chart-dir                  Local chart directory path (e.g. ~/solo-chart
                                    s/charts                             [string]
       --prometheus-svc-monitor     Enable prometheus service monitor for the net
                                    work nodes                          [boolean]
@@ -630,7 +630,7 @@ Options:
       --load-balancer              Enable load balancer for network node proxies
                                                                        [boolean]
       --log4j2-xml                 log4j2.xml file for node             [string]
-      --deployment                 The name the user will reference locally to l
+  -d, --deployment                 The name the user will reference locally to l
                                    ink to a deployment                  [string]
   -i, --node-aliases               Comma separated node aliases (empty means all
                                     nodes)                              [string]
@@ -771,7 +771,7 @@ Options:
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
       --cache-dir           Local cache directory                       [string]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -t, --release-tag         Release tag to be used (e.g. v0.58.10)      [string]
       --app                 Testing app name                            [string]
@@ -801,7 +801,7 @@ Options:
       --dev                 Enable developer mode                      [boolean]
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -t, --release-tag         Release tag to be used (e.g. v0.58.10)      [string]
       --app                 Testing app name                            [string]
@@ -833,7 +833,7 @@ Options:
       --dev                 Enable developer mode                      [boolean]
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -i, --node-aliases        Comma separated node aliases (empty means all nodes)
                                                                         [string]
@@ -859,7 +859,7 @@ Options:
       --cache-dir           Local cache directory                       [string]
       --gossip-keys         Generate gossip keys for nodes             [boolean]
       --tls-keys            Generate gRPC TLS keys for nodes           [boolean]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -q, --quiet-mode          Quiet mode, do not prompt for confirmation [boolean]
   -i, --node-aliases        Comma separated node aliases (empty means all nodes)
@@ -883,7 +883,7 @@ Options:
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
       --cache-dir           Local cache directory                       [string]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -i, --node-aliases        Comma separated node aliases (empty means all nodes)
                                                                         [string]
@@ -910,7 +910,7 @@ Options:
       --dev                 Enable developer mode                      [boolean]
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -i, --node-aliases        Comma separated node aliases (empty means all nodes)
                                                                         [string]
@@ -934,7 +934,7 @@ Options:
       --dev                 Enable developer mode                      [boolean]
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -i, --node-aliases        Comma separated node aliases (empty means all nodes)
                                                                         [string]
@@ -961,7 +961,7 @@ Options:
       --endpoint-type       Endpoint type (IP or FQDN)                  [string]
       --gossip-keys         Generate gossip keys for nodes             [boolean]
       --tls-keys            Generate gRPC TLS keys for nodes           [boolean]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -t, --release-tag         Release tag to be used (e.g. v0.58.10)      [string]
       --app                 Testing app name                            [string]
@@ -989,7 +989,7 @@ Options:
                             8)                                          [string]
   -f, --force               Force actions even if those can be skipped [boolean]
       --local-build-path    path of hedera local repo                   [string]
-  -d, --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
+      --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
                             s                                           [string]
   -q, --quiet-mode          Quiet mode, do not prompt for confirmation [boolean]
       --admin-key           Admin key                                   [string]
@@ -1021,7 +1021,7 @@ Options:
       --endpoint-type       Endpoint type (IP or FQDN)                  [string]
       --gossip-keys         Generate gossip keys for nodes             [boolean]
       --tls-keys            Generate gRPC TLS keys for nodes           [boolean]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -t, --release-tag         Release tag to be used (e.g. v0.58.10)      [string]
       --output-dir          Path to the directory where the command context will
@@ -1051,7 +1051,7 @@ Options:
                             8)                                          [string]
   -f, --force               Force actions even if those can be skipped [boolean]
       --local-build-path    path of hedera local repo                   [string]
-  -d, --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
+      --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
                             s                                           [string]
   -q, --quiet-mode          Quiet mode, do not prompt for confirmation [boolean]
       --admin-key           Admin key                                   [string]
@@ -1077,7 +1077,7 @@ Options:
       --endpoint-type       Endpoint type (IP or FQDN)                  [string]
       --gossip-keys         Generate gossip keys for nodes             [boolean]
       --tls-keys            Generate gRPC TLS keys for nodes           [boolean]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -t, --release-tag         Release tag to be used (e.g. v0.58.10)      [string]
       --input-dir           Path to the directory where the command context will
@@ -1107,7 +1107,7 @@ Options:
                             8)                                          [string]
   -f, --force               Force actions even if those can be skipped [boolean]
       --local-build-path    path of hedera local repo                   [string]
-  -d, --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
+      --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
                             s                                           [string]
   -q, --quiet-mode          Quiet mode, do not prompt for confirmation [boolean]
   -h, --help                Show help                                  [boolean]
@@ -1132,7 +1132,7 @@ Options:
       --endpoint-type       Endpoint type (IP or FQDN)                  [string]
       --gossip-keys         Generate gossip keys for nodes             [boolean]
       --tls-keys            Generate gRPC TLS keys for nodes           [boolean]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -t, --release-tag         Release tag to be used (e.g. v0.58.10)      [string]
       --input-dir           Path to the directory where the command context will
@@ -1162,7 +1162,7 @@ Options:
                             8)                                          [string]
   -f, --force               Force actions even if those can be skipped [boolean]
       --local-build-path    path of hedera local repo                   [string]
-  -d, --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
+      --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
                             s                                           [string]
   -q, --quiet-mode          Quiet mode, do not prompt for confirmation [boolean]
       --haproxy-ips         IP mapping where key = value is node alias and stati
@@ -1190,7 +1190,7 @@ Options:
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
       --cache-dir           Local cache directory                       [string]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -t, --release-tag         Release tag to be used (e.g. v0.58.10)      [string]
       --node-alias          Node alias (e.g. node99)                    [string]
@@ -1210,7 +1210,7 @@ Options:
                             sip in PEM key format to be used            [string]
       --tls-private-key     path and file name of the private TLS key to be used
                                                                         [string]
-  -d, --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
+      --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
                             s                                           [string]
   -q, --quiet-mode          Quiet mode, do not prompt for confirmation [boolean]
       --local-build-path    path of hedera local repo                   [string]
@@ -1239,7 +1239,7 @@ Options:
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
       --cache-dir           Local cache directory                       [string]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -t, --release-tag         Release tag to be used (e.g. v0.58.10)      [string]
       --output-dir          Path to the directory where the command context will
@@ -1261,7 +1261,7 @@ Options:
                             sip in PEM key format to be used            [string]
       --tls-private-key     path and file name of the private TLS key to be used
                                                                         [string]
-  -d, --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
+      --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
                             s                                           [string]
   -q, --quiet-mode          Quiet mode, do not prompt for confirmation [boolean]
       --local-build-path    path of hedera local repo                   [string]
@@ -1290,7 +1290,7 @@ Options:
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
       --cache-dir           Local cache directory                       [string]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -t, --release-tag         Release tag to be used (e.g. v0.58.10)      [string]
       --input-dir           Path to the directory where the command context will
@@ -1300,7 +1300,7 @@ Options:
                             ode id                                      [string]
       --endpoint-type       Endpoint type (IP or FQDN)                  [string]
       --solo-chart-version  Solo testing chart version                  [string]
-  -d, --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
+      --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
                             s                                           [string]
   -q, --quiet-mode          Quiet mode, do not prompt for confirmation [boolean]
       --local-build-path    path of hedera local repo                   [string]
@@ -1328,7 +1328,7 @@ Options:
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
       --cache-dir           Local cache directory                       [string]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -t, --release-tag         Release tag to be used (e.g. v0.58.10)      [string]
       --input-dir           Path to the directory where the command context will
@@ -1338,7 +1338,7 @@ Options:
                             ode id                                      [string]
       --endpoint-type       Endpoint type (IP or FQDN)                  [string]
       --solo-chart-version  Solo testing chart version                  [string]
-  -d, --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
+      --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
                             s                                           [string]
   -q, --quiet-mode          Quiet mode, do not prompt for confirmation [boolean]
       --local-build-path    path of hedera local repo                   [string]
@@ -1366,7 +1366,7 @@ Options:
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
       --cache-dir           Local cache directory                       [string]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
       --node-alias          Node alias (e.g. node99)                    [string]
   -t, --release-tag         Release tag to be used (e.g. v0.58.10)      [string]
@@ -1379,7 +1379,7 @@ Options:
   -f, --force               Force actions even if those can be skipped [boolean]
       --local-build-path    path of hedera local repo                   [string]
   -q, --quiet-mode          Quiet mode, do not prompt for confirmation [boolean]
-  -d, --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
+      --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
                             s                                           [string]
   -h, --help                Show help                                  [boolean]
   -v, --version             Show version number                        [boolean]
@@ -1400,7 +1400,7 @@ Options:
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
       --cache-dir           Local cache directory                       [string]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
       --node-alias          Node alias (e.g. node99)                    [string]
   -t, --release-tag         Release tag to be used (e.g. v0.58.10)      [string]
@@ -1415,7 +1415,7 @@ Options:
   -f, --force               Force actions even if those can be skipped [boolean]
       --local-build-path    path of hedera local repo                   [string]
   -q, --quiet-mode          Quiet mode, do not prompt for confirmation [boolean]
-  -d, --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
+      --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
                             s                                           [string]
   -h, --help                Show help                                  [boolean]
   -v, --version             Show version number                        [boolean]
@@ -1436,7 +1436,7 @@ Options:
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
       --cache-dir           Local cache directory                       [string]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
       --node-alias          Node alias (e.g. node99)                    [string]
   -t, --release-tag         Release tag to be used (e.g. v0.58.10)      [string]
@@ -1451,7 +1451,7 @@ Options:
   -f, --force               Force actions even if those can be skipped [boolean]
       --local-build-path    path of hedera local repo                   [string]
   -q, --quiet-mode          Quiet mode, do not prompt for confirmation [boolean]
-  -d, --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
+      --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
                             s                                           [string]
   -h, --help                Show help                                  [boolean]
   -v, --version             Show version number                        [boolean]
@@ -1472,7 +1472,7 @@ Options:
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
       --cache-dir           Local cache directory                       [string]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
       --node-alias          Node alias (e.g. node99)                    [string]
   -t, --release-tag         Release tag to be used (e.g. v0.58.10)      [string]
@@ -1487,7 +1487,7 @@ Options:
   -f, --force               Force actions even if those can be skipped [boolean]
       --local-build-path    path of hedera local repo                   [string]
   -q, --quiet-mode          Quiet mode, do not prompt for confirmation [boolean]
-  -d, --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
+      --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
                             s                                           [string]
   -h, --help                Show help                                  [boolean]
   -v, --version             Show version number                        [boolean]
@@ -1507,7 +1507,7 @@ Options:
       --dev                 Enable developer mode                      [boolean]
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
       --cache-dir           Local cache directory                       [string]
   -t, --release-tag         Release tag to be used (e.g. v0.58.10)      [string]
@@ -1531,7 +1531,7 @@ Options:
       --dev                 Enable developer mode                      [boolean]
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
       --cache-dir           Local cache directory                       [string]
   -t, --release-tag         Release tag to be used (e.g. v0.58.10)      [string]
@@ -1555,7 +1555,7 @@ Options:
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
       --cache-dir           Local cache directory                       [string]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -t, --release-tag         Release tag to be used (e.g. v0.58.10)      [string]
       --upgrade-zip-file    A zipped file used for network upgrade      [string]
@@ -1565,7 +1565,7 @@ Options:
   -i, --node-aliases        Comma separated node aliases (empty means all nodes)
                                                                         [string]
       --solo-chart-version  Solo testing chart version                  [string]
-  -d, --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
+      --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
                             s                                           [string]
   -q, --quiet-mode          Quiet mode, do not prompt for confirmation [boolean]
       --local-build-path    path of hedera local repo                   [string]
@@ -1589,7 +1589,7 @@ Options:
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
       --cache-dir           Local cache directory                       [string]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -t, --release-tag         Release tag to be used (e.g. v0.58.10)      [string]
       --upgrade-zip-file    A zipped file used for network upgrade      [string]
@@ -1601,7 +1601,7 @@ Options:
   -i, --node-aliases        Comma separated node aliases (empty means all nodes)
                                                                         [string]
       --solo-chart-version  Solo testing chart version                  [string]
-  -d, --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
+      --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
                             s                                           [string]
   -q, --quiet-mode          Quiet mode, do not prompt for confirmation [boolean]
       --local-build-path    path of hedera local repo                   [string]
@@ -1625,7 +1625,7 @@ Options:
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
       --cache-dir           Local cache directory                       [string]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -t, --release-tag         Release tag to be used (e.g. v0.58.10)      [string]
       --input-dir           Path to the directory where the command context will
@@ -1636,7 +1636,7 @@ Options:
   -i, --node-aliases        Comma separated node aliases (empty means all nodes)
                                                                         [string]
       --solo-chart-version  Solo testing chart version                  [string]
-  -d, --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
+      --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
                             s                                           [string]
   -q, --quiet-mode          Quiet mode, do not prompt for confirmation [boolean]
       --local-build-path    path of hedera local repo                   [string]
@@ -1660,7 +1660,7 @@ Options:
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
       --cache-dir           Local cache directory                       [string]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -t, --release-tag         Release tag to be used (e.g. v0.58.10)      [string]
       --input-dir           Path to the directory where the command context will
@@ -1671,7 +1671,7 @@ Options:
   -i, --node-aliases        Comma separated node aliases (empty means all nodes)
                                                                         [string]
       --solo-chart-version  Solo testing chart version                  [string]
-  -d, --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
+      --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
                             s                                           [string]
   -q, --quiet-mode          Quiet mode, do not prompt for confirmation [boolean]
       --local-build-path    path of hedera local repo                   [string]
@@ -1694,7 +1694,7 @@ Options:
       --dev                 Enable developer mode                      [boolean]
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
       --cache-dir           Local cache directory                       [string]
   -t, --release-tag         Release tag to be used (e.g. v0.58.10)      [string]
@@ -1740,14 +1740,14 @@ Options:
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
   -l, --ledger-id           Ledger ID (a.k.a. Chain ID)                 [string]
-  -d, --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
+      --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
                             s                                           [string]
   -c, --cluster-ref         The cluster reference that will be used for referenc
                             ing the Kubernetes cluster and stored in the local a
                             nd remote configuration for the deployment.  For com
                             mands that take multiple clusters they can be separa
                             ted by commas.                              [string]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -i, --node-aliases        Comma separated node aliases (empty means all nodes)
                                                                         [string]
@@ -1779,9 +1779,9 @@ Options:
       --dev                 Enable developer mode                      [boolean]
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
-  -d, --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
+      --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
                             s                                           [string]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -q, --quiet-mode          Quiet mode, do not prompt for confirmation [boolean]
   -i, --node-aliases        Comma separated node aliases (empty means all nodes)
@@ -1833,9 +1833,9 @@ Options:
                                            commands that take multiple clusters
                                           they can be separated by commas.
                                                                         [string]
-  -d, --chart-dir                         Local chart directory path (e.g. ~/sol
+      --chart-dir                         Local chart directory path (e.g. ~/sol
                                           o-charts/charts               [string]
-      --deployment                        The name the user will reference local
+  -d, --deployment                        The name the user will reference local
                                           ly to link to a deployment    [string]
       --profile-file                      Resource profile definition (e.g. cust
                                           om-spec.yaml)                 [string]
@@ -1900,7 +1900,7 @@ Options:
       --dev                 Enable developer mode                      [boolean]
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
-  -d, --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
+      --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
                             s                                           [string]
   -c, --cluster-ref         The cluster reference that will be used for referenc
                             ing the Kubernetes cluster and stored in the local a
@@ -1909,7 +1909,7 @@ Options:
                             ted by commas.                              [string]
   -f, --force               Force actions even if those can be skipped [boolean]
   -q, --quiet-mode          Quiet mode, do not prompt for confirmation [boolean]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -h, --help                Show help                                  [boolean]
   -v, --version             Show version number                        [boolean]
@@ -1951,7 +1951,7 @@ Options:
       --dev                            Enable developer mode           [boolean]
       --force-port-forward             Force port forward to access the network
                                        services                        [boolean]
-  -d, --chart-dir                      Local chart directory path (e.g. ~/solo-c
+      --chart-dir                      Local chart directory path (e.g. ~/solo-c
                                        harts/charts                     [string]
   -c, --cluster-ref                    The cluster reference that will be used f
                                        or referencing the Kubernetes cluster and
@@ -1976,7 +1976,7 @@ Options:
       --mirror-static-ip               static IP address for the mirror node
                                                                         [string]
   -n, --namespace                      Namespace                        [string]
-      --deployment                     The name the user will reference locally
+  -d, --deployment                     The name the user will reference locally
                                        to link to a deployment          [string]
       --profile-file                   Resource profile definition (e.g. custom-
                                        spec.yaml)                       [string]
@@ -2009,7 +2009,7 @@ Options:
       --dev                 Enable developer mode                      [boolean]
       --force-port-forward  Force port forward to access the network services
                                                                        [boolean]
-  -d, --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
+      --chart-dir           Local chart directory path (e.g. ~/solo-charts/chart
                             s                                           [string]
   -c, --cluster-ref         The cluster reference that will be used for referenc
                             ing the Kubernetes cluster and stored in the local a
@@ -2018,7 +2018,7 @@ Options:
                             ted by commas.                              [string]
   -f, --force               Force actions even if those can be skipped [boolean]
   -q, --quiet-mode          Quiet mode, do not prompt for confirmation [boolean]
-      --deployment          The name the user will reference locally to link to
+  -d, --deployment          The name the user will reference locally to link to
                             a deployment                                [string]
   -h, --help                Show help                                  [boolean]
   -v, --version             Show version number                        [boolean]
@@ -2071,7 +2071,7 @@ Options:
                              parated by commas.                         [string]
       --email                User email address used for local configuration
                                                                         [string]
-      --deployment           The name the user will reference locally to link to
+  -d, --deployment           The name the user will reference locally to link to
                               a deployment                              [string]
       --deployment-clusters  Solo deployment cluster list (comma separated)
                                                                         [string]

--- a/src/commands/explorer.ts
+++ b/src/commands/explorer.ts
@@ -21,7 +21,7 @@ import {type ClusterChecks} from '../core/cluster_checks.js';
 import {container} from 'tsyringe-neo';
 import {InjectTokens} from '../core/dependency_injection/inject_tokens.js';
 
-interface ExplorerDeployConfigClass {
+export interface ExplorerDeployConfigClass {
   chartDirectory: string;
   clusterRef: string;
   clusterContext: string;

--- a/src/commands/mirror_node.ts
+++ b/src/commands/mirror_node.ts
@@ -32,7 +32,7 @@ import {PvcName} from '../core/kube/resources/pvc/pvc_name.js';
 import {type ClusterRef, type DeploymentName} from '../core/config/remote/types.js';
 import {extractContextFromConsensusNodes} from '../core/helpers.js';
 
-interface MirrorNodeDeployConfigClass {
+export interface MirrorNodeDeployConfigClass {
   chartDirectory: string;
   clusterContext: string;
   namespace: NamespaceName;
@@ -61,7 +61,7 @@ interface MirrorNodeDeployConfigClass {
   externalDatabaseReadonlyPassword: Optional<string>;
 }
 
-interface Context {
+export interface Context {
   config: MirrorNodeDeployConfigClass;
   addressBook: string;
 }

--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -88,7 +88,7 @@ export interface NetworkDeployConfigClass {
   clusterRefs: ClusterRefs;
 }
 
-interface NetworkDestroyContext {
+export interface NetworkDestroyContext {
   config: {
     deletePvcs: boolean;
     deleteSecrets: boolean;
@@ -558,7 +558,6 @@ export class NetworkCommand extends BaseCommand {
    * @param consensusNodes - the consensus nodes to iterate over
    * @param valuesArgs - the values arguments to add to
    * @param templateString - the template string to add
-   * @private
    */
   private addArgForEachRecord(
     records: Record<NodeAlias, string>,

--- a/src/commands/node/configs.ts
+++ b/src/commands/node/configs.ts
@@ -605,7 +605,7 @@ export interface NodeUpdateConfigClass {
   contexts: string[];
 }
 
-interface NodePrepareUpgradeConfigClass {
+export interface NodePrepareUpgradeConfigClass {
   cacheDir: string;
   namespace: NamespaceName;
   deployment: string;
@@ -617,7 +617,7 @@ interface NodePrepareUpgradeConfigClass {
   contexts: string[];
 }
 
-interface NodeDownloadGeneratedFilesConfigClass {
+export interface NodeDownloadGeneratedFilesConfigClass {
   cacheDir: string;
   namespace: NamespaceName;
   deployment: string;

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -1077,7 +1077,6 @@ export class NodeCommandTasks {
 
   /**
    * Generate genesis network json file
-   * @private
    * @param namespace - namespace
    * @param consensusNodes - consensus nodes
    * @param keysDir - keys directory

--- a/src/core/account_manager.ts
+++ b/src/core/account_manager.ts
@@ -340,7 +340,6 @@ export class AccountManager {
   /**
    * pings the node client at a set interval, can throw an exception if the ping fails
    * @param operatorId
-   * @private
    */
   private startIntervalPinger(operatorId: string) {
     const interval = constants.NODE_CLIENT_PING_INTERVAL;
@@ -416,7 +415,6 @@ export class AccountManager {
    * @param obj - the object containing the network node service and the account id
    * @param accountId - the account id to ping
    * @throws {@link SoloError} if the ping fails
-   * @private
    */
   private async testNodeClientConnection(obj: Record<SdkNetworkEndpoint, AccountId>, accountId: AccountId) {
     const maxRetries = constants.NODE_CLIENT_PING_MAX_RETRIES;
@@ -1008,7 +1006,6 @@ export class AccountManager {
    * @param obj - the network node object where the key is the network endpoint and the value is the account id
    * @param accountId - the account id to ping
    * @throws {@link SoloError} if the ping fails
-   * @private
    */
   private async pingNetworkNode(obj: Record<SdkNetworkEndpoint, AccountId>, accountId: AccountId) {
     let nodeClient: Client;

--- a/src/core/config/remote/enumerations.ts
+++ b/src/core/config/remote/enumerations.ts
@@ -1,6 +1,8 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
+import {ComponentsDataWrapper} from './components_data_wrapper.js';
+import {ConsensusNodeComponent} from './components/consensus_node_component.js';
 
 /**
  * Enumerations that represent the component types used in remote config

--- a/src/core/config/remote/enumerations.ts
+++ b/src/core/config/remote/enumerations.ts
@@ -1,12 +1,9 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-import {ComponentsDataWrapper} from './components_data_wrapper.js';
-import {ConsensusNodeComponent} from './components/consensus_node_component.js';
 
 /**
  * Enumerations that represent the component types used in remote config
- * {@link ComponentsDataWrapper}
  */
 export enum ComponentType {
   ConsensusNode = 'consensusNodes',
@@ -19,7 +16,6 @@ export enum ComponentType {
 
 /**
  * Enumerations that represent the state of consensus node in remote config
- * {@link ConsensusNodeComponent}
  */
 export enum ConsensusNodeStates {
   REQUESTED = 'requested',

--- a/src/core/config/remote/remote_config_manager.ts
+++ b/src/core/config/remote/remote_config_manager.ts
@@ -91,7 +91,7 @@ export class RemoteConfigManager {
    * The callback operates on the configuration data, which is then saved to the cluster.
    *
    * @param callback - an async function that modifies the remote configuration data.
-   * @throws {@link SoloError} if the configuration is not loaded before modification.
+   * @throws if the configuration is not loaded before modification, will throw a SoloError {@link SoloError}
    */
   public async modify(callback: (remoteConfig: RemoteConfigDataWrapper) => Promise<void>): Promise<void> {
     if (!this.remoteConfig) {
@@ -362,7 +362,7 @@ export class RemoteConfigManager {
    * Retrieves the ConfigMap containing the remote configuration from the Kubernetes cluster.
    *
    * @returns the remote configuration data.
-   * @throws {@link SoloError} if the ConfigMap could not be read and the error is not a 404 status.
+   * @throws if the ConfigMap could not be read and the error is not a 404 status, will throw a SoloError {@link SoloError}
    */
   public async getConfigMap(): Promise<k8s.V1ConfigMap> {
     try {

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -118,7 +118,7 @@ export const NODE_LOG_FAILURE_MSG = 'failed to download logs from pod';
 
 /**
  * Listr related
- * @return a object that defines the default color options
+ * @returns a object that defines the default color options
  */
 export const LISTR_DEFAULT_RENDERER_TIMER_OPTION = {
   ...PRESET_TIMER,

--- a/src/core/key_manager.ts
+++ b/src/core/key_manager.ts
@@ -423,7 +423,7 @@ export class KeyManager {
    * @param keysDir - keys directory
    * @param curDate - current date
    * @param [allNodeAliases] - includes the nodeAliases to get new keys as well as existing nodeAliases that will be included in the public.pfx file
-   * @return a list of subtasks
+   * @returns a list of subtasks
    */
   taskGenerateGossipKeys(
     nodeAliases: NodeAliases,
@@ -466,7 +466,7 @@ export class KeyManager {
    * @param nodeAliases
    * @param keysDir keys directory
    * @param curDate current date
-   * @return return a list of subtasks
+   * @returns return a list of subtasks
    */
   taskGenerateTLSKeys(nodeAliases: NodeAliases, keysDir: string, curDate = new Date()) {
     // check if nodeAliases is an array of strings

--- a/src/core/kube/k8_client/k8_client_base.ts
+++ b/src/core/kube/k8_client/k8_client_base.ts
@@ -61,7 +61,6 @@ export abstract class K8ClientBase {
    * Wraps the V1ObjectMeta object instance into a ObjectMeta instance.
    *
    * @param v1meta - the V1ObjectMeta object from the K8S API client.
-   * @protected
    */
   protected wrapObjectMeta(v1meta: V1ObjectMeta): ObjectMeta {
     if (!v1meta) {

--- a/src/core/kube/k8_client/k8_client_factory.ts
+++ b/src/core/kube/k8_client/k8_client_factory.ts
@@ -22,7 +22,6 @@ export class K8ClientFactory implements K8Factory {
    * Create a new k8Factory client for the given context
    * @param context - The context to create the k8Factory client for
    * @returns a new k8Factory client
-   * @private
    */
   private createK8Client(context: string): K8 {
     return new K8Client(context);

--- a/src/core/platform_installer.ts
+++ b/src/core/platform_installer.ts
@@ -319,7 +319,6 @@ export class PlatformInstaller {
    * @param podRef - pod reference
    * @param isGenesis - true if this is `solo node setup` and we are at genesis
    * @param context
-   * @private
    */
   private async copyConfigurationFiles(stagingDir: string, podRef: PodRef, isGenesis: boolean, context?: string) {
     if (isGenesis) {

--- a/src/core/profile_manager.ts
+++ b/src/core/profile_manager.ts
@@ -155,7 +155,6 @@ export class ProfileManager {
    * @param itemPath - item path in the YAML, if empty then root of the YAML object will be used
    * @param items - the element object
    * @param yamlRoot - root of the YAML object to update
-   * @private
    */
   _setChartItems(itemPath: string, items: any, yamlRoot: AnyObject) {
     if (!items) return;


### PR DESCRIPTION
## Description

This pull request changes the following:

* Fixed some tsDoc warning
* There are a few warnings left untouched due to some code were commented out and will be restored later
* Added "excludeExternals" flag to typedoc to ignore warning from external libraries

### Related Issues

#1522