### PR TITLE
feat: new deployment for explorer on different namespace

### DIFF
--- a/Taskfile.helper.yml
+++ b/Taskfile.helper.yml
@@ -85,6 +85,7 @@ tasks:
       - echo "LOAD_BALANCER_FLAG=${LOAD_BALANCER_FLAG}"
       - echo "ENABLE_EXPLORER_TLS_FLAG=${ENABLE_EXPLORER_TLS_FLAG}"
       - echo "ENABLE_EXPLORER_INGRESS=${ENABLE_EXPLORER_INGRESS}"
+      - echo "ENABLE_MIRROR_INGRESS=${ENABLE_MIRROR_INGRESS}"
       - echo "CLUSTER_TLS_FLAGS=${CLUSTER_TLS_FLAGS}"
       - echo "NETWORK_DEPLOY_EXTRA_FLAGS=${NETWORK_DEPLOY_EXTRA_FLAGS}"
       - echo "MIRROR_NODE_DEPLOY_EXTRA_FLAGS=${MIRROR_NODE_DEPLOY_EXTRA_FLAGS}"
@@ -431,6 +432,7 @@ tasks:
     cmds:
       - task: "default"
       - task: "solo:mirror-node"
+      - task: "solo:explorer"
 
   default-with-relay:
     desc: in addition to default-with-mirror, deploy the JSON RPC relay
@@ -439,25 +441,45 @@ tasks:
     cmds:
       - task: "default"
       - task: "solo:mirror-node"
+      - task: "solo:explorer"
       - task: "solo:relay"
 
   solo:mirror-node:
     silent: true
-    desc: solo mirror-node deploy with port forward on explorer
+    desc: solo mirror-node deploy with port forward
     deps:
       - task: "init"
     cmds:
-      - SOLO_HOME_DIR=${SOLO_HOME_DIR} npm run solo -- mirror-node deploy --deployment  "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME} ${SOLO_CHARTS_DIR_FLAG} ${MIRROR_NODE_DEPLOY_EXTRA_FLAGS} --pinger -q --dev
-      - SOLO_HOME_DIR=${SOLO_HOME_DIR} npm run solo -- explorer deploy --deployment  "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME} -s ${SOLO_CLUSTER_SETUP_NAMESPACE} ${SOLO_CHARTS_DIR_FLAG} ${EXPLORER_DEPLOY_EXTRA_FLAGS}  ${ENABLE_EXPLORER_TLS_FLAG} ${TLS_CLUSTER_ISSUER_TYPE_FLAG} ${ENABLE_EXPLORER_INGRESS} -q --dev
+      - SOLO_HOME_DIR=${SOLO_HOME_DIR} npm run solo -- mirror-node deploy --deployment  "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME} ${SOLO_CHARTS_DIR_FLAG} ${MIRROR_NODE_DEPLOY_EXTRA_FLAGS} ${ENABLE_MIRROR_INGRESS} --pinger -q --dev
       - |
         if [[ "{{ .use_port_forwards }}" == "true" ]];then
-          echo "Enable port forwarding for Hedera Explorer & Mirror Node Network"
-          echo "Port forwarding for Hedera Explorer: http://localhost:8080"
-          explorer_svc="$(kubectl get svc -l app.kubernetes.io/component=hedera-explorer -n ${SOLO_NAMESPACE} --output json | jq -r '.items[].metadata.name')"
-          /bin/bash -c "nohup kubectl port-forward -n \"${SOLO_NAMESPACE}\" \"svc/${explorer_svc}\" 8080:80 > /dev/null 2>&1 &"
           echo "Port forwarding for Mirror Node Network: grpc:5600, rest:5551"
           /bin/bash -c "nohup kubectl port-forward -n \"${SOLO_NAMESPACE}\" svc/mirror-grpc 5600:5600 > /dev/null 2>&1 &"
           /bin/bash -c "nohup kubectl port-forward -n \"${SOLO_NAMESPACE}\" svc/mirror-rest 5551:80 > /dev/null 2>&1 &"
+          sleep 4
+        fi
+
+  solo:explorer:
+    silent: true
+    desc: solo explorer deploy with port forward on explorer
+    deps:
+      - task: "init"
+    cmds:
+      - |
+        if [[ "${EXPLORER_DEPLOYMENT}" != "" ]]; then
+          # create deployment on different namespace
+          SOLO_HOME_DIR=${SOLO_HOME_DIR} npm run solo -- deployment create --deployment "${EXPLORER_DEPLOYMENT}" -n "${EXPLORER_NAME_SPACE}" --context ${EXPLORER_CLUSTER_CONTEXT} --email ${SOLO_EMAIL} --deployment-clusters ${EXPLORER_CLUSTER_CONTEXT} --cluster-ref ${EXPLORER_CLUSTER_CONTEXT} --node-aliases {{.node_identifiers}} --dev
+          SOLO_HOME_DIR=${SOLO_HOME_DIR} npm run solo -- explorer deploy --deployment "${EXPLORER_DEPLOYMENT}" --cluster-ref ${EXPLORER_CLUSTER_CONTEXT} --mirrorNamespace ${SOLO_NAMESPACE} ${SOLO_CHARTS_DIR_FLAG} ${EXPLORER_DEPLOY_EXTRA_FLAGS}  ${ENABLE_EXPLORER_TLS_FLAG} ${TLS_CLUSTER_ISSUER_TYPE_FLAG} ${ENABLE_EXPLORER_INGRESS} -q --dev
+          export EXPLORER_DEPLOYED_NAME_SPACE=${EXPLORER_NAME_SPACE}
+        else
+          SOLO_HOME_DIR=${SOLO_HOME_DIR} npm run solo -- explorer deploy --deployment "${SOLO_DEPLOYMENT}"  --cluster-ref kind-${SOLO_CLUSTER_NAME} --mirrorNamespace ${SOLO_NAMESPACE} ${SOLO_CHARTS_DIR_FLAG} ${EXPLORER_DEPLOY_EXTRA_FLAGS}  ${ENABLE_EXPLORER_TLS_FLAG} ${TLS_CLUSTER_ISSUER_TYPE_FLAG} ${ENABLE_EXPLORER_INGRESS} -q --dev
+          export EXPLORER_DEPLOYED_NAME_SPACE=${SOLO_NAMESPACE}
+        fi
+        if [[ "{{ .use_port_forwards }}" == "true" ]];then
+          echo "Enable port forwarding for Hedera Explorer & Mirror Node Network"
+          echo "Port forwarding for Hedera Explorer: http://localhost:8080"
+          explorer_svc="$(kubectl get svc -l app.kubernetes.io/component=hedera-explorer -n ${EXPLORER_DEPLOYED_NAME_SPACE} --output json | jq -r '.items[].metadata.name')"
+          /bin/bash -c "nohup kubectl port-forward -n \"${EXPLORER_DEPLOYED_NAME_SPACE}\" \"svc/${explorer_svc}\" 8080:80 > /dev/null 2>&1 &"
           sleep 4
         fi
 
@@ -471,7 +493,19 @@ tasks:
       - task: "init"
     cmds:
       - SOLO_HOME_DIR=${SOLO_HOME_DIR} npm run solo -- mirror-node destroy --deployment  "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME} --force -q --dev || true
-      - SOLO_HOME_DIR=${SOLO_HOME_DIR} npm run solo -- explorer destroy --deployment  "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME} --force -q --dev || true
+
+  solo:destroy-explorer:
+    silent: true
+    desc: solo explorer destroy
+    deps:
+      - task: "init"
+    cmds:
+      - |
+        if [[ "${EXPLORER_DEPLOYMENT}" != "" ]]; then
+          SOLO_HOME_DIR=${SOLO_HOME_DIR} npm run solo -- explorer destroy --deployment "${EXPLORER_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME} --force -q --dev || true
+        else
+          SOLO_HOME_DIR=${SOLO_HOME_DIR} npm run solo -- explorer destroy --deployment  "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME} --force -q --dev || true
+        fi
 
   clean:
     desc: destroy, then remove cache directory, logs directory, config, and port forwards

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -14,9 +14,14 @@ env:
   # DEBUG_NODE_ALIAS: "node2"
   # SOLO_CHARTS_DIR_FLAG: "--chart-directory /Users/user/source/solo-charts/charts"
   # LOAD_BALANCER_FLAG: "--load-balancer"
-  # ENABLE_EXPLORER_TLS_FLAG: "--enable-hedera-explorer-tls"
-  # TLS_CLUSTER_ISSUER_TYPE_FLAG: "--tls-cluster-issuer-type acme-staging"
+  ENABLE_EXPLORER_TLS_FLAG: "--enable-hedera-explorer-tls"
+  TLS_CLUSTER_ISSUER_TYPE_FLAG: "--tls-cluster-issuer-type acme-staging"
   # NETWORK_DEPLOY_EXTRA_FLAGS: "--haproxy-ips node1="
+  ENABLE_EXPLORER_INGRESS: "--enable-ingress"
+  ENABLE_MIRROR_INGRESS: "--enable-ingress"
+  EXPLORER_NAME_SPACE: "explorer-name-space"
+  EXPLORER_DEPLOYMENT: "explorer-deployment"
+  EXPLORER_CLUSTER_CONTEXT: "kind-solo-cluster"
 vars:
   use_port_forwards: "true"
 

--- a/examples/external-database-test/Taskfile.yml
+++ b/examples/external-database-test/Taskfile.yml
@@ -56,6 +56,7 @@ tasks:
       - task: "solo:node:start"
       - task: "solo:external-database"
       - task: "solo:mirror-node"
+      - task: "solo:explorer"
       - name: "Copy database-seeding-query.sql inside the database pod"
         cmd: |
           kubectl cp {{.HOME}}/.solo/cache/database-seeding-query.sql {{.postgres_container_name}}:/tmp/database-seeding-query.sql \

--- a/examples/solo-gke-test/Taskfile.yml
+++ b/examples/solo-gke-test/Taskfile.yml
@@ -10,6 +10,8 @@ env:
   SOLO_NETWORK_SIZE: 4
   SOLO_NAMESPACE: solo-gke-test
   SOLO_DEPLOYMENT: solo-deployment-gke-test
+  CLUSTER_CONTEXT: "gke_hashsphere-staging_us-central1_jeromy-sphere-load-test-us-central"
+  # CLUSTER_CONTEXT: "gke_hashsphere-staging_us-central1_jeffrey-explorer-testing"
   # SOLO_CHART_VERSION: 0.39.0
   # CONSENSUS_NODE_VERSION: v0.58.0
   VALUES_FLAG: "--values-file {{.USER_WORKING_DIR}}/init-containers-values.yaml"
@@ -24,10 +26,14 @@ env:
   LOAD_BALANCER_FLAG: "--load-balancer true"
   ENABLE_EXPLORER_TLS_FLAG: "--enable-hedera-explorer-tls"
   ENABLE_EXPLORER_INGRESS: "--enable-ingress"
+  ENABLE_MIRROR_INGRESS: "--enable-ingress"
   TLS_CLUSTER_ISSUER_TYPE_FLAG: "--tls-cluster-issuer-type acme-staging"
   # CLUSTER_TLS_FLAGS: "--cert-manager --cert-manager-crds"
 #  NETWORK_DEPLOY_EXTRA_FLAGS: "--haproxy-ips node1=<ip-address>,node2=<ip-address>,node3=<ip-address>,node4=<ip-address> --pvcs"
-  MIRROR_NODE_DEPLOY_EXTRA_FLAGS: "--values-file {{.USER_WORKING_DIR}}/mirror-node-values.yaml"
+  MIRROR_NODE_DEPLOY_EXTRA_FLAGS: "--values-file {{.USER_WORKING_DIR}}/mirror-node-values.yaml --mirror-static-ip 34.55.235.252"
   EXPLORER_DEPLOY_EXTRA_FLAGS: "--values-file {{.USER_WORKING_DIR}}/ingress-values.yaml --hedera-explorer-static-ip 35.226.75.168"
+  EXPLORER_NAME_SPACE: "explorer-name-space"
+  EXPLORER_DEPLOYMENT: "explorer-deployment"
+  EXPLORER_CLUSTER_CONTEXT: "{{ .CLUSTER_CONTEXT }}"
   RELAY_NODE_DEPLOY_EXTRA_FLAGS: "--values-file {{.USER_WORKING_DIR}}/relay-values.yaml"
   SKIP_NODE_PING: 'true'

