### PR TITLE
feat: Improve error handling

### DIFF
--- a/solo.ts
+++ b/solo.ts
@@ -4,13 +4,17 @@
  */
 import * as fnm from './src/index.js';
 import {type SoloLogger} from './src/core/logging.js';
+import {InjectTokens} from './src/core/dependency_injection/inject_tokens.js';
+import {container} from 'tsyringe-neo';
+import {type ErrorHandler} from './src/core/error_handler.js';
 
 const context: {logger: SoloLogger} = {logger: undefined};
 await fnm
   .main(process.argv, context)
   .then(() => {
-    context.logger.logAndExitSuccess('Solo CLI completed, via entrypoint');
+    context.logger.info('Solo CLI completed, via entrypoint');
   })
-  .catch(err => {
-    context.logger.logAndExitError(err);
+  .catch(e => {
+    const errorHandler: ErrorHandler = container.resolve(InjectTokens.ErrorHandler);
+    errorHandler.handle(e);
   });

--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -117,6 +117,7 @@ export class AccountCommand extends BaseCommand {
         const privateKey = PrivateKey.fromStringDer(newAccountInfo.privateKey);
         newAccountInfo.privateKeyRaw = privateKey.toStringRaw();
       } catch {
+        // TODO should this error be thrown or just logged?
         this.logger.error(`failed to retrieve EVM address for accountId ${newAccountInfo.accountId}`);
       }
     }
@@ -169,8 +170,7 @@ export class AccountCommand extends BaseCommand {
           ctx.accountInfo.privateKey,
         ))
       ) {
-        this.logger.error(`failed to update account keys for accountId ${ctx.accountInfo.accountId}`);
-        return false;
+        throw new SoloError(`failed to update account keys for accountId ${ctx.accountInfo.accountId}`);
       }
     } else {
       amount = amount || (flags.amount.definition.defaultValue as number);
@@ -183,8 +183,7 @@ export class AccountCommand extends BaseCommand {
 
     if (hbarAmount > 0) {
       if (!(await this.transferAmountFromOperator(ctx.accountInfo.accountId, hbarAmount))) {
-        this.logger.error(`failed to transfer amount for accountId ${ctx.accountInfo.accountId}`);
-        return false;
+        throw new SoloError(`failed to transfer amount for accountId ${ctx.accountInfo.accountId}`);
       }
       this.logger.debug(`sent transfer amount for account ${ctx.accountInfo.accountId}`);
     }
@@ -731,7 +730,6 @@ export class AccountCommand extends BaseCommand {
                   if (!r) throw new SoloError('Error running init, expected return value to be true');
                 })
                 .catch(err => {
-                  self.logger.showUserError(err);
                   throw new SoloError(`Error running init: ${err.message}`, err);
                 });
             },
@@ -751,7 +749,6 @@ export class AccountCommand extends BaseCommand {
                   if (!r) throw new SoloError('Error running create, expected return value to be true');
                 })
                 .catch(err => {
-                  self.logger.showUserError(err);
                   throw new SoloError(`Error running create: ${err.message}`, err);
                 });
             },
@@ -771,7 +768,6 @@ export class AccountCommand extends BaseCommand {
                   if (!r) throw new SoloError('Error running update, expected return value to be true');
                 })
                 .catch(err => {
-                  self.logger.showUserError(err);
                   throw new SoloError(`Error running update: ${err.message}`, err);
                 });
             },
@@ -791,7 +787,6 @@ export class AccountCommand extends BaseCommand {
                   if (!r) throw new SoloError('Error running get, expected return value to be true');
                 })
                 .catch(err => {
-                  self.logger.showUserError(err);
                   throw new SoloError(`Error running get: ${err.message}`, err);
                 });
             },

--- a/src/commands/base.ts
+++ b/src/commands/base.ts
@@ -197,7 +197,6 @@ export abstract class BaseCommand extends ShellRunner {
         self.logger.debug(`OK: setup directory: ${dirPath}`);
       });
     } catch (e: Error | any) {
-      self.logger.error(e);
       throw new SoloError(`failed to create directory: ${e.message}`, e);
     }
 

--- a/src/commands/cluster/configs.ts
+++ b/src/commands/cluster/configs.ts
@@ -6,7 +6,7 @@ import {Flags as flags} from '../flags.js';
 import * as constants from '../../core/constants.js';
 import {ListrInquirerPromptAdapter} from '@listr2/prompt-adapter-inquirer';
 import {confirm as confirmPrompt} from '@inquirer/prompts';
-import {SoloError} from '../../core/errors.js';
+import {SoloError, UserBreak} from '../../core/errors.js';
 import {type NamespaceName} from '../../core/kube/resources/namespace/namespace_name.js';
 import {type DeploymentName} from '../../core/config/remote/types.js';
 import {inject, injectable} from 'tsyringe-neo';
@@ -44,7 +44,7 @@ export class ClusterCommandConfigs {
 
   public async connectConfigBuilder(argv, ctx, task) {
     if (!this.localConfig.configFileExists()) {
-      this.logger.logAndExitError(new SoloError(ErrorMessages.LOCAL_CONFIG_DOES_NOT_EXIST));
+      throw new SoloError(ErrorMessages.LOCAL_CONFIG_DOES_NOT_EXIST);
     }
 
     this.configManager.update(argv);
@@ -110,7 +110,7 @@ export class ClusterCommandConfigs {
       });
 
       if (!confirmResult) {
-        this.logger.logAndExitSuccess('Aborted application by user prompt');
+        throw new UserBreak('Aborted application by user prompt');
       }
     }
 

--- a/src/commands/cluster/tasks.ts
+++ b/src/commands/cluster/tasks.ts
@@ -12,7 +12,7 @@ import path from 'path';
 import chalk from 'chalk';
 import {ListrLease} from '../../core/lease/listr_lease.js';
 import {ErrorMessages} from '../../core/error_messages.js';
-import {SoloError} from '../../core/errors.js';
+import {SoloError, UserBreak} from '../../core/errors.js';
 import {RemoteConfigManager} from '../../core/config/remote/remote_config_manager.js';
 import {type RemoteConfigDataWrapper} from '../../core/config/remote/remote_config_data_wrapper.js';
 import {type K8Factory} from '../../core/kube/k8_factory.js';
@@ -296,14 +296,14 @@ export class ClusterCommandTasks {
           }
         }
 
-        // If one or more clusters are provided, use the first one to determine the context
+          // If one or more clusters are provided, use the first one to determine the context
         // from the mapping in the LocalConfig
         else if (clusters.length) {
           selectedCluster = clusters[0];
           selectedContext = await this.selectContextForFirstCluster(task, clusters, localConfig, isQuiet);
         }
 
-        // If a deployment name is provided, get the clusters associated with the deployment from the LocalConfig
+          // If a deployment name is provided, get the clusters associated with the deployment from the LocalConfig
         // and select the context from the mapping, corresponding to the first deployment cluster
         else if (deploymentName) {
           const deployment = localConfig.deployments[deploymentName];
@@ -490,7 +490,10 @@ export class ClusterCommandTasks {
             // ignore error during uninstall since we are doing the best-effort uninstall here
           }
 
-          throw e;
+          throw new SoloError(
+            `Error on installing ${constants.SOLO_CLUSTER_SETUP_CHART}. attempting to rollback by uninstalling the chart`,
+            e,
+          );
         }
 
         if (argv.dev) {
@@ -525,7 +528,7 @@ export class ClusterCommandTasks {
           });
 
           if (!confirm) {
-            self.logger.logAndExitSuccess('Aborted application by user prompt');
+            throw new UserBreak('Aborted application by user prompt');
           }
         }
         await self.chartManager.uninstall(

--- a/src/commands/deployment.ts
+++ b/src/commands/deployment.ts
@@ -193,9 +193,7 @@ export class DeploymentCommand extends BaseCommand {
           task: async (ctx, task) => {
             self.configManager.update(argv);
             self.logger.debug('Updated config with argv', {config: self.configManager.config});
-
             await self.configManager.executePrompt(task, [flags.clusterRef]);
-
             ctx.config = {
               clusterName: self.configManager.getFlag<ClusterRef>(flags.clusterRef),
             } as Config;
@@ -264,7 +262,6 @@ export class DeploymentCommand extends BaseCommand {
                   if (!r) throw new SoloError('Error creating deployment, expected return value to be true');
                 })
                 .catch(err => {
-                  self.logger.showUserError(err);
                   throw new SoloError(`Error creating deployment: ${err.message}`, err);
                 });
             },
@@ -285,7 +282,6 @@ export class DeploymentCommand extends BaseCommand {
                   if (!r) throw new SoloError('Error listing deployments, expected return value to be true');
                 })
                 .catch(err => {
-                  self.logger.showUserError(err);
                   throw new SoloError(`Error listing deployments: ${err.message}`, err);
                 });
             },

--- a/src/commands/explorer.ts
+++ b/src/commands/explorer.ts
@@ -4,7 +4,7 @@
 import {ListrInquirerPromptAdapter} from '@listr2/prompt-adapter-inquirer';
 import {confirm as confirmPrompt} from '@inquirer/prompts';
 import {Listr} from 'listr2';
-import {SoloError, MissingArgumentError} from '../core/errors.js';
+import {SoloError, MissingArgumentError, UserBreak} from '../core/errors.js';
 import * as constants from '../core/constants.js';
 import {type ProfileManager} from '../core/profile_manager.js';
 import {BaseCommand, type Opts} from './base.js';
@@ -372,9 +372,7 @@ export class ExplorerCommand extends BaseCommand {
       await tasks.run();
       self.logger.debug('explorer deployment has completed');
     } catch (e) {
-      const message = `Error deploying explorer: ${e.message}`;
-      self.logger.error(message, e);
-      throw new SoloError(message, e);
+      throw new SoloError(`Error deploying explorer: ${e.message}`, e);
     } finally {
       await lease.release();
     }
@@ -406,7 +404,7 @@ export class ExplorerCommand extends BaseCommand {
               });
 
               if (!confirmResult) {
-                this.logger.logAndExitSuccess('Aborted application by user prompt');
+                throw new UserBreak('Aborted application by user prompt');
               }
             }
 
@@ -509,7 +507,6 @@ export class ExplorerCommand extends BaseCommand {
                   if (!r) throw new Error('Explorer deployment failed, expected return value to be true');
                 })
                 .catch(err => {
-                  self.logger.showUserError(err);
                   throw new SoloError(`Explorer deployment failed: ${err.message}`, err);
                 });
             },
@@ -537,7 +534,6 @@ export class ExplorerCommand extends BaseCommand {
                   if (!r) throw new SoloError('Explorer destruction failed, expected return value to be true');
                 })
                 .catch(err => {
-                  self.logger.showUserError(err);
                   throw new SoloError(`Explorer destruction failed: ${err.message}`, err);
                 });
             },

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -6,7 +6,7 @@ import path from 'path';
 import {BaseCommand} from './base.js';
 import fs from 'fs';
 import * as constants from '../core/constants.js';
-import {SoloError} from '../core/errors.js';
+import {SoloError, UserBreak} from '../core/errors.js';
 import {Flags as flags} from './flags.js';
 import chalk from 'chalk';
 
@@ -85,7 +85,7 @@ export class InitCommand extends BaseCommand {
             self.logger.showUser(
               chalk.grey(
                 `Note: solo stores various artifacts (config, logs, keys etc.) in its home directory: ${constants.SOLO_HOME_DIR}\n` +
-                  "If a full reset is needed, delete the directory or relevant sub-directories before running 'solo init'.",
+                "If a full reset is needed, delete the directory or relevant sub-directories before running 'solo init'.",
               ),
             );
             self.logger.showUser(
@@ -100,11 +100,7 @@ export class InitCommand extends BaseCommand {
       },
     );
 
-    try {
-      await tasks.run();
-    } catch (e: Error | any) {
-      throw new SoloError('Error running init', e);
-    }
+    await tasks.run();
 
     return true;
   }
@@ -128,7 +124,6 @@ export class InitCommand extends BaseCommand {
             if (!r) throw new SoloError('Error running init, expected return value to be true');
           })
           .catch(err => {
-            self.logger.showUserError(err);
             throw new SoloError('Error running init', err);
           });
       },

--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -5,7 +5,7 @@ import {ListrInquirerPromptAdapter} from '@listr2/prompt-adapter-inquirer';
 import {confirm as confirmPrompt} from '@inquirer/prompts';
 import chalk from 'chalk';
 import {Listr} from 'listr2';
-import {IllegalArgumentError, MissingArgumentError, SoloError} from '../core/errors.js';
+import {IllegalArgumentError, MissingArgumentError, SoloError, UserBreak} from '../core/errors.js';
 import {BaseCommand, type Opts} from './base.js';
 import {Flags as flags} from './flags.js';
 import * as constants from '../core/constants.js';
@@ -324,9 +324,7 @@ export class NetworkCommand extends BaseCommand {
 
       await this.prepareBackupUploaderSecrets(config);
     } catch (e: Error | any) {
-      const errorMessage = 'failed to create Kubernetes storage secret ';
-      this.logger.error(errorMessage, e);
-      throw new SoloError(errorMessage, e);
+      throw new SoloError('Failed to create Kubernetes storage secret', e);
     }
   }
 
@@ -1129,7 +1127,7 @@ export class NetworkCommand extends BaseCommand {
               });
 
               if (!confirmResult) {
-                this.logger.logAndExitSuccess('Aborted application by user prompt');
+                throw new UserBreak('Aborted application by user prompt');
               }
             }
 
@@ -1278,7 +1276,6 @@ export class NetworkCommand extends BaseCommand {
                   if (!r) throw new SoloError('Error deploying network, expected return value to be true');
                 })
                 .catch(err => {
-                  self.logger.showUserError(err);
                   throw new SoloError(`Error deploying network: ${err.message}`, err);
                 });
             },
@@ -1308,7 +1305,6 @@ export class NetworkCommand extends BaseCommand {
                   if (!r) throw new SoloError('Error destroying network, expected return value to be true');
                 })
                 .catch(err => {
-                  self.logger.showUserError(err);
                   throw new SoloError(`Error destroying network: ${err.message}`, err);
                 });
             },
@@ -1329,7 +1325,6 @@ export class NetworkCommand extends BaseCommand {
                   if (!r) throw new SoloError('Error refreshing network, expected return value to be true');
                 })
                 .catch(err => {
-                  self.logger.showUserError(err);
                   throw new SoloError(`Error refreshing network: ${err.message}`, err);
                 });
             },

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -427,7 +427,7 @@ export class NodeCommandTasks {
         if (!response) {
           task.title = `${title} - status ${chalk.yellow('UNKNOWN')}, attempt ${chalk.blueBright(`${attempt}/${maxAttempts}`)}`;
           clearTimeout(timeoutId);
-          throw new Error('empty response'); // Guard
+          throw new SoloError('empty response'); // Guard
         }
 
         const statusLine = response.split('\n').find(line => line.startsWith('platform_PlatformStatus'));
@@ -435,7 +435,7 @@ export class NodeCommandTasks {
         if (!statusLine) {
           task.title = `${title} - status ${chalk.yellow('STARTING')}, attempt: ${chalk.blueBright(`${attempt}/${maxAttempts}`)}`;
           clearTimeout(timeoutId);
-          throw new Error('missing status line'); // Guard
+          throw new SoloError('missing status line'); // Guard
         }
 
         const statusNumber = parseInt(statusLine.split(' ').pop());
@@ -466,7 +466,7 @@ export class NodeCommandTasks {
     if (!success) {
       throw new SoloError(
         `node '${nodeAlias}' is not ${NodeStatusEnums[status]}` +
-          `[ attempt = ${chalk.blueBright(`${attempt}/${maxAttempts}`)} ]`,
+        `[ attempt = ${chalk.blueBright(`${attempt}/${maxAttempts}`)} ]`,
       );
     }
 
@@ -710,7 +710,6 @@ export class NodeCommandTasks {
           prepareUpgradeReceipt.status.toString(),
         );
       } catch (e) {
-        self.logger.error(`Error in prepare upgrade: ${e.message}`, e);
         throw new SoloError(`Error in prepare upgrade: ${e.message}`, e);
       }
     });
@@ -747,7 +746,6 @@ export class NodeCommandTasks {
           freezeUpgradeReceipt.status.toString(),
         );
       } catch (e) {
-        self.logger.error(`Error in freeze upgrade: ${e.message}`, e);
         throw new SoloError(`Error in freeze upgrade: ${e.message}`, e);
       }
     });
@@ -783,7 +781,6 @@ export class NodeCommandTasks {
           freezeOnlyReceipt.status.toString(),
         );
       } catch (e) {
-        self.logger.error(`Error in sending freeze transaction: ${e.message}`, e);
         throw new SoloError(`Error in sending freeze transaction: ${e.message}`, e);
       }
     });
@@ -919,7 +916,7 @@ export class NodeCommandTasks {
               undefined,
               context,
             );
-          } catch (_) {
+          } catch (e: Error | any) {
             ctx.config.skipStop = true;
           }
         },
@@ -1034,21 +1031,21 @@ export class NodeCommandTasks {
 
       return localBuildPath !== ''
         ? self._uploadPlatformSoftware(
-            ctx.config[aliasesField],
-            podRefs,
-            task,
-            localBuildPath,
-            ctx.config.consensusNodes,
-            releaseTag,
-          )
+          ctx.config[aliasesField],
+          podRefs,
+          task,
+          localBuildPath,
+          ctx.config.consensusNodes,
+          releaseTag,
+        )
         : self._fetchPlatformSoftware(
-            ctx.config[aliasesField],
-            podRefs,
-            releaseTag,
-            task,
-            this.platformInstaller,
-            ctx.config.consensusNodes,
-          );
+          ctx.config[aliasesField],
+          podRefs,
+          releaseTag,
+          task,
+          this.platformInstaller,
+          ctx.config.consensusNodes,
+        );
     });
   }
 
@@ -1634,8 +1631,6 @@ export class NodeCommandTasks {
         const nodeUpdateReceipt = await txResp.getReceipt(config.nodeClient);
         self.logger.debug(`NodeUpdateReceipt: ${nodeUpdateReceipt.toString()}`);
       } catch (e) {
-        self.logger.error(`Error updating node to network: ${e.message}`, e);
-        self.logger.error(e.stack);
         throw new SoloError(`Error updating node to network: ${e.message}`, e);
       }
     });
@@ -2012,7 +2007,6 @@ export class NodeCommandTasks {
 
         this.logger.debug(`NodeUpdateReceipt: ${nodeUpdateReceipt.toString()}`);
       } catch (e) {
-        this.logger.error(`Error deleting node from network: ${e.message}`, e);
         throw new SoloError(`Error deleting node from network: ${e.message}`, e);
       }
     });
@@ -2036,7 +2030,6 @@ export class NodeCommandTasks {
         const nodeCreateReceipt = await txResp.getReceipt(config.nodeClient);
         this.logger.debug(`NodeCreateReceipt: ${nodeCreateReceipt.toString()}`);
       } catch (e) {
-        this.logger.error(`Error adding node to network: ${e.message}`, e);
         throw new SoloError(`Error adding node to network: ${e.message}`, e);
       }
     });

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -345,7 +345,7 @@ export class RelayCommand extends BaseCommand {
     try {
       await tasks.run();
     } catch (e) {
-      throw new SoloError('Error installing relays', e);
+      throw new SoloError(`Error deploying relay: ${e.message}`, e);
     } finally {
       await lease.release();
       await self.accountManager.close();
@@ -466,17 +466,10 @@ export class RelayCommand extends BaseCommand {
               self.logger.info("==== Running 'relay deploy' ===", {argv});
               self.logger.info(argv);
 
-              await self
-                .deploy(argv)
-                .then(r => {
-                  self.logger.info('==== Finished running `relay deploy`====');
-
-                  if (!r) throw new SoloError('Error deploying relay, expected return value to be true');
-                })
-                .catch(err => {
-                  self.logger.showUserError(err);
-                  throw new SoloError(`Error deploying relay: ${err.message}`, err);
-                });
+              await self.deploy(argv).then(r => {
+                self.logger.info('==== Finished running `relay deploy`====');
+                if (!r) throw new SoloError('Error deploying relay, expected return value to be true');
+              });
             },
           })
           .command({

--- a/src/core/config/remote/remote_config_manager.ts
+++ b/src/core/config/remote/remote_config_manager.ts
@@ -179,10 +179,7 @@ export class RemoteConfigManager {
 
       return false;
     } catch (e) {
-      const newError = new SoloError('Failed to load remote config from cluster', e);
-      // TODO: throw newError instead of showUserError()
-      this.logger.showUserError(newError);
-      return false;
+      throw new SoloError('Failed to load remote config from cluster', e);
     }
   }
 
@@ -240,10 +237,7 @@ export class RemoteConfigManager {
     }
 
     if (!(await self.load())) {
-      const newError = new SoloError('Failed to load remote config');
-      // TODO throw newError instead of showUserError()
-      self.logger.showUserError(newError);
-      return;
+      throw new SoloError('Failed to load remote config');
     }
     self.logger.info('Remote config loaded');
     if (!validate) {
@@ -392,21 +386,14 @@ export class RemoteConfigManager {
         .configMaps()
         .read(namespace, constants.SOLO_REMOTE_CONFIGMAP_NAME);
       if (!configMap) {
-        // TODO throw newError instead of showUserError()
-        const newError = new SoloError(
-          `Remote config ConfigMap not found for namespace: ${namespace}, context: ${context}`,
-        );
-        this.logger.showUserError(newError);
+        throw new SoloError(`Remote config ConfigMap not found for namespace: ${namespace}, context: ${context}`);
       }
       return configMap;
     } catch (e) {
-      // TODO throw newError instead of showUserError()
-      const newError = new SoloError(
+      throw new SoloError(
         `Failed to read remote config from cluster for namespace: ${namespace}, context: ${context}`,
         e,
       );
-      this.logger.showUserError(newError);
-      return null;
     }
   }
 

--- a/src/core/dependency_injection/container_init.ts
+++ b/src/core/dependency_injection/container_init.ts
@@ -32,6 +32,7 @@ import {NodeCommandHandlers} from '../../commands/node/handlers.js';
 import {NodeCommandTasks} from '../../commands/node/tasks.js';
 import {ClusterCommandConfigs} from '../../commands/cluster/configs.js';
 import {NodeCommandConfigs} from '../../commands/node/configs.js';
+import {ErrorHandler} from '../error_handler.js';
 
 /**
  * Container class to manage the dependency injection container
@@ -170,6 +171,8 @@ export class Container {
       {useClass: NodeCommandConfigs},
       {lifecycle: Lifecycle.Singleton},
     );
+
+    container.register(InjectTokens.ErrorHandler, {useClass: ErrorHandler}, {lifecycle: Lifecycle.Singleton});
   }
 
   /**

--- a/src/core/dependency_injection/inject_tokens.ts
+++ b/src/core/dependency_injection/inject_tokens.ts
@@ -40,4 +40,5 @@ export const InjectTokens = {
   NodeCommandHandlers: Symbol.for('NodeCommandHandlers'),
   ClusterCommandConfigs: Symbol.for('ClusterCommandConfigs'),
   NodeCommandConfigs: Symbol.for('NodeCommandConfigs'),
+  ErrorHandler: Symbol.for('ErrorHandler'),
 };

--- a/src/core/error_handler.ts
+++ b/src/core/error_handler.ts
@@ -1,0 +1,47 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {inject, injectable} from 'tsyringe-neo';
+import {InjectTokens} from './dependency_injection/inject_tokens.js';
+import {patchInject} from './dependency_injection/container_helper.js';
+import {type SoloLogger} from './logging.js';
+import {UserBreak} from './errors.js';
+
+@injectable()
+export class ErrorHandler {
+  constructor(@inject(InjectTokens.SoloLogger) private readonly logger: SoloLogger) {
+    this.logger = patchInject(logger, InjectTokens.SoloLogger, this.constructor.name);
+  }
+
+  public handle(error: Error | any): void {
+    const userBreak = this.extractUserBreak(error);
+    if (userBreak) {
+      this.handleUserBreak(userBreak);
+    } else {
+      this.handleError(error);
+    }
+  }
+
+  private handleUserBreak(userBreak: UserBreak): void {
+    this.logger.showUser(userBreak.message);
+  }
+
+  private handleError(error: Error | any): void {
+    this.logger.showUserError(error);
+  }
+
+  /**
+   * Recursively checks if an error is or is caused by a UserBreak
+   * Returns the UserBreak if found, otherwise false
+   * @param err
+   */
+  private extractUserBreak(err: Error | any): UserBreak | false {
+    if (err instanceof UserBreak) {
+      return err;
+    }
+    if (err?.cause) {
+      return this.extractUserBreak(err.cause);
+    }
+    return false;
+  }
+}

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -87,3 +87,14 @@ export class DataValidationError extends SoloError {
     super(message, cause, {expected, found});
   }
 }
+
+export class UserBreak extends SoloError {
+  /**
+   * Create a custom error for user break scenarios
+   *
+   * @param message - break message
+   */
+  constructor(message: string) {
+    super(message);
+  }
+}

--- a/src/core/kube/k8_client/resources/config_map/k8_client_config_maps.ts
+++ b/src/core/kube/k8_client/resources/config_map/k8_client_config_maps.ts
@@ -53,7 +53,9 @@ export class K8ClientConfigMaps implements ConfigMaps {
   }
 
   public async read(namespace: NamespaceName, name: string): Promise<V1ConfigMap> {
-    const {response, body} = await this.kubeClient.readNamespacedConfigMap(name, namespace.name).catch(e => e);
+    const {response, body} = await this.kubeClient.readNamespacedConfigMap(name, namespace.name).catch(e => {
+      throw new SoloError(`Error reading namespaced ConfigMap: ${e.message}`, e);
+    });
     KubeApiResponse.check(response, ResourceOperation.READ, ResourceType.CONFIG_MAP, namespace, name);
     return body as V1ConfigMap;
   }

