### PR TITLE
fix: node keys should be called after deployment command

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -41,8 +41,8 @@ tasks:
       - task: "cluster:create"
       - task: "solo:init"
       - task: "solo:cluster:setup"
-      - task: "solo:keys"
       - task: "solo:deployment:create"
+      - task: "solo:keys"
       - task: "solo:network:deploy"
 
   destroy:


### PR DESCRIPTION
## Description

This pull request changes the following:

* node keys should be called after deployment command since deployment flag is added to task solo:init command

### Related Issues

N/A