### PR TITLE
chore: Enhance Grammar and Clarity in Solo Documentation

### DIFF
--- a/DEV.md
+++ b/DEV.md
@@ -1,6 +1,6 @@
 # Instructions for developers working on solo project
 
-Below we describe how you can set up local environment and contribute to `solo`.
+Below we describe how you can set up a local environment and contribute to `solo`.
 
 * Clone the repo
 * In order to support ES6 modules with `jest`, set an env variable `NODE_OPTIONS` as below:

--- a/docs/site/content/User/PlatformDeveloper.md
+++ b/docs/site/content/User/PlatformDeveloper.md
@@ -1,7 +1,7 @@
 ### Use solo with local build platform code
 
 First, please clone hedera service repo `https://github.com/hiero-ledger/hiero-consensus-node/` and build the code
-with `./gradlew assemble`. If need to running nodes with different versions or releases, please duplicate the repo or build directories in
+with `./gradlew assemble`. If need to run nodes with different versions or releases, please duplicate the repo or build directories in
 multiple directories, checkout to the respective version and build the code.
 
 Then you can start customized built platform testing application with the following command:


### PR DESCRIPTION
 Original:
Below we describe how you can set up local environment and contribute to `solo`.
Updated:
Below we describe how you can set up a local environment and contribute to `solo`.
Reason for Change:
Added "a" before "local environment" because "environment" is a singular countable noun, which requires an article.
This change improves grammatical correctness and readability.
Original:
with `./gradlew assemble`. If need to running nodes with different versions or releases, please duplicate the repo or build directories in
Updated:
with `./gradlew assemble`. If need to run nodes with different versions or releases, please duplicate the repo or build directories in
Reason for Change:
Changed "running" → "run" to correct the verb form. The phrase should use the base verb "run" rather than the continuous form "running" after "need to".
The previous phrasing was grammatically incorrect and needed correction for proper English usage.