--- a/src/core/kube/k8_client/resources/lease/k8_client_leases.ts
+++ b/src/core/kube/k8_client/resources/lease/k8_client_leases.ts
@@ -46,9 +46,9 @@ export class K8ClientLeases implements Leases {
     spec.acquireTime = new V1MicroTime();
     lease.spec = spec;
 
-    const {response, body} = await this.coordinationApiClient
-      .createNamespacedLease(namespace.name, lease)
-      .catch(e => e);
+    const {response, body} = await this.coordinationApiClient.createNamespacedLease(namespace.name, lease).catch(e => {
+      throw new SoloError(`Error creating namespaced lease: ${e.message}`, e);
+    });
 
     this.handleKubernetesClientError(response, body, 'Failed to create namespaced lease');
 
@@ -56,7 +56,9 @@ export class K8ClientLeases implements Leases {
   }
 
   public async delete(namespace: NamespaceName, name: string): Promise<V1Status> {
-    const {response, body} = await this.coordinationApiClient.deleteNamespacedLease(name, namespace.name).catch(e => e);
+    const {response, body} = await this.coordinationApiClient.deleteNamespacedLease(name, namespace.name).catch(e => {
+      throw new SoloError(`Error deleting namespaced lease: ${e.message}`, e);
+    });
 
     this.handleKubernetesClientError(response, body, 'Failed to delete namespaced lease');
 
@@ -66,7 +68,9 @@ export class K8ClientLeases implements Leases {
   public async read(namespace: NamespaceName, leaseName: string, timesCalled?: number): Promise<any> {
     const {response, body} = await this.coordinationApiClient
       .readNamespacedLease(leaseName, namespace.name)
-      .catch(e => e);
+      .catch(e => {
+        throw new SoloError(`Error reading namespaced lease: ${e.message}`, e);
+      });
 
     if (response?.statusCode === StatusCodes.INTERNAL_SERVER_ERROR && timesCalled < 4) {
       // could be k8s control plane has no resources available
@@ -87,7 +91,9 @@ export class K8ClientLeases implements Leases {
 
     const {response, body} = await this.coordinationApiClient
       .replaceNamespacedLease(leaseName, namespace.name, lease)
-      .catch(e => e);
+      .catch(e => {
+        throw new SoloError(`Error replacing namespaced lease: ${e.message}`, e);
+      });
 
     this.handleKubernetesClientError(response, body, 'Failed to renew namespaced lease');
 
@@ -101,7 +107,9 @@ export class K8ClientLeases implements Leases {
 
     const {response, body} = await this.coordinationApiClient
       .replaceNamespacedLease(lease.metadata.name, lease.metadata.namespace, lease)
-      .catch(e => e);
+      .catch(e => {
+        throw new SoloError(`Error replacing namespaced lease: ${e.message}`, e);
+      });
 
     this.handleKubernetesClientError(response, body, 'Failed to transfer namespaced lease');
 

--- a/src/core/kube/k8_client/resources/secret/k8_client_secrets.ts
+++ b/src/core/kube/k8_client/resources/secret/k8_client_secrets.ts
@@ -15,6 +15,7 @@ import {ResourceType} from '../../../resources/resource_type.js';
 import {ResourceOperation} from '../../../resources/resource_operation.js';
 import {Duration} from '../../../../time/duration.js';
 import {type SecretType} from '../../../resources/secret/secret_type.js';
+import {SoloError} from '../../../../errors.js';
 
 export class K8ClientSecrets implements Secrets {
   public constructor(private readonly kubeClient: CoreV1Api) {}
@@ -64,7 +65,9 @@ export class K8ClientSecrets implements Secrets {
     type: string;
     labels: Record<string, string>;
   }> {
-    const {response, body} = await this.kubeClient.readNamespacedSecret(name, namespace.name).catch(e => e);
+    const {response, body} = await this.kubeClient.readNamespacedSecret(name, namespace.name).catch(e => {
+      throw new SoloError(`Error reading namespaced secret: ${e.message}`, e);
+    });
     KubeApiResponse.check(response, ResourceOperation.READ, ResourceType.SECRET, namespace, name);
     return {
       name: body.metadata!.name as string,

--- a/src/core/logging.ts
+++ b/src/core/logging.ts
@@ -107,9 +107,14 @@ export class SoloLogger {
       let indent = '';
       stack.forEach(s => {
         console.log(indent + prefix + chalk.yellow(s.message));
-        console.log(indent + chalk.gray(s.stacktrace) + '\n');
-        indent += ' ';
-        prefix += 'Caused by: ';
+        // Remove everything after the first "Caused by: " and add indentation
+        const formattedStacktrace = s.stacktrace
+          .replace(/Caused by:.*/s, '')
+          .replace(/\n\s*/g, '\n' + indent)
+          .trim();
+        console.log(indent + chalk.gray(formattedStacktrace) + '\n');
+        indent += '  ';
+        prefix = 'Caused by: ';
       });
     } else {
       const lines: string[] = err.message.split('\n');
@@ -155,25 +160,6 @@ export class SoloLogger {
     this.showUser(chalk.green(`\n *** ${title} ***`));
     this.showUser(chalk.green('-------------------------------------------------------------------------------'));
     console.log(JSON.stringify(obj, null, ' '));
-  }
-
-  logAndExitSuccess(msg: string, ...args: any) {
-    this.winstonLogger.log('info', msg, args, () => {
-      queueMicrotask(() => {
-        // eslint-disable-next-line n/no-process-exit
-        process.exit(0);
-      });
-    });
-  }
-
-  logAndExitError(error: Error) {
-    this.showUserError(error);
-    this.winstonLogger.log('error', '', error, () => {
-      queueMicrotask(() => {
-        // eslint-disable-next-line n/no-process-exit
-        process.exit(1);
-      });
-    });
   }
 }
 

--- a/src/core/middlewares.ts
+++ b/src/core/middlewares.ts
@@ -27,6 +27,22 @@ export class Middlewares {
     this.logger = opts.logger;
   }
 
+  public setLoggerDevFlag() {
+    const logger = this.logger;
+
+    /**
+     * @param argv - listr Argv
+     */
+    return (argv: any): AnyObject => {
+      if (argv.dev) {
+        logger.debug('Setting logger dev flag');
+        logger.setDevMode(argv.dev);
+      }
+
+      return argv;
+    };
+  }
+
   /**
    * Processes the Argv and display the command header
    *

--- a/src/index.ts
+++ b/src/index.ts
@@ -34,7 +34,7 @@ import {Container} from './core/dependency_injection/container_init.js';
 import {InjectTokens} from './core/dependency_injection/inject_tokens.js';
 import {type Opts} from './commands/base.js';
 import {Middlewares} from './core/middlewares.js';
-import {SoloError} from './core/errors.js';
+import {SoloError, UserBreak} from './core/errors.js';
 
 export async function main(argv: string[], context?: {logger: SoloLogger}) {
   try {
@@ -46,99 +46,97 @@ export async function main(argv: string[], context?: {logger: SoloLogger}) {
 
   const logger = container.resolve<SoloLogger>(InjectTokens.SoloLogger);
 
-  try {
-    if (context) {
-      // save the logger so that solo.ts can use it to properly flush the logs and exit
-      context.logger = logger;
-    }
-    process.on('unhandledRejection', (reason, promise) => {
-      logger.logAndExitError(
-        new SoloError(`Unhandled Rejection at: ${JSON.stringify(promise)}, reason: ${JSON.stringify(reason)}`),
-      );
-    });
-    process.on('uncaughtException', (err, origin) => {
-      logger.logAndExitError(new SoloError(`Uncaught Exception: ${err}, origin: ${origin}`));
-    });
-
-    logger.debug('Initializing Solo CLI');
-    constants.LISTR_DEFAULT_RENDERER_OPTION.logger = new ListrLogger({processOutput: new CustomProcessOutput(logger)});
-    if (argv.length >= 3 && ['-version', '--version', '-v', '--v'].includes(argv[2])) {
-      logger.showUser(
-        chalk.cyan('\n******************************* Solo *********************************************'),
-      );
-      logger.showUser(chalk.cyan('Version\t\t\t:'), chalk.yellow(helpers.getSoloVersion()));
-      logger.showUser(chalk.cyan('**********************************************************************************'));
-      logger.logAndExitSuccess('displayed version information, exiting');
-    }
-
-    // prepare dependency manger registry
-    const downloader: PackageDownloader = container.resolve(InjectTokens.PackageDownloader);
-    const depManager: DependencyManager = container.resolve(InjectTokens.DependencyManager);
-    const helm: Helm = container.resolve(InjectTokens.Helm);
-    const chartManager: ChartManager = container.resolve(InjectTokens.ChartManager);
-    const configManager: ConfigManager = container.resolve(InjectTokens.ConfigManager);
-    const k8Factory: K8Factory = container.resolve(InjectTokens.K8Factory);
-    const accountManager: AccountManager = container.resolve(InjectTokens.AccountManager);
-    const platformInstaller: PlatformInstaller = container.resolve(InjectTokens.PlatformInstaller);
-    const keyManager: KeyManager = container.resolve(InjectTokens.KeyManager);
-    const profileManager: ProfileManager = container.resolve(InjectTokens.ProfileManager);
-    const leaseManager: LeaseManager = container.resolve(InjectTokens.LeaseManager);
-    const certificateManager: CertificateManager = container.resolve(InjectTokens.CertificateManager);
-    const localConfig: LocalConfig = container.resolve(InjectTokens.LocalConfig);
-    const remoteConfigManager: RemoteConfigManager = container.resolve(InjectTokens.RemoteConfigManager);
-
-    const opts: Opts = {
-      logger,
-      helm,
-      k8Factory,
-      downloader,
-      platformInstaller,
-      chartManager,
-      configManager,
-      depManager,
-      keyManager,
-      accountManager,
-      profileManager,
-      leaseManager,
-      remoteConfigManager,
-      certificateManager,
-      localConfig,
-    };
-
-    logger.debug('Initializing middlewares');
-    const middlewares = new Middlewares(opts);
-
-    logger.debug('Initializing commands');
-    const rootCmd = yargs(hideBin(argv))
-      .scriptName('')
-      .usage('Usage:\n  solo <command> [options]')
-      .alias('h', 'help')
-      .alias('v', 'version')
-      // @ts-expect-error - TS2769: No overload matches this call.
-      .command(commands.Initialize(opts))
-      .strict()
-      .demand(1, 'Select a command')
-
-      .middleware(
-        // @ts-expect-error - TS2322: To assign middlewares
-        [middlewares.processArgumentsAndDisplayHeader(), middlewares.loadRemoteConfig()],
-        false, // applyBeforeValidate is false as otherwise middleware is called twice
-      );
-
-    rootCmd.fail((msg, err) => {
-      logger.logAndExitError(
-        new SoloError(`Error running Solo CLI, failure occurred: ${msg ? msg : ''} ${err.message}`, err),
-      );
-    });
-
-    logger.debug('Setting up flags');
-    // set root level flags
-    flags.setCommandFlags(rootCmd, ...[flags.devMode, flags.forcePortForward]);
-    logger.debug('Parsing root command (executing the commands)');
-    return rootCmd.parse();
-  } catch (e) {
-    logger.logAndExitError(new SoloError(`Error running Solo CLI: ${e.message}`, e));
-    // technically unreachable, but helps TS understand that we're exiting
-    throw e;
+  if (context) {
+    // save the logger so that solo.ts can use it to properly flush the logs and exit
+    context.logger = logger;
   }
+  process.on('unhandledRejection', (reason, promise) => {
+    logger.showUserError(
+      new SoloError(`Unhandled Rejection at: ${JSON.stringify(promise)}, reason: ${JSON.stringify(reason)}`),
+    );
+  });
+  process.on('uncaughtException', (err, origin) => {
+    logger.showUserError(new SoloError(`Uncaught Exception: ${err}, origin: ${origin}`));
+  });
+
+  logger.debug('Initializing Solo CLI');
+  constants.LISTR_DEFAULT_RENDERER_OPTION.logger = new ListrLogger({processOutput: new CustomProcessOutput(logger)});
+  if (argv.length >= 3 && ['-version', '--version', '-v', '--v'].includes(argv[2])) {
+    logger.showUser(chalk.cyan('\n******************************* Solo *********************************************'));
+    logger.showUser(chalk.cyan('Version\t\t\t:'), chalk.yellow(helpers.getSoloVersion()));
+    logger.showUser(chalk.cyan('**********************************************************************************'));
+    throw new UserBreak('displayed version information, exiting');
+  }
+
+  // prepare dependency manger registry
+  const downloader: PackageDownloader = container.resolve(InjectTokens.PackageDownloader);
+  const depManager: DependencyManager = container.resolve(InjectTokens.DependencyManager);
+  const helm: Helm = container.resolve(InjectTokens.Helm);
+  const chartManager: ChartManager = container.resolve(InjectTokens.ChartManager);
+  const configManager: ConfigManager = container.resolve(InjectTokens.ConfigManager);
+  const k8Factory: K8Factory = container.resolve(InjectTokens.K8Factory);
+  const accountManager: AccountManager = container.resolve(InjectTokens.AccountManager);
+  const platformInstaller: PlatformInstaller = container.resolve(InjectTokens.PlatformInstaller);
+  const keyManager: KeyManager = container.resolve(InjectTokens.KeyManager);
+  const profileManager: ProfileManager = container.resolve(InjectTokens.ProfileManager);
+  const leaseManager: LeaseManager = container.resolve(InjectTokens.LeaseManager);
+  const certificateManager: CertificateManager = container.resolve(InjectTokens.CertificateManager);
+  const localConfig: LocalConfig = container.resolve(InjectTokens.LocalConfig);
+  const remoteConfigManager: RemoteConfigManager = container.resolve(InjectTokens.RemoteConfigManager);
+
+  const opts: Opts = {
+    logger,
+    helm,
+    k8Factory,
+    downloader,
+    platformInstaller,
+    chartManager,
+    configManager,
+    depManager,
+    keyManager,
+    accountManager,
+    profileManager,
+    leaseManager,
+    remoteConfigManager,
+    certificateManager,
+    localConfig,
+  };
+
+  logger.debug('Initializing middlewares');
+  const middlewares = new Middlewares(opts);
+
+  logger.debug('Initializing commands');
+  const rootCmd = yargs(hideBin(argv))
+    .scriptName('')
+    .usage('Usage:\n  solo <command> [options]')
+    .alias('h', 'help')
+    .alias('v', 'version')
+    // @ts-expect-error - TS2769: No overload matches this call.
+    .command(commands.Initialize(opts))
+    .strict()
+    .demand(1, 'Select a command')
+
+    .middleware(
+      // @ts-expect-error - TS2322: To assign middlewares
+      [middlewares.setLoggerDevFlag(), middlewares.processArgumentsAndDisplayHeader(), middlewares.loadRemoteConfig()],
+      false, // applyBeforeValidate is false as otherwise middleware is called twice
+    );
+
+  rootCmd.fail((msg, error) => {
+    if (msg) {
+      if (msg.includes('Unknown argument')) {
+        logger.showUser(msg);
+        rootCmd.showHelp();
+      } else {
+        logger.showUserError(new SoloError(`Error running Solo CLI, failure occurred: ${msg ? msg : ''}`));
+      }
+      rootCmd.exit(0, error);
+    }
+  });
+
+  logger.debug('Setting up flags');
+  // set root level flags
+  flags.setCommandFlags(rootCmd, ...[flags.devMode, flags.forcePortForward]);
+  logger.debug('Parsing root command (executing the commands)');
+  return rootCmd.parse();
 }


### PR DESCRIPTION
## Description

- Adds an `ErrorHandler` class
- Removes duplicate logging of errors
- Fixes an issue where `logErrorAndExit` and `logSuccessAndExit` were not actually terminating the process as intended
- Removes the possibility of `cannot access property of undefined` due to some errors being returned as a result instead of being thrown
- fixes the `--dev` flag to correctly set the `devMode` property of the logger. When passing `--dev` you will now see the error stack trace in the console.

### Related Issues

* Closes #1585
* Closes #1505