--- a/src/commands/cluster/configs.ts
+++ b/src/commands/cluster/configs.ts
@@ -31,8 +31,6 @@ export const setupConfigBuilder = async function (argv, ctx, task) {
   await configManager.executePrompt(task, [
     flags.chartDirectory,
     flags.clusterSetupNamespace,
-    flags.deployCertManager,
-    flags.deployCertManagerCrds,
     flags.deployMinio,
     flags.deployPrometheusStack,
   ]);
@@ -40,8 +38,6 @@ export const setupConfigBuilder = async function (argv, ctx, task) {
   ctx.config = {
     chartDir: configManager.getFlag(flags.chartDirectory) as string,
     clusterSetupNamespace: configManager.getFlag(flags.clusterSetupNamespace) as NamespaceName,
-    deployCertManager: configManager.getFlag(flags.deployCertManager) as boolean,
-    deployCertManagerCrds: configManager.getFlag(flags.deployCertManagerCrds) as boolean,
     deployMinio: configManager.getFlag(flags.deployMinio) as boolean,
     deployPrometheusStack: configManager.getFlag(flags.deployPrometheusStack) as boolean,
     soloChartVersion: configManager.getFlag(flags.soloChartVersion) as string,
@@ -98,8 +94,6 @@ export interface ClusterConnectConfigClass {
 export interface ClusterSetupConfigClass {
   chartDir: string;
   clusterSetupNamespace: NamespaceName;
-  deployCertManager: boolean;
-  deployCertManagerCrds: boolean;
   deployMinio: boolean;
   deployPrometheusStack: boolean;
   soloChartVersion: string;

--- a/src/commands/cluster/flags.ts
+++ b/src/commands/cluster/flags.ts
@@ -17,8 +17,6 @@ export const SETUP_FLAGS = {
     flags.chartDirectory,
     flags.clusterRef,
     flags.clusterSetupNamespace,
-    flags.deployCertManager,
-    flags.deployCertManagerCrds,
     flags.deployMinio,
     flags.deployPrometheusStack,
     flags.quiet,

--- a/src/commands/cluster/tasks.ts
+++ b/src/commands/cluster/tasks.ts
@@ -229,24 +229,11 @@ export class ClusterCommandTasks {
     chartDir = flags.chartDirectory.definition.defaultValue as string,
     prometheusStackEnabled = flags.deployPrometheusStack.definition.defaultValue as boolean,
     minioEnabled = flags.deployMinio.definition.defaultValue as boolean,
-    certManagerEnabled = flags.deployCertManager.definition.defaultValue as boolean,
-    certManagerCrdsEnabled = flags.deployCertManagerCrds.definition.defaultValue as boolean,
   ) {
     let valuesArg = chartDir ? `-f ${path.join(chartDir, 'solo-cluster-setup', 'values.yaml')}` : '';
 
     valuesArg += ` --set cloud.prometheusStack.enabled=${prometheusStackEnabled}`;
-    valuesArg += ` --set cloud.certManager.enabled=${certManagerEnabled}`;
-    valuesArg += ` --set cert-manager.installCRDs=${certManagerCrdsEnabled}`;
     valuesArg += ` --set cloud.minio.enabled=${minioEnabled}`;
-
-    if (certManagerEnabled && !certManagerCrdsEnabled) {
-      this.parent.logger.showUser(
-        chalk.yellowBright('> WARNING:'),
-        chalk.yellow(
-          'cert-manager CRDs are required for cert-manager, please enable it if you have not installed it independently.',
-        ),
-      );
-    }
 
     return valuesArg;
   }
@@ -411,22 +398,8 @@ export class ClusterCommandTasks {
           ctx.config.deployPrometheusStack = false;
         }
 
-        // if cert manager is installed, don't deploy it
-        if (
-          (ctx.config.deployCertManager || ctx.config.deployCertManagerCrds) &&
-          (await self.clusterChecks.isCertManagerInstalled())
-        ) {
-          ctx.config.deployCertManager = false;
-          ctx.config.deployCertManagerCrds = false;
-        }
-
         // If all are already present or not wanted, skip installation
-        if (
-          !ctx.config.deployPrometheusStack &&
-          !ctx.config.deployMinio &&
-          !ctx.config.deployCertManager &&
-          !ctx.config.deployCertManagerCrds
-        ) {
+        if (!ctx.config.deployPrometheusStack && !ctx.config.deployMinio) {
           ctx.isChartInstalled = true;
           return;
         }
@@ -435,8 +408,6 @@ export class ClusterCommandTasks {
           ctx.config.chartDir,
           ctx.config.deployPrometheusStack,
           ctx.config.deployMinio,
-          ctx.config.deployCertManager,
-          ctx.config.deployCertManagerCrds,
         );
       },
       ctx => ctx.isChartInstalled,

--- a/src/commands/explorer.ts
+++ b/src/commands/explorer.ts
@@ -16,10 +16,12 @@ import {ComponentType} from '../core/config/remote/enumerations.js';
 import {MirrorNodeExplorerComponent} from '../core/config/remote/components/mirror_node_explorer_component.js';
 import {type SoloListrTask} from '../types/index.js';
 import {resolveNamespaceFromDeployment} from '../core/resolvers.js';
-import {type NamespaceName} from '../core/kube/resources/namespace/namespace_name.js';
+import {NamespaceName} from '../core/kube/resources/namespace/namespace_name.js';
 import {type ClusterChecks} from '../core/cluster_checks.js';
 import {container} from 'tsyringe-neo';
 import {InjectTokens} from '../core/dependency_injection/inject_tokens.js';
+import {INGRESS_CONTROLLER_NAME} from '../core/constants.js';
+import {INGRESS_CONTROLLER_VERSION} from '../../version.js';
 
 export interface ExplorerDeployConfigClass {
   chartDirectory: string;
@@ -30,7 +32,7 @@ export interface ExplorerDeployConfigClass {
   hederaExplorerTlsHostName: string;
   hederaExplorerStaticIp: string | '';
   hederaExplorerVersion: string;
-  mirrorStaticIp: string;
+  mirrorNamespace: NamespaceName;
   namespace: NamespaceName;
   profileFile: string;
   profileName: string;
@@ -38,7 +40,6 @@ export interface ExplorerDeployConfigClass {
   valuesFile: string;
   valuesArg: string;
   getUnusedConfigs: () => string[];
-  clusterSetupNamespace: NamespaceName;
   soloChartVersion: string;
 }
 
@@ -71,13 +72,12 @@ export class ExplorerCommand extends BaseCommand {
       flags.hederaExplorerTlsHostName,
       flags.hederaExplorerStaticIp,
       flags.hederaExplorerVersion,
-      flags.mirrorStaticIp,
+      flags.mirrorNamespace,
       flags.namespace,
       flags.deployment,
       flags.profileFile,
       flags.profileName,
       flags.quiet,
-      flags.clusterSetupNamespace,
       flags.soloChartVersion,
       flags.tlsClusterIssuerType,
       flags.valuesFile,
@@ -102,18 +102,24 @@ export class ExplorerCommand extends BaseCommand {
 
     if (config.enableIngress) {
       valuesArg += ' --set ingress.enabled=true';
-      valuesArg += ` --set ingressClassName=${config.namespace}-hedera-explorer-ingress-class`;
+      valuesArg += ` --set ingressClassName=${constants.EXPLORER_INGRESS_CLASS_NAME}`;
     }
     valuesArg += ` --set fullnameOverride=${constants.HEDERA_EXPLORER_RELEASE_NAME}`;
-    valuesArg += ` --set proxyPass./api="http://${constants.MIRROR_NODE_RELEASE_NAME}-rest" `;
+
+    if (config.mirrorNamespace) {
+      // use fully qualified service name for mirror node since the explorer is in a different namespace
+      valuesArg += ` --set proxyPass./api="http://${constants.MIRROR_NODE_RELEASE_NAME}-rest.${config.mirrorNamespace}.svc.cluster.local" `;
+    } else {
+      valuesArg += ` --set proxyPass./api="http://${constants.MIRROR_NODE_RELEASE_NAME}-rest" `;
+    }
     return valuesArg;
   }
 
   /**
    * @param config - the configuration object
    */
-  private async prepareSoloChartSetupValuesArg(config: ExplorerDeployConfigClass) {
-    const {tlsClusterIssuerType, namespace, mirrorStaticIp, hederaExplorerStaticIp} = config;
+  private async prepareCertManagerChartValuesArg(config: ExplorerDeployConfigClass) {
+    const {tlsClusterIssuerType, namespace} = config;
 
     let valuesArg = '';
 
@@ -125,22 +131,8 @@ export class ExplorerCommand extends BaseCommand {
 
     const clusterChecks: ClusterChecks = container.resolve(InjectTokens.ClusterChecks);
 
-    // Install ingress controller only if haproxy ingress not already present
-    if (!(await clusterChecks.isIngressControllerInstalled()) && config.enableIngress) {
-      valuesArg += ' --set ingress.enabled=true';
-      valuesArg += ' --set haproxyIngressController.enabled=true';
-      valuesArg += ` --set ingressClassName=${namespace}-hedera-explorer-ingress-class`;
-    }
-
     if (!(await clusterChecks.isCertManagerInstalled())) {
-      valuesArg += ' --set cloud.certManager.enabled=true';
       valuesArg += ' --set cert-manager.installCRDs=true';
-    }
-
-    if (hederaExplorerStaticIp !== '') {
-      valuesArg += ` --set haproxy-ingress.controller.service.loadBalancerIP=${hederaExplorerStaticIp}`;
-    } else if (mirrorStaticIp !== '') {
-      valuesArg += ` --set haproxy-ingress.controller.service.loadBalancerIP=${mirrorStaticIp}`;
     }
 
     if (tlsClusterIssuerType === 'self-signed') {
@@ -181,6 +173,7 @@ export class ExplorerCommand extends BaseCommand {
               flags.hederaExplorerTlsHostName,
               flags.hederaExplorerStaticIp,
               flags.hederaExplorerVersion,
+              flags.mirrorNamespace,
               flags.tlsClusterIssuerType,
               flags.valuesFile,
             ]);
@@ -205,32 +198,30 @@ export class ExplorerCommand extends BaseCommand {
         },
         ListrRemoteConfig.loadRemoteConfig(this, argv),
         {
-          title: 'Upgrade solo-setup chart',
+          title: 'Install cert manager',
           task: async ctx => {
             const config = ctx.config;
-            const {chartDirectory, clusterSetupNamespace, soloChartVersion} = config;
+            const {chartDirectory, soloChartVersion} = config;
 
             const chartPath = await this.prepareChartPath(
               chartDirectory,
               constants.SOLO_TESTING_CHART_URL,
-              constants.SOLO_CLUSTER_SETUP_CHART,
+              constants.SOLO_CERT_MANAGER_CHART,
             );
 
-            const soloChartSetupValuesArg = await self.prepareSoloChartSetupValuesArg(config);
+            const soloCertManagerValuesArg = await self.prepareCertManagerChartValuesArg(config);
 
             // if cert-manager isn't already installed we want to install it separate from the certificate issuers
             // as they will fail to be created due to the order of the installation being dependent on the cert-manager
             // being installed first
-            if (soloChartSetupValuesArg.includes('cloud.certManager.enabled=true')) {
-              await self.chartManager.upgrade(
-                clusterSetupNamespace,
-                constants.SOLO_CLUSTER_SETUP_CHART,
-                chartPath,
-                soloChartVersion,
-                '  --set cloud.certManager.enabled=true --set cert-manager.installCRDs=true',
-                ctx.config.clusterContext,
-              );
-            }
+            await self.chartManager.install(
+              NamespaceName.of(constants.CERT_MANAGER_NAME_SPACE),
+              constants.SOLO_CERT_MANAGER_CHART,
+              chartPath,
+              soloChartVersion,
+              '  --set cert-manager.installCRDs=true',
+              ctx.config.clusterContext,
+            );
 
             // wait cert-manager to be ready to proceed, otherwise may get error of "failed calling webhook"
             await self.k8Factory
@@ -240,7 +231,7 @@ export class ExplorerCommand extends BaseCommand {
                 constants.DEFAULT_CERT_MANAGER_NAMESPACE,
                 [
                   'app.kubernetes.io/component=webhook',
-                  `app.kubernetes.io/instance=${constants.SOLO_CLUSTER_SETUP_CHART}`,
+                  `app.kubernetes.io/instance=${constants.SOLO_CERT_MANAGER_CHART}`,
                 ],
                 constants.PODS_READY_MAX_ATTEMPTS,
                 constants.PODS_READY_DELAY,
@@ -249,36 +240,19 @@ export class ExplorerCommand extends BaseCommand {
             // sleep for a few seconds to allow cert-manager to be ready
             await new Promise(resolve => setTimeout(resolve, 10000));
 
+            // sleep for a few seconds to allow cert-manager to be ready
+            await new Promise(resolve => setTimeout(resolve, 10000));
+
             await self.chartManager.upgrade(
-              clusterSetupNamespace,
-              constants.SOLO_CLUSTER_SETUP_CHART,
+              NamespaceName.of(constants.CERT_MANAGER_NAME_SPACE),
+              constants.SOLO_CERT_MANAGER_CHART,
               chartPath,
               soloChartVersion,
-              soloChartSetupValuesArg,
+              soloCertManagerValuesArg,
               ctx.config.clusterContext,
             );
-
-            if (config.enableIngress) {
-              // patch ingressClassName of mirror ingress so it can be recognized by haproxy ingress controller
-              await this.k8Factory
-                .getK8(ctx.config.clusterContext)
-                .ingresses()
-                .update(config.namespace, constants.MIRROR_NODE_RELEASE_NAME, {
-                  spec: {
-                    ingressClassName: `${config.namespace}-hedera-explorer-ingress-class`,
-                  },
-                });
-
-              // to support GRPC over HTTP/2
-              await this.k8Factory
-                .getK8(ctx.config.clusterContext)
-                .configMaps()
-                .update(clusterSetupNamespace, constants.SOLO_CLUSTER_SETUP_CHART + '-haproxy-ingress', {
-                  'backend-protocol': 'h2',
-                });
-            }
           },
-          skip: ctx => !ctx.config.enableHederaExplorerTls && !ctx.config.enableIngress,
+          skip: ctx => !ctx.config.enableHederaExplorerTls,
         },
 
         {
@@ -297,6 +271,34 @@ export class ExplorerCommand extends BaseCommand {
               exploreValuesArg,
               ctx.config.clusterContext,
             );
+          },
+        },
+        {
+          title: 'Install explorer ingress controller',
+          task: async ctx => {
+            const config = ctx.config;
+
+            let explorerIngressControllerValuesArg = '';
+
+            if (config.hederaExplorerStaticIp !== '') {
+              explorerIngressControllerValuesArg += ` --set controller.service.loadBalancerIP=${config.hederaExplorerStaticIp}`;
+            }
+            explorerIngressControllerValuesArg += ` --set fullnameOverride=${constants.EXPLORER_INGRESS_CONTROLLER}`;
+
+            const ingressControllerChartPath = await self.prepareChartPath(
+              '', // don't use chartPath which is for local solo-charts only
+              constants.INGRESS_CONTROLLER_RELEASE_NAME,
+              constants.INGRESS_CONTROLLER_RELEASE_NAME,
+            );
+
+            await self.chartManager.install(
+              config.namespace,
+              constants.INGRESS_CONTROLLER_RELEASE_NAME,
+              ingressControllerChartPath,
+              INGRESS_CONTROLLER_VERSION,
+              explorerIngressControllerValuesArg,
+              ctx.config.clusterContext,
+            );
 
             // patch explorer ingress to use h1 protocol, haproxy ingress controller default backend protocol is h2
             // to support grpc over http/2
@@ -310,7 +312,12 @@ export class ExplorerCommand extends BaseCommand {
                   },
                 },
               });
+            await this.k8Factory
+              .getK8(ctx.config.clusterContext)
+              .ingressClasses()
+              .create(constants.EXPLORER_INGRESS_CLASS_NAME, INGRESS_CONTROLLER_NAME);
           },
+          skip: ctx => !ctx.config.enableIngress,
         },
         {
           title: 'Check explorer pod is ready',
@@ -333,10 +340,10 @@ export class ExplorerCommand extends BaseCommand {
               .getK8(ctx.config.clusterContext)
               .pods()
               .waitForReadyStatus(
-                constants.SOLO_SETUP_NAMESPACE,
+                ctx.config.namespace,
                 [
-                  'app.kubernetes.io/name=haproxy-ingress',
-                  `app.kubernetes.io/instance=${constants.SOLO_CLUSTER_SETUP_CHART}`,
+                  `app.kubernetes.io/name=${constants.INGRESS_CONTROLLER_RELEASE_NAME}`,
+                  `app.kubernetes.io/instance=${constants.INGRESS_CONTROLLER_RELEASE_NAME}`,
                 ],
                 constants.PODS_READY_MAX_ATTEMPTS,
                 constants.PODS_READY_DELAY,
@@ -430,6 +437,25 @@ export class ExplorerCommand extends BaseCommand {
             );
           },
           skip: ctx => !ctx.config.isChartInstalled,
+        },
+        {
+          title: 'Uninstall explorer ingress controller',
+          task: async ctx => {
+            await this.chartManager.uninstall(ctx.config.namespace, constants.INGRESS_CONTROLLER_RELEASE_NAME);
+            // delete ingress class if found one
+            const existingIngressClasses = await this.k8Factory
+              .getK8(ctx.config.clusterContext)
+              .ingressClasses()
+              .list();
+            existingIngressClasses.map(ingressClass => {
+              if (ingressClass.name === constants.EXPLORER_INGRESS_CLASS_NAME) {
+                this.k8Factory
+                  .getK8(ctx.config.clusterContext)
+                  .ingressClasses()
+                  .delete(constants.EXPLORER_INGRESS_CLASS_NAME);
+              }
+            });
+          },
         },
         this.removeMirrorNodeExplorerComponents(),
       ],

--- a/src/commands/flags.ts
+++ b/src/commands/flags.ts
@@ -202,6 +202,24 @@ export class Flags {
     },
   };
 
+  static readonly mirrorNamespace: CommandFlag = {
+    constName: 'mirrorNamespace',
+    name: 'mirror-namespace',
+    definition: {
+      describe: 'Namespace to use for the Mirror Node deployment, a new one will be created if it does not exist',
+      type: 'string',
+    },
+    prompt: async function promptNamespace(task: ListrTaskWrapper<any, any, any>, input: any) {
+      return await Flags.promptText(
+        task,
+        input,
+        'solo',
+        'Enter mirror node namespace name: ',
+        'namespace cannot be empty',
+        Flags.mirrorNamespace.name,
+      );
+    },
+  };
   /**
    * Parse the values files input string that includes the cluster reference and the values file path
    * <p>It supports input as below:
@@ -2094,6 +2112,7 @@ export class Flags {
     Flags.log4j2Xml,
     Flags.mirrorNodeVersion,
     Flags.mirrorStaticIp,
+    Flags.mirrorNamespace,
     Flags.namespace,
     Flags.networkDeploymentValuesFile,
     Flags.newAccountNumber,

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -58,6 +58,7 @@ export const SOLO_SETUP_NAMESPACE = NamespaceName.of('solo-setup');
 export const SOLO_TESTING_CHART_URL = 'oci://ghcr.io/hashgraph/solo-charts';
 export const SOLO_CLUSTER_SETUP_CHART = 'solo-cluster-setup';
 export const SOLO_DEPLOYMENT_CHART = 'solo-deployment';
+export const SOLO_CERT_MANAGER_CHART = 'solo-cert-manager';
 export const JSON_RPC_RELAY_CHART_URL = 'https://hashgraph.github.io/hedera-json-rpc-relay/charts';
 export const JSON_RPC_RELAY_CHART = 'hedera-json-rpc-relay';
 export const MIRROR_NODE_CHART_URL = 'https://hashgraph.github.io/hedera-mirror-node/charts';
@@ -68,6 +69,11 @@ export const HEDERA_EXPLORER_RELEASE_NAME = 'hedera-explorer';
 export const SOLO_RELAY_LABEL = 'app=hedera-json-rpc-relay';
 export const SOLO_HEDERA_EXPLORER_LABEL = 'app.kubernetes.io/component=hedera-explorer';
 
+export const INGRESS_CONTROLLER_CHART_URL = 'https://haproxy-ingress.github.io/charts';
+export const INGRESS_CONTROLLER_RELEASE_NAME = 'haproxy-ingress';
+export const INGRESS_CONTROLLER_NAME = 'haproxy-ingress.github.io/controller';
+
+export const CERT_MANAGER_NAME_SPACE = 'cert-manager';
 export const SOLO_HEDERA_MIRROR_IMPORTER = [
   'app.kubernetes.io/component=importer',
   'app.kubernetes.io/instance=mirror',
@@ -75,8 +81,13 @@ export const SOLO_HEDERA_MIRROR_IMPORTER = [
 
 export const DEFAULT_CHART_REPO: Map<string, string> = new Map()
   .set(JSON_RPC_RELAY_CHART, JSON_RPC_RELAY_CHART_URL)
-  .set(MIRROR_NODE_RELEASE_NAME, MIRROR_NODE_CHART_URL);
+  .set(MIRROR_NODE_RELEASE_NAME, MIRROR_NODE_CHART_URL)
+  .set(INGRESS_CONTROLLER_RELEASE_NAME, INGRESS_CONTROLLER_CHART_URL);
 
+export const MIRROR_INGRESS_CLASS_NAME = 'mirror-ingress-class';
+export const MIRROR_INGRESS_CONTROLLER = 'mirror-ingress-controller';
+export const EXPLORER_INGRESS_CLASS_NAME = 'explorer-ingress-class';
+export const EXPLORER_INGRESS_CONTROLLER = 'explorer-ingress-controller';
 // ------------------- Hedera Account related ---------------------------------------------------------------------------------
 export const OPERATOR_ID = process.env.SOLO_OPERATOR_ID || '0.0.2';
 export const OPERATOR_KEY =
@@ -112,7 +123,6 @@ export const POD_CONDITION_STATUS_TRUE = 'True';
 
 export const EXPLORER_VALUES_FILE = path.join(RESOURCES_DIR, 'hedera-explorer-values.yaml');
 export const MIRROR_NODE_VALUES_FILE = path.join(RESOURCES_DIR, 'mirror-node-values.yaml');
-
 export const NODE_LOG_FAILURE_MSG = 'failed to download logs from pod';
 
 /**

--- a/src/core/kube/k8.ts
+++ b/src/core/kube/k8.ts
@@ -13,6 +13,7 @@ import {type Leases} from './resources/lease/leases.js';
 import {type IngressClasses} from './resources/ingress_class/ingress_classes.js';
 import {type Secrets} from './resources/secret/secrets.js';
 import {type Ingresses} from './resources/ingress/ingresses.js';
+import {type NamespaceName} from './resources/namespace/namespace_name.js';
 
 export interface K8 {
   /**

--- a/src/core/kube/k8_client/k8_client.ts
+++ b/src/core/kube/k8_client/k8_client.ts
@@ -28,6 +28,7 @@ import {type Secrets} from '../resources/secret/secrets.js';
 import {K8ClientSecrets} from './resources/secret/k8_client_secrets.js';
 import {type Ingresses} from '../resources/ingress/ingresses.js';
 import {K8ClientIngresses} from './resources/ingress/k8_client_ingresses.js';
+import {type NamespaceName} from '../resources/namespace/namespace_name.js';
 
 /**
  * A kubernetes API wrapper class providing custom functionalities required by solo

--- a/src/core/kube/k8_client/resources/ingress_class/k8_client_ingress_classes.ts
+++ b/src/core/kube/k8_client/resources/ingress_class/k8_client_ingress_classes.ts
@@ -6,6 +6,8 @@ import {type IngressClass} from '../../../resources/ingress_class/ingress_class.
 import {type V1IngressClass, type NetworkingV1Api} from '@kubernetes/client-node';
 import {K8ClientIngressClass} from './k8_client_ingress_class.js';
 import {SoloError} from '../../../../errors.js';
+import {ResourceCreateError, ResourceDeleteError} from '../../../errors/resource_operation_errors.js';
+import {ResourceType} from '../../../resources/resource_type.js';
 
 export class K8ClientIngressClasses implements IngressClasses {
   constructor(private readonly networkingApi: NetworkingV1Api) {}
@@ -24,6 +26,32 @@ export class K8ClientIngressClasses implements IngressClasses {
       return ingressClasses;
     } catch (e) {
       throw new SoloError('Failed to list IngressClasses:', e);
+    }
+  }
+
+  public async create(ingressClassName: string, controllerName: string) {
+    const ingressClass = {
+      apiVersion: 'networking.k8s.io/v1',
+      kind: 'IngressClass',
+      metadata: {
+        name: ingressClassName,
+      },
+      spec: {
+        controller: controllerName,
+      },
+    };
+    try {
+      await this.networkingApi.createIngressClass(ingressClass);
+    } catch (e) {
+      throw new ResourceCreateError(ResourceType.INGRESS_CLASS, undefined, ingressClassName, e);
+    }
+  }
+
+  public async delete(ingressClassName: string) {
+    try {
+      await this.networkingApi.deleteIngressClass(ingressClassName);
+    } catch (e) {
+      throw new ResourceDeleteError(ResourceType.INGRESS_CLASS, undefined, ingressClassName, e);
     }
   }
 }

--- a/src/core/kube/resources/ingress_class/ingress_classes.ts
+++ b/src/core/kube/resources/ingress_class/ingress_classes.ts
@@ -11,4 +11,19 @@ export interface IngressClasses {
    * @throws SoloError if failed to list IngressClasses
    */
   list(): Promise<IngressClass[]>;
+
+  /**
+   * Create an IngressClass
+   * @param ingressClassName
+   * @param controllerName
+   * @throws SoloError if failed to create IngressClasses
+   */
+  create(ingressClassName: string, controllerName: string): Promise<void>;
+
+  /**
+   * Delete an IngressClass
+   * @param ingressClassName
+   * @throws SoloError if failed to delete IngressClasses
+   */
+  delete(ingressClassName: string): Promise<void>;
 }

--- a/test/e2e/commands/mirror_node.test.ts
+++ b/test/e2e/commands/mirror_node.test.ts
@@ -47,6 +47,7 @@ argv.setArg(flags.chartDirectory, process.env.SOLO_CHARTS_DIR ?? undefined);
 argv.setArg(flags.quiet, true);
 argv.setArg(flags.pinger, true);
 argv.setArg(flags.enableHederaExplorerTls, true);
+argv.setArg(flags.enableIngress, true);
 
 e2eTestSuite(testName, argv, {}, bootstrapResp => {
   describe('MirrorNodeCommand', async () => {

--- a/version.ts
+++ b/version.ts
@@ -7,9 +7,10 @@
  */
 
 export const HELM_VERSION = 'v3.14.2';
-export const SOLO_CHART_VERSION = '0.44.0';
+export const SOLO_CHART_VERSION = '0.45.0';
 export const HEDERA_PLATFORM_VERSION = 'v0.58.10';
 export const LOCAL_HEDERA_PLATFORM_VERSION = 'v0.58.3';
 export const MIRROR_NODE_VERSION = 'v0.122';
 export const HEDERA_EXPLORER_VERSION = '24.12.0';
 export const HEDERA_JSON_RPC_RELAY_VERSION = 'v0.63.2';
+export const INGRESS_CONTROLLER_VERSION = '0.14.5';


### PR DESCRIPTION
## Description

This pull request changes the following:

* Add new flag to let explorer know what is mirror node namesapce
* Update Taskfile to separate mirror command and explorer command
* Create a new deployment before explorer deploy command
* Install cert-manager chart with explorer deploy command if TLS is enabled
* Install separate ingress controller for mirror and explorer

### Related Issues

* Closes #929
