### PR TITLE
fix: update Hedera platform versions to v0.59.2 and more

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.jar filter=lfs diff=lfs merge=lfs -text

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,9 +8,9 @@
 #####  Project Files  ######
 ############################
 
-/src/**                                         @hashgraph/release-engineering @leninmehedy
-/test/**                                        @hashgraph/release-engineering @leninmehedy
-/resources/**                                   @hashgraph/release-engineering @leninmehedy
+/src/**                                         @hashgraph/release-engineering
+/test/**                                        @hashgraph/release-engineering
+/resources/**                                   @hashgraph/release-engineering
 
 #########################
 #####  Core Files  ######

--- a/.github/workflows/flow-task-test.yaml
+++ b/.github/workflows/flow-task-test.yaml
@@ -76,6 +76,6 @@ jobs:
       - name: Run Example Task File Test with type ${{ matrix.type }}
         run: |
           cd examples/external-database-test
-          export CONSENSUS_NODE_VERSION=v0.58.3
+          export CONSENSUS_NODE_VERSION=v0.58.10
           SOLO_CLUSTER_NAME=solo-task-test-${{ matrix.type }}-${{ github.run_id }}-${{ github.run_attempt }} task install
           task destroy

--- a/.github/workflows/flow-task-test.yaml
+++ b/.github/workflows/flow-task-test.yaml
@@ -76,6 +76,6 @@ jobs:
       - name: Run Example Task File Test with type ${{ matrix.type }}
         run: |
           cd examples/external-database-test
-          export CONSENSUS_NODE_VERSION=v0.58.10
+          export CONSENSUS_NODE_VERSION=$(grep 'HEDERA_PLATFORM_VERSION' version.ts | sed -E "s/.*'([^']+)';/\1/")
           SOLO_CLUSTER_NAME=solo-task-test-${{ matrix.type }}-${{ github.run_id }}-${{ github.run_attempt }} task install
           task destroy

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -187,8 +187,10 @@ jobs:
         if: ${{ runner.os == 'linux' && (inputs.npm-test-script == 'test-e2e-node-local-hedera' || inputs.npm-test-script == 'test-e2e-node-local-ptt' || inputs.npm-test-script == 'test-e2e-node-add-local') && !cancelled() && !failure() }}
         run: |
           cd ..
-          git clone https://github.com/hashgraph/hedera-services.git --depth 1 --branch v0.58.3
-          cd hedera-services
+          # TODO revert before merge
+          # git clone https://github.com/hiero-ledger/hiero-consensus-node.git --depth 1 --branch v0.58.10
+          git clone https://github.com/hiero-ledger/hiero-consensus-node.git --depth 1 --branch jeromy-v0.58.10-debug
+          cd hiero-consensus-node
           ls -ltr
           ${{ env.CG_EXEC }} ./gradlew assemble --stacktrace --info
           cd ../solo

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -186,8 +186,9 @@ jobs:
       - name: Build Hedera code locally
         if: ${{ runner.os == 'linux' && (inputs.npm-test-script == 'test-e2e-node-local-hedera' || inputs.npm-test-script == 'test-e2e-node-local-ptt' || inputs.npm-test-script == 'test-e2e-node-add-local') && !cancelled() && !failure() }}
         run: |
+          export CONSENSUS_NODE_VERSION=$(grep 'TEST_LOCAL_HEDERA_PLATFORM_VERSION' version_test.ts | sed -E "s/.*'([^']+)';/\1/")
           cd ..
-          git clone https://github.com/hiero-ledger/hiero-consensus-node.git --depth 1 --branch v0.58.10
+          git clone https://github.com/hiero-ledger/hiero-consensus-node.git --depth 1 --branch ${CONSENSUS_NODE_VERSION}
           cd hiero-consensus-node
           ls -ltr
           ${{ env.CG_EXEC }} ./gradlew assemble --stacktrace --info

--- a/.github/workflows/zxc-e2e-test.yaml
+++ b/.github/workflows/zxc-e2e-test.yaml
@@ -187,9 +187,7 @@ jobs:
         if: ${{ runner.os == 'linux' && (inputs.npm-test-script == 'test-e2e-node-local-hedera' || inputs.npm-test-script == 'test-e2e-node-local-ptt' || inputs.npm-test-script == 'test-e2e-node-add-local') && !cancelled() && !failure() }}
         run: |
           cd ..
-          # TODO revert before merge
-          # git clone https://github.com/hiero-ledger/hiero-consensus-node.git --depth 1 --branch v0.58.10
-          git clone https://github.com/hiero-ledger/hiero-consensus-node.git --depth 1 --branch jeromy-v0.58.10-debug
+          git clone https://github.com/hiero-ledger/hiero-consensus-node.git --depth 1 --branch v0.58.10
           cd hiero-consensus-node
           ls -ltr
           ${{ env.CG_EXEC }} ./gradlew assemble --stacktrace --info

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,7 +9,7 @@ env:
   SOLO_DEPLOYMENT: solo-deployment
   # SOLO_CHART_VERSION: 0.39.0
   # CONSENSUS_NODE_VERSION: v0.58.0
-  HEDERA_SERVICES_ROOT: "/Users/user/source/hedera-services"
+  HEDERA_SERVICES_ROOT: "/Users/user/source/hiero-consensus-node"
   # LOCAL_BUILD_FLAG: "--local-build-path {{.HEDERA_SERVICES_ROOT}}/hedera-node/data"
   # DEBUG_NODE_ALIAS: "node2"
   # SOLO_CHARTS_DIR_FLAG: "--chart-directory /Users/user/source/solo-charts/charts"

--- a/docs/site/content/User/DebugLog/HowToDebugHederaServicesAndPlatformSDK.md
+++ b/docs/site/content/User/DebugLog/HowToDebugHederaServicesAndPlatformSDK.md
@@ -43,7 +43,7 @@ solo node logs -i node1 -n solo-e2e
 
 ### 2. Using IntelliJ remote debug with Solo
 
-NOTE: the hedera-services path referenced '../hedera-services/hedera-node/data' may
+NOTE: the hiero-consensus-node path referenced '../hiero-consensus-node/hedera-node/data' may
 need to be updated based on what directory you are currently in.  This also assumes that you have done an assemble/build and the directory contents are up-to-date.
 
 Setup a Intellij run/debug configuration for remote JVM Debug as shown in the below screenshot:
@@ -66,7 +66,7 @@ Example 1: attach jvm debugger to a hedera node
 ./test/e2e/setup-e2e.sh
 solo node keys --gossip-keys --tls-keys -i node1,node2,node3
 solo network deploy -i node1,node2,node3 --debug-node-alias node2 -n "${SOLO_NAMESPACE}"
-solo node setup -i node1,node2,node3 --local-build-path ../hedera-services/hedera-node/data -n "${SOLO_NAMESPACE}"
+solo node setup -i node1,node2,node3 --local-build-path ../hiero-consensus-node/hedera-node/data -n "${SOLO_NAMESPACE}"
 solo node start -i node1,node2,node3 --debug-node-alias node2 -n "${SOLO_NAMESPACE}"
 ```
 
@@ -90,9 +90,9 @@ Example 2: attach jvm debugger with node add operation
 ./test/e2e/setup-e2e.sh
 solo node keys --gossip-keys --tls-keys -i node1,node2,node3
 solo network deploy -i node1,node2,node3 --pvcs -n "${SOLO_NAMESPACE}"
-solo node setup -i node1,node2,node3 --local-build-path ../hedera-services/hedera-node/data -n "${SOLO_NAMESPACE}"
+solo node setup -i node1,node2,node3 --local-build-path ../hiero-consensus-node/hedera-node/data -n "${SOLO_NAMESPACE}"
 solo node start -i node1,node2,node3 -n "${SOLO_NAMESPACE}"
-solo node add --gossip-keys --tls-keys --debug-node-alias node4 --local-build-path ../hedera-services/hedera-node/data -n "${SOLO_NAMESPACE}" --pvcs true
+solo node add --gossip-keys --tls-keys --debug-node-alias node4 --local-build-path ../hiero-consensus-node/hedera-node/data -n "${SOLO_NAMESPACE}" --pvcs true
 ```
 
 Example 3: attach jvm debugger with node update operation
@@ -101,9 +101,9 @@ Example 3: attach jvm debugger with node update operation
 ./test/e2e/setup-e2e.sh
 solo node keys --gossip-keys --tls-keys -i node1,node2,node3
 solo network deploy -i node1,node2,node3 -n "${SOLO_NAMESPACE}"
-solo node setup -i node1,node2,node3 --local-build-path ../hedera-services/hedera-node/data -n "${SOLO_NAMESPACE}"
+solo node setup -i node1,node2,node3 --local-build-path ../hiero-consensus-node/hedera-node/data -n "${SOLO_NAMESPACE}"
 solo node start -i node1,node2,node3 -n "${SOLO_NAMESPACE}"
-solo node update --node-alias node2  --debug-node-alias node2 --local-build-path ../hedera-services/hedera-node/data --new-account-number 0.0.7 --gossip-public-key ./s-public-node2.pem --gossip-private-key ./s-private-node2.pem  -n "${SOLO_NAMESPACE}"
+solo node update --node-alias node2  --debug-node-alias node2 --local-build-path ../hiero-consensus-node/hedera-node/data --new-account-number 0.0.7 --gossip-public-key ./s-public-node2.pem --gossip-private-key ./s-private-node2.pem  -n "${SOLO_NAMESPACE}"
 ```
 
 Example 4: attach jvm debugger with node delete operation
@@ -112,7 +112,7 @@ Example 4: attach jvm debugger with node delete operation
 ./test/e2e/setup-e2e.sh
 solo node keys --gossip-keys --tls-keys -i node1,node2,node3
 solo network deploy -i node1,node2,node3,node4 -n "${SOLO_NAMESPACE}"
-solo node setup -i node1,node2,node3,node4 --local-build-path ../hedera-services/hedera-node/data -n "${SOLO_NAMESPACE}"
+solo node setup -i node1,node2,node3,node4 --local-build-path ../hiero-consensus-node/hedera-node/data -n "${SOLO_NAMESPACE}"
 solo node start -i node1,node2,node3,node4 -n "${SOLO_NAMESPACE}"
 solo node delete --node-alias node2  --debug-node-alias node3 -n "${SOLO_NAMESPACE}"
 ```
@@ -145,7 +145,7 @@ Later, user can use the following command to upload the state files to the netwo
 ./test/e2e/setup-e2e.sh
 solo node keys --gossip-keys --tls-keys -i node1,node2,node3
 solo network deploy -i node1,node2,node3 -n "${SOLO_NAMESPACE}"
-solo node setup -i node1,node2,node3 --local-build-path ../hedera-services/hedera-node/data -n "${SOLO_NAMESPACE}"
+solo node setup -i node1,node2,node3 --local-build-path ../hiero-consensus-node/hedera-node/data -n "${SOLO_NAMESPACE}"
 
 # start network with pre-existing state files
 solo node start -i node1,node2 -n solo-e2e --state-file network-node1-0-state.zip

--- a/docs/site/content/User/HederaDeveloper.md
+++ b/docs/site/content/User/HederaDeveloper.md
@@ -21,10 +21,10 @@ solo deployment create --namespace "${SOLO_NAMESPACE}"  --context kind-"${SOLO_C
 solo network deploy --deployment "${SOLO_DEVELOPMENT}" -i node1,node2,node3 
 
 # option 1) if all nodes are running the same version of Hedera app
-solo node setup --deployment "${SOLO_DEVELOPMENT}" -i node1,node2,node3 --local-build-path ../hedera-services/hedera-node/data/
+solo node setup --deployment "${SOLO_DEVELOPMENT}" -i node1,node2,node3 --local-build-path ../hiero-consensus-node/hedera-node/data/
 
 # option 2) if each node is running different version of Hedera app, please provide different paths to the local repositories
-solo node setup --deployment "${SOLO_DEVELOPMENT}" -i node1,node2,node3 --local-build-path node1=../hedera-services/hedera-node/data/,node1=<path2>,node3=<path3>
+solo node setup --deployment "${SOLO_DEVELOPMENT}" -i node1,node2,node3 --local-build-path node1=../hiero-consensus-node/hedera-node/data/,node1=<path2>,node3=<path3>
 
 solo node start --deployment "${SOLO_DEVELOPMENT}" -i node1,node2,node3 
 

--- a/docs/site/content/User/PlatformDeveloper.md
+++ b/docs/site/content/User/PlatformDeveloper.md
@@ -21,10 +21,10 @@ solo deployment create --namespace "${SOLO_NAMESPACE}"  --context kind-"${SOLO_C
 solo network deploy --deployment "${SOLO_DEVELOPMENT}" -i node1,node2,node3 --app PlatformTestingTool.jar
 
 # option 1) if all nodes are running the same version of platform testing app
-solo node setup --deployment "${SOLO_DEVELOPMENT}" -i node1,node2,node3 --local-build-path ../hedera-services/platform-sdk/sdk/data
+solo node setup --deployment "${SOLO_DEVELOPMENT}" -i node1,node2,node3 --local-build-path ../hiero-consensus-node/platform-sdk/sdk/data
 
 # option 2) if each node is running different version of platform testing app, please provide different paths to the local repositories
-solo node setup --deployment "${SOLO_DEVELOPMENT}" -i node1,node2,node3 --local-build-path node1=../hedera-services/platform-sdk/sdk/data,node1=<path2>,node3=<path3>
+solo node setup --deployment "${SOLO_DEVELOPMENT}" -i node1,node2,node3 --local-build-path node1=../hiero-consensus-node/platform-sdk/sdk/data,node1=<path2>,node3=<path3>
 
 solo node start --deployment "${SOLO_DEVELOPMENT}" -i node1,node2,node3 --app PlatformTestingTool.jar
 ```

--- a/examples/README.md
+++ b/examples/README.md
@@ -13,7 +13,7 @@
 NOTES:
 
 * Some of these examples are for running against large clusters with a lot of resources available.
-* the `env` environment variables if set in your shell will take precedence over what is in the Taskfile.yml. e.g. `export HEDERA_SERVICES_ROOT=<path-to-hedera-services-root>`
+* the `env` environment variables if set in your shell will take precedence over what is in the Taskfile.yml. e.g. `export HEDERA_SERVICES_ROOT=<path-to-hiero-consensus-node-root>`
 
 ## Customizing the examples
 

--- a/examples/address-book/README.md
+++ b/examples/address-book/README.md
@@ -8,6 +8,9 @@ NOTE: Mirror Node refers to File 102 as its address book.
 
 To get the address book from the ledger, this requires a port forward to be setup on port 50211 to consensus node with node ID = 0.
 
+> \[!NOTE] 
+> Due to file size, the Yahcli.jar file is stored with Git LFS (Large File Storage).  You will need to install Git LFS prior to cloning this repository to automatically download the Yahcli.jar file. For instructions on how to install see: https://docs.github.com/en/repositories/working-with-files/managing-large-files/installing-git-large-file-storage
+
 ```bash
 # try and detect if the port forward is already setup
 netstat -na | grep 50211

--- a/examples/custom-network-config/Taskfile.yml
+++ b/examples/custom-network-config/Taskfile.yml
@@ -14,5 +14,5 @@ env:
   SOLO_HOME: "/Users/user/.solo-alex-kuzmin-n4"
   LOG4J2_FLAG: "--log4j2-xml {{.USER_WORKING_DIR}}/log4j2.xml"
   APPLICATION_PROPERTIES_FLAG: "--application-properties {{.USER_WORKING_DIR}}/application.properties"
-  # HEDERA_SERVICES_ROOT: "/Users/user/source/hedera-services"
+  # HEDERA_SERVICES_ROOT: "/Users/user/source/hiero-consensus-node"
   # LOCAL_BUILD_FLAG: "--local-build-path {{.HEDERA_SERVICES_ROOT}}/hedera-node/data"

--- a/examples/performance-tuning/solo-gke/Taskfile.yml
+++ b/examples/performance-tuning/solo-gke/Taskfile.yml
@@ -16,7 +16,7 @@ env:
   SOLO_HOME: "{{.solo_home_override_dir}}"
   LOG4J2_FLAG: "--log4j2-xml {{.USER_WORKING_DIR}}/log4j2.xml"
   APPLICATION_PROPERTIES_FLAG: "--application-properties {{.USER_WORKING_DIR}}/application.properties"
-  HEDERA_SERVICES_ROOT: "/home/gke1/workspaces/10nodes/hedera-services"
+  HEDERA_SERVICES_ROOT: "/home/gke1/workspaces/10nodes/hiero-consensus-node"
   LOCAL_BUILD_FLAG: "--local-build-path {{.HEDERA_SERVICES_ROOT}}/hedera-node/data"
   GENESIS_THROTTLES_FLAG: "--genesis-throttles-file {{.USER_WORKING_DIR}}/throttles.json"
   # SOLO_CHARTS_DIR_FLAG: "--chart-directory /Users/user/source/solo-charts/charts"

--- a/examples/performance-tuning/solo-perf-test/Taskfile.yml
+++ b/examples/performance-tuning/solo-perf-test/Taskfile.yml
@@ -14,5 +14,5 @@ env:
   SOLO_HOME: "/Users/user/.solo-perf-test"
   # LOG4J2_FLAG: "--log4j2-xml {{.USER_WORKING_DIR}}/log4j2.xml"
   # APPLICATION_PROPERTIES_FLAG: "--application-properties {{.USER_WORKING_DIR}}/application.properties"
-  # HEDERA_SERVICES_ROOT: "/Users/user/source/hedera-services"
+  # HEDERA_SERVICES_ROOT: "/Users/user/source/hiero-consensus-node"
   # LOCAL_BUILD_FLAG: "--local-build-path {{.HEDERA_SERVICES_ROOT}}/hedera-node/data"

--- a/examples/solo-gke-test/Taskfile.yml
+++ b/examples/solo-gke-test/Taskfile.yml
@@ -19,7 +19,7 @@ env:
   # SOLO_HOME: "{{.solo_home_override_dir}}"
   LOG4J2_FLAG: "--log4j2-xml {{.USER_WORKING_DIR}}/log4j2.xml"
   APPLICATION_PROPERTIES_FLAG: "--application-properties {{.USER_WORKING_DIR}}/application.properties"
-  HEDERA_SERVICES_ROOT: "/Users/user/source/hedera-services"
+  HEDERA_SERVICES_ROOT: "/Users/user/source/hiero-consensus-node"
   #  LOCAL_BUILD_FLAG: "--local-build-path {{.HEDERA_SERVICES_ROOT}}/hedera-node/data"
   GENESIS_THROTTLES_FLAG: "--genesis-throttles-file {{.USER_WORKING_DIR}}/throttles.json"
 #  SOLO_CHARTS_DIR_FLAG: "--chart-directory /Users/user/source/solo-charts/charts"

--- a/resources/mirror-node-values.yaml
+++ b/resources/mirror-node-values.yaml
@@ -11,9 +11,11 @@ rosetta: # not needed for default use case
   enabled: false
 redis:
   enabled: true
-#global:
+global:
+  image:
+    # TODO: global.image.tag can be deleted after we get a v0.126.0-rc1 or later release for mirror node
+    tag: main # a bit dangerous, but image tag main-dcfa7ed1960daf9c4d42a6fbdff60cdd20adbe05 will only last for 7 days
 #  namespaceOverride: "{{ tpl (.Values.global.namespaceOverride | toString) }}"
-
 # importer is a component of the hedera mirror node
 # config for subchart hedera-mirror/importer
 importer:

--- a/resources/templates/application.properties
+++ b/resources/templates/application.properties
@@ -20,3 +20,5 @@ scheduling.longTermEnabled=false
 addressBook.useRosterLifecycle=true
 # TODO: we can remove this after we no longer need less than v0.59.x
 networkAdmin.exportCandidateRoster=true
+# for v0.59+, write the network.json file when you freeze the network
+networkAdmin.diskNetworkExport=ONLY_FREEZE_BLOCK

--- a/resources/templates/application.properties
+++ b/resources/templates/application.properties
@@ -16,8 +16,6 @@ staking.periodMins=1
 nodes.updateAccountIdAllowed=true
 blockStream.streamMode=RECORDS
 scheduling.longTermEnabled=false
-# TODO: uncomment this when we are ready to use genesis-network.json
-addressBook.useRosterLifecycle=true
 # TODO: we can remove this after we no longer need less than v0.59.x
 networkAdmin.exportCandidateRoster=true
 # for v0.59+, write the network.json file when you freeze the network

--- a/resources/templates/application.properties
+++ b/resources/templates/application.properties
@@ -17,6 +17,6 @@ nodes.updateAccountIdAllowed=true
 blockStream.streamMode=RECORDS
 scheduling.longTermEnabled=false
 # TODO: uncomment this when we are ready to use genesis-network.json
-#addressBook.useRosterLifecycle=true
+addressBook.useRosterLifecycle=true
 # TODO: we can remove this after we no longer need less than v0.59.x
 networkAdmin.exportCandidateRoster=true

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -826,10 +826,6 @@ export class NodeCommandTasks {
         .readByRef(containerRef)
         .copyFrom(`${constants.HEDERA_HAPI_PATH}/data/upgrade/current/config.txt`, config.stagingDir);
 
-      // set the config.txt to empty so that the nodes will pull from state, this is needed for v0.58.3+
-      // const configTxtPath: string = path.join(config.stagingDir, 'config.txt');
-      // fs.writeFileSync(configTxtPath, '');
-
       // if directory data/upgrade/current/data/keys does not exist, then use data/upgrade/current
       let keyDir = `${constants.HEDERA_HAPI_PATH}/data/upgrade/current/data/keys`;
       if (!(await k8.containers().readByRef(containerRef).hasDir(keyDir))) {

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -268,14 +268,25 @@ export class NodeCommandTasks {
         title: `Copy local build to Node: ${chalk.yellow(nodeAlias)} from ${localDataLibBuildPath}`,
         task: async () => {
           const shellRunner = new ShellRunner();
-          const retrievedReleaseTag = await shellRunner.run(
-            `git -C ${localDataLibBuildPath} describe --tags --abbrev=0`,
-          );
-          const expectedReleaseTag = releaseTag ? releaseTag : HEDERA_PLATFORM_VERSION;
-          if (retrievedReleaseTag.join('\n') !== expectedReleaseTag) {
-            this.logger.showUser(
-              chalk.cyan(
-                `Checkout version ${retrievedReleaseTag} does not match the release version ${expectedReleaseTag}`,
+          try {
+            const retrievedReleaseTag = await shellRunner.run(
+              `git -C ${localDataLibBuildPath} describe --tags --abbrev=0`,
+            );
+            const expectedReleaseTag = releaseTag ? releaseTag : HEDERA_PLATFORM_VERSION;
+            if (retrievedReleaseTag.join('\n') !== expectedReleaseTag) {
+              this.logger.showUser(
+                chalk.cyan(
+                  `Checkout version ${retrievedReleaseTag} does not match the release version ${expectedReleaseTag}`,
+                ),
+              );
+            }
+          } catch {
+            // if we can't find the release tag in the local build path directory, we will skip the check and continue
+            self.logger.warn('Could not find release tag in local build path directory');
+            self.logger.showUser(
+              chalk.yellowBright(
+                'The release tag could not be verified, please ensure that the release tag passed on the command line ' +
+                  'matches the release tag of the code in the local build path directory',
               ),
             );
           }

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -826,6 +826,10 @@ export class NodeCommandTasks {
         .readByRef(containerRef)
         .copyFrom(`${constants.HEDERA_HAPI_PATH}/data/upgrade/current/config.txt`, config.stagingDir);
 
+      // set the config.txt to empty so that the nodes will pull from state, this is needed for v0.58.3+
+      // const configTxtPath: string = path.join(config.stagingDir, 'config.txt');
+      // fs.writeFileSync(configTxtPath, '');
+
       // if directory data/upgrade/current/data/keys does not exist, then use data/upgrade/current
       let keyDir = `${constants.HEDERA_HAPI_PATH}/data/upgrade/current/data/keys`;
       if (!(await k8.containers().readByRef(containerRef).hasDir(keyDir))) {
@@ -1553,6 +1557,7 @@ export class NodeCommandTasks {
     });
   }
 
+  // this is only used by `node delete`
   refreshNodeList() {
     return new Task('Refresh node alias list', (ctx: any, task: ListrTaskWrapper<any, any, any>) => {
       ctx.config.allNodeAliases = ctx.config.existingNodeAliases.filter(

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -1090,6 +1090,7 @@ export class NodeCommandTasks {
         );
       }
 
+      // TODO: during `node add` ctx.config.nodeAliases is empty, since ctx.config.nodeAliasesUnparsed is empty
       await this.generateNodeOverridesJson(ctx.config.namespace, ctx.config.nodeAliases, ctx.config.stagingDir);
 
       const consensusNodes = ctx.config.consensusNodes;
@@ -1123,8 +1124,8 @@ export class NodeCommandTasks {
 
     const nodeOverridesModel = new NodeOverridesModel(nodeAliases, networkNodeServiceMap);
 
-    const nodeOverridesJson = path.join(stagingDir, constants.NODE_OVERRIDE_FILE);
-    fs.writeFileSync(nodeOverridesJson, nodeOverridesModel.toYAML());
+    const nodeOverridesYaml = path.join(stagingDir, constants.NODE_OVERRIDE_FILE);
+    fs.writeFileSync(nodeOverridesYaml, nodeOverridesModel.toYAML());
   }
 
   /**

--- a/src/core/platform_installer.ts
+++ b/src/core/platform_installer.ts
@@ -326,8 +326,9 @@ export class PlatformInstaller {
       await this.copyFiles(podRef, genesisNetworkJson, `${constants.HEDERA_HAPI_PATH}/data/config`, undefined, context);
     }
 
-    const nodeOverridesYaml = [path.join(stagingDir, constants.NODE_OVERRIDE_FILE)];
-    await this.copyFiles(podRef, nodeOverridesYaml, `${constants.HEDERA_HAPI_PATH}/data/config`, undefined, context);
+    // TODO: temporarily disable this until we add logic to only set this when the user provides the node override gossip endpoints for each node they want to override
+    // const nodeOverridesYaml = [path.join(stagingDir, constants.NODE_OVERRIDE_FILE)];
+    // await this.copyFiles(podRef, nodeOverridesYaml, `${constants.HEDERA_HAPI_PATH}/data/config`, undefined, context);
   }
 
   /**

--- a/src/core/profile_manager.ts
+++ b/src/core/profile_manager.ts
@@ -348,13 +348,13 @@ export class ProfileManager {
     await writeFile(applicationPropertiesPath, lines.join('\n'));
   }
 
-  public async prepareValuesForNodeAdd(configTxtPath: string, applicationPropertiesPath: string) {
+  public async prepareValuesForNodeTransaction(configTxtPath: string, applicationPropertiesPath: string) {
     const yamlRoot = {};
     this._setFileContentsAsValue('hedera.configMaps.configTxt', configTxtPath, yamlRoot);
     await this.bumpHederaConfigVersion(applicationPropertiesPath);
     this._setFileContentsAsValue('hedera.configMaps.applicationProperties', applicationPropertiesPath, yamlRoot);
 
-    const cachedValuesFile = path.join(this.cacheDir, 'solo-node-add.yaml');
+    const cachedValuesFile = path.join(this.cacheDir, 'solo-node-transaction.yaml');
     return this.writeToYaml(cachedValuesFile, yamlRoot);
   }
 

--- a/src/core/templates.ts
+++ b/src/core/templates.ts
@@ -257,7 +257,6 @@ export class Templates {
    * @param dnsBaseDomain - the base domain of the cluster
    * @param dnsConsensusNodePattern - the pattern to use for the consensus node
    */
-  // TODO @Lenin, needs testing
   static renderConsensusNodeFullyQualifiedDomainName(
     nodeAlias: string,
     nodeId: number,

--- a/test/e2e/commands/account.test.ts
+++ b/test/e2e/commands/account.test.ts
@@ -19,7 +19,7 @@ import {
 } from '@hashgraph/sdk';
 import * as constants from '../../../src/core/constants.js';
 import * as version from '../../../version.js';
-import {e2eTestSuite, HEDERA_PLATFORM_VERSION_TAG, TEST_CLUSTER, getTestLogger} from '../../test_util.js';
+import {e2eTestSuite, HEDERA_PLATFORM_VERSION_TAG, getTestLogger, getTestCluster} from '../../test_util.js';
 import {AccountCommand} from '../../../src/commands/account.js';
 import {Flags as flags} from '../../../src/commands/flags.js';
 import {Duration} from '../../../src/core/time/duration.js';
@@ -50,7 +50,7 @@ argv.setArg(flags.releaseTag, HEDERA_PLATFORM_VERSION_TAG);
 argv.setArg(flags.nodeAliasesUnparsed, 'node1,node2');
 argv.setArg(flags.generateGossipKeys, true);
 argv.setArg(flags.generateTlsKeys, true);
-argv.setArg(flags.clusterRef, TEST_CLUSTER);
+argv.setArg(flags.clusterRef, getTestCluster());
 argv.setArg(flags.soloChartVersion, version.SOLO_CHART_VERSION);
 argv.setArg(flags.loadBalancerEnabled, true);
 argv.setArg(flags.chartDirectory, process.env.SOLO_CHARTS_DIR ?? undefined);

--- a/test/e2e/commands/cluster.test.ts
+++ b/test/e2e/commands/cluster.test.ts
@@ -29,7 +29,8 @@ describe('ClusterCommand', () => {
     logging.SoloLogger.prototype.showJSON.restore();
   });
 
-  const TEST_CONTEXT = TEST_CLUSTER;
+  const TEST_CONTEXT = getTestCluster();
+  const TEST_CLUSTER = getTestCluster();
   const testName = 'cluster-cmd-e2e';
   const namespace = NamespaceName.of(testName);
   const argv = Argv.getDefaultArgv(namespace);

--- a/test/e2e/commands/cluster.test.ts
+++ b/test/e2e/commands/cluster.test.ts
@@ -6,7 +6,7 @@ import {it, describe, after, before, afterEach, beforeEach} from 'mocha';
 import {expect} from 'chai';
 
 import {Flags as flags} from '../../../src/commands/flags.js';
-import {bootstrapTestVariables, HEDERA_PLATFORM_VERSION_TAG, TEST_CLUSTER} from '../../test_util.js';
+import {bootstrapTestVariables, getTestCluster, HEDERA_PLATFORM_VERSION_TAG} from '../../test_util.js';
 import * as constants from '../../../src/core/constants.js';
 import * as logging from '../../../src/core/logging.js';
 import {sleep} from '../../../src/core/helpers.js';
@@ -39,7 +39,7 @@ describe('ClusterCommand', () => {
   argv.setArg(flags.nodeAliasesUnparsed, 'node1');
   argv.setArg(flags.generateGossipKeys, true);
   argv.setArg(flags.generateTlsKeys, true);
-  argv.setArg(flags.clusterRef, TEST_CLUSTER);
+  argv.setArg(flags.clusterRef, getTestCluster());
   argv.setArg(flags.soloChartVersion, version.SOLO_CHART_VERSION);
   argv.setArg(flags.force, true);
   argv.setArg(flags.chartDirectory, process.env.SOLO_CHARTS_DIR ?? undefined);

--- a/test/e2e/commands/dual_cluster_full.test.ts
+++ b/test/e2e/commands/dual_cluster_full.test.ts
@@ -4,7 +4,7 @@
 import {describe} from 'mocha';
 
 import {Flags} from '../../../src/commands/flags.js';
-import {getTestCacheDir, TEST_CLUSTER} from '../../test_util.js';
+import {getTestCacheDir, getTestCluster} from '../../test_util.js';
 import {getSoloVersion} from '../../../src/core/helpers.js';
 import * as constants from '../../../src/core/constants.js';
 import {main} from '../../../src/index.js';
@@ -30,7 +30,7 @@ describe('Dual Cluster Full E2E Test', async function dualClusterFullE2eTest(): 
   const namespace: NamespaceName = NamespaceName.of(testName);
   const deployment = `${testName}-deployment`;
   const testClusterRefs: ClusterRef[] = ['e2e-cluster-1', 'e2e-cluster-2'];
-  const testCluster = TEST_CLUSTER.includes('c1') ? TEST_CLUSTER : `${TEST_CLUSTER}-c1`;
+  const testCluster = getTestCluster().includes('c1') ? getTestCluster() : `${getTestCluster()}-c1`;
   const contexts: string[] = [`${testCluster}`, `${testCluster.replace('-c1', '-c2')}`];
   const nodeAliasesUnparsed = 'node1,node2';
   const nodeAliasesWithClusterRefsUnparsed = 'e2e-cluster-1=node1,e2e-cluster-2=node2';

--- a/test/e2e/commands/mirror_node.test.ts
+++ b/test/e2e/commands/mirror_node.test.ts
@@ -9,8 +9,8 @@ import {
   accountCreationShouldSucceed,
   balanceQueryShouldSucceed,
   e2eTestSuite,
+  getTestCluster,
   HEDERA_PLATFORM_VERSION_TAG,
-  TEST_CLUSTER,
 } from '../../test_util.js';
 import * as version from '../../../version.js';
 import {sleep} from '../../../src/core/helpers.js';
@@ -40,7 +40,7 @@ argv.setArg(flags.forcePortForward, true);
 argv.setArg(flags.nodeAliasesUnparsed, 'node1'); // use a single node to reduce resource during e2e tests
 argv.setArg(flags.generateGossipKeys, true);
 argv.setArg(flags.generateTlsKeys, true);
-argv.setArg(flags.clusterRef, TEST_CLUSTER);
+argv.setArg(flags.clusterRef, getTestCluster());
 argv.setArg(flags.soloChartVersion, version.SOLO_CHART_VERSION);
 argv.setArg(flags.force, true);
 argv.setArg(flags.relayReleaseTag, flags.relayReleaseTag.definition.defaultValue);

--- a/test/e2e/commands/node_add_local.test.ts
+++ b/test/e2e/commands/node_add_local.test.ts
@@ -8,6 +8,6 @@ import {Duration} from '../../../src/core/time/duration.js';
 
 describe('Node add with hedera local build', () => {
   const localBuildPath =
-    'node1=../hedera-services/hedera-node/data/,../hedera-services/hedera-node/data,node3=../hedera-services/hedera-node/data';
+    'node1=../hiero-consensus-node/hedera-node/data/,../hiero-consensus-node/hedera-node/data,node3=../hiero-consensus-node/hedera-node/data';
   testNodeAdd(localBuildPath);
 }).timeout(Duration.ofMinutes(3).toMillis());

--- a/test/e2e/commands/node_local_hedera.test.ts
+++ b/test/e2e/commands/node_local_hedera.test.ts
@@ -4,7 +4,7 @@
 import {describe} from 'mocha';
 
 import {Flags as flags} from '../../../src/commands/flags.js';
-import {e2eTestSuite, TEST_CLUSTER} from '../../test_util.js';
+import {e2eTestSuite, getTestCluster} from '../../test_util.js';
 import {sleep} from '../../../src/core/helpers.js';
 import {SOLO_LOGS_DIR} from '../../../src/core/constants.js';
 import {type K8Factory} from '../../../src/core/kube/k8_factory.js';
@@ -15,7 +15,7 @@ import {Duration} from '../../../src/core/time/duration.js';
 import {type NodeCommand} from '../../../src/commands/node/index.js';
 import {type AccountCommand} from '../../../src/commands/account.js';
 import {type AccountManager} from '../../../src/core/account_manager.js';
-import {LOCAL_HEDERA_PLATFORM_VERSION} from '../../../version.js';
+import {TEST_LOCAL_HEDERA_PLATFORM_VERSION} from '../../../version_test.js';
 import {NamespaceName} from '../../../src/core/kube/resources/namespace/namespace_name.js';
 import {type NetworkNodes} from '../../../src/core/network_nodes.js';
 import {container} from 'tsyringe-neo';
@@ -29,15 +29,18 @@ argv.setArg(flags.forcePortForward, true);
 argv.setArg(flags.nodeAliasesUnparsed, 'node1,node2');
 argv.setArg(flags.generateGossipKeys, true);
 argv.setArg(flags.generateTlsKeys, true);
-argv.setArg(flags.clusterRef, TEST_CLUSTER);
+argv.setArg(flags.clusterRef, getTestCluster());
 argv.setArg(flags.chartDirectory, process.env.SOLO_CHARTS_DIR ?? undefined);
 argv.setArg(flags.quiet, true);
 
 let k8Factory: K8Factory;
 console.log('Starting local build for Hedera app');
-argv.setArg(flags.localBuildPath, 'node1=../hedera-services/hedera-node/data/,../hedera-services/hedera-node/data');
+argv.setArg(
+  flags.localBuildPath,
+  'node1=../hiero-consensus-node/hedera-node/data/,../hiero-consensus-node/hedera-node/data',
+);
 argv.setArg(flags.namespace, namespace.name);
-argv.setArg(flags.releaseTag, LOCAL_HEDERA_PLATFORM_VERSION);
+argv.setArg(flags.releaseTag, TEST_LOCAL_HEDERA_PLATFORM_VERSION);
 
 e2eTestSuite(namespace.name, argv, {}, bootstrapResp => {
   describe('Node for hedera app should have started successfully', () => {

--- a/test/e2e/commands/node_local_ptt.test.ts
+++ b/test/e2e/commands/node_local_ptt.test.ts
@@ -4,10 +4,10 @@
 import {describe} from 'mocha';
 
 import {Flags as flags} from '../../../src/commands/flags.js';
-import {e2eTestSuite, TEST_CLUSTER} from '../../test_util.js';
+import {e2eTestSuite, getTestCluster} from '../../test_util.js';
 import {Duration} from '../../../src/core/time/duration.js';
 import {type K8Factory} from '../../../src/core/kube/k8_factory.js';
-import {LOCAL_HEDERA_PLATFORM_VERSION} from '../../../version.js';
+import {TEST_LOCAL_HEDERA_PLATFORM_VERSION} from '../../../version_test.js';
 import {NamespaceName} from '../../../src/core/kube/resources/namespace/namespace_name.js';
 import {type NetworkNodes} from '../../../src/core/network_nodes.js';
 import {container} from 'tsyringe-neo';
@@ -19,23 +19,23 @@ const argv = Argv.getDefaultArgv(namespace);
 argv.setArg(flags.nodeAliasesUnparsed, 'node1,node2,node3');
 argv.setArg(flags.generateGossipKeys, true);
 argv.setArg(flags.generateTlsKeys, true);
-argv.setArg(flags.clusterRef, TEST_CLUSTER);
+argv.setArg(flags.clusterRef, getTestCluster());
 argv.setArg(flags.chartDirectory, process.env.SOLO_CHARTS_DIR ?? undefined);
 argv.setArg(flags.quiet, true);
 
 console.log('Starting local build for Platform app');
 argv.setArg(
   flags.localBuildPath,
-  '../hedera-services/platform-sdk/sdk/data,node1=../hedera-services/platform-sdk/sdk/data,node2=../hedera-services/platform-sdk/sdk/data',
+  '../hiero-consensus-node/platform-sdk/sdk/data,node1=../hiero-consensus-node/platform-sdk/sdk/data,node2=../hiero-consensus-node/platform-sdk/sdk/data',
 );
 argv.setArg(
   flags.appConfig,
-  '../hedera-services/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/resources/FCMFCQ-Basic-2.5k-5m.json',
+  '../hiero-consensus-node/platform-sdk/platform-apps/tests/PlatformTestingTool/src/main/resources/FCMFCQ-Basic-2.5k-5m.json',
 );
 
 argv.setArg(flags.app, 'PlatformTestingTool.jar');
 argv.setArg(flags.namespace, namespace.name);
-argv.setArg(flags.releaseTag, LOCAL_HEDERA_PLATFORM_VERSION);
+argv.setArg(flags.releaseTag, TEST_LOCAL_HEDERA_PLATFORM_VERSION);
 
 e2eTestSuite(namespace.name, argv, {}, bootstrapResp => {
   describe('Node for platform app should start successfully', () => {

--- a/test/e2e/commands/node_update.test.ts
+++ b/test/e2e/commands/node_update.test.ts
@@ -142,20 +142,14 @@ e2eTestSuite(namespace.name, argv, {}, bootstrapResp => {
       }
     }).timeout(defaultTimeout);
 
-    it('config.txt should be changed with new account id', async () => {
+    it('the consensus nodes accountId should be the newAccountId', async () => {
       // read config.txt file from first node, read config.txt line by line, it should not contain value of newAccountId
-      const pods: V1Pod[] = await k8Factory.default().pods().list(namespace, ['solo.hedera.com/type=network-node']);
-      const podName: PodName = PodName.of(pods[0].metadata.name);
-      const tmpDir = getTmpDir();
-      await k8Factory
+      const pods: V1Pod[] = await k8Factory
         .default()
-        .containers()
-        .readByRef(ContainerRef.of(PodRef.of(namespace, podName), ROOT_CONTAINER))
-        .copyFrom(`${HEDERA_HAPI_PATH}/config.txt`, tmpDir);
-      const configTxt = fs.readFileSync(`${tmpDir}/config.txt`, 'utf8');
-      console.log('config.txt:', configTxt);
-
-      expect(configTxt).to.contain(newAccountId);
+        .pods()
+        .list(namespace, [`solo.hedera.com/node-name=${updateNodeId}`]);
+      const accountId: string = pods[0].metadata.labels['solo.hedera.com/account-id'];
+      expect(accountId).to.equal(newAccountId);
     }).timeout(Duration.ofMinutes(10).toMillis());
   });
 });

--- a/test/e2e/commands/relay.test.ts
+++ b/test/e2e/commands/relay.test.ts
@@ -6,7 +6,7 @@ import {expect} from 'chai';
 import each from 'mocha-each';
 
 import {Flags as flags} from '../../../src/commands/flags.js';
-import {e2eTestSuite, HEDERA_PLATFORM_VERSION_TAG, TEST_CLUSTER} from '../../test_util.js';
+import {e2eTestSuite, getTestCluster, HEDERA_PLATFORM_VERSION_TAG} from '../../test_util.js';
 import * as version from '../../../version.js';
 import {sleep} from '../../../src/core/helpers.js';
 import {RelayCommand} from '../../../src/commands/relay.js';
@@ -25,7 +25,7 @@ argv.setArg(flags.releaseTag, HEDERA_PLATFORM_VERSION_TAG);
 argv.setArg(flags.nodeAliasesUnparsed, 'node1,node2');
 argv.setArg(flags.generateGossipKeys, true);
 argv.setArg(flags.generateTlsKeys, true);
-argv.setArg(flags.clusterRef, TEST_CLUSTER);
+argv.setArg(flags.clusterRef, getTestCluster());
 argv.setArg(flags.soloChartVersion, version.SOLO_CHART_VERSION);
 argv.setArg(flags.force, true);
 argv.setArg(flags.relayReleaseTag, flags.relayReleaseTag.definition.defaultValue);

--- a/test/e2e/commands/separate_node_update.test.ts
+++ b/test/e2e/commands/separate_node_update.test.ts
@@ -152,18 +152,14 @@ e2eTestSuite(namespace.name, argv, {}, bootstrapResp => {
       }
     }).timeout(defaultTimeout);
 
-    it('config.txt should be changed with new account id', async () => {
+    it('the consensus nodes accountId should be the newAccountId', async () => {
       // read config.txt file from first node, read config.txt line by line, it should not contain value of newAccountId
-      const pods: V1Pod[] = await k8Factory.default().pods().list(namespace, ['solo.hedera.com/type=network-node']);
-      const podName: PodName = PodName.of(pods[0].metadata.name);
-      const podRef: PodRef = PodRef.of(namespace, podName);
-      const containerRef: ContainerRef = ContainerRef.of(podRef, ROOT_CONTAINER);
-      const tmpDir: string = getTmpDir();
-      await k8Factory.default().containers().readByRef(containerRef).copyFrom(`${HEDERA_HAPI_PATH}/config.txt`, tmpDir);
-      const configTxt: string = fs.readFileSync(`${tmpDir}/config.txt`, 'utf8');
-      console.log('config.txt:', configTxt);
-
-      expect(configTxt).to.contain(newAccountId);
+      const pods: V1Pod[] = await k8Factory
+        .default()
+        .pods()
+        .list(namespace, [`solo.hedera.com/node-name=${updateNodeId}`]);
+      const accountId: string = pods[0].metadata.labels['solo.hedera.com/account-id'];
+      expect(accountId).to.equal(newAccountId);
     }).timeout(Duration.ofMinutes(10).toMillis());
   });
 });

--- a/test/e2e/e2e_node_util.ts
+++ b/test/e2e/e2e_node_util.ts
@@ -9,8 +9,8 @@ import {
   accountCreationShouldSucceed,
   balanceQueryShouldSucceed,
   e2eTestSuite,
+  getTestCluster,
   HEDERA_PLATFORM_VERSION_TAG,
-  TEST_CLUSTER,
 } from '../test_util.js';
 import {sleep} from '../../src/core/helpers.js';
 import * as NodeCommandConfigs from '../../src/commands/node/configs.js';
@@ -38,7 +38,7 @@ export function e2eNodeKeyRefreshTest(testName: string, mode: string, releaseTag
   argv.setArg(flags.nodeAliasesUnparsed, 'node1,node2,node3');
   argv.setArg(flags.generateGossipKeys, true);
   argv.setArg(flags.generateTlsKeys, true);
-  argv.setArg(flags.clusterRef, TEST_CLUSTER);
+  argv.setArg(flags.clusterRef, getTestCluster());
   argv.setArg(flags.devMode, true);
   argv.setArg(flags.chartDirectory, process.env.SOLO_CHARTS_DIR ?? undefined);
   argv.setArg(flags.quiet, true);

--- a/test/e2e/integration/core/account_manager.test.ts
+++ b/test/e2e/integration/core/account_manager.test.ts
@@ -5,7 +5,7 @@ import {it, describe, after} from 'mocha';
 import {expect} from 'chai';
 
 import {Flags as flags} from '../../../../src/commands/flags.js';
-import {e2eTestSuite, TEST_CLUSTER} from '../../../test_util.js';
+import {e2eTestSuite, getTestCluster} from '../../../test_util.js';
 import * as version from '../../../../version.js';
 import {PodName} from '../../../../src/core/kube/resources/pod/pod_name.js';
 import {Duration} from '../../../../src/core/time/duration.js';
@@ -20,7 +20,7 @@ const argv = Argv.getDefaultArgv(namespace);
 argv.setArg(flags.namespace, namespace.name);
 argv.setArg(flags.deployment, `${namespace.name}-deployment`);
 argv.setArg(flags.nodeAliasesUnparsed, 'node1');
-argv.setArg(flags.clusterRef, TEST_CLUSTER);
+argv.setArg(flags.clusterRef, getTestCluster());
 argv.setArg(flags.soloChartVersion, version.SOLO_CHART_VERSION);
 argv.setArg(flags.generateGossipKeys, true);
 argv.setArg(flags.generateTlsKeys, true);

--- a/test/e2e/integration/core/platform_installer_e2e.test.ts
+++ b/test/e2e/integration/core/platform_installer_e2e.test.ts
@@ -7,7 +7,7 @@ import {expect} from 'chai';
 import * as constants from '../../../../src/core/constants.js';
 import * as fs from 'fs';
 
-import {e2eTestSuite, getTestCacheDir, TEST_CLUSTER, getTestLogger} from '../../../test_util.js';
+import {e2eTestSuite, getTestCacheDir, getTestCluster, getTestLogger} from '../../../test_util.js';
 import {Flags as flags} from '../../../../src/commands/flags.js';
 import * as version from '../../../../version.js';
 import {Duration} from '../../../../src/core/time/duration.js';
@@ -28,7 +28,7 @@ const testCacheDir = getTestCacheDir();
 argv.setArg(flags.cacheDir, testCacheDir);
 argv.setArg(flags.namespace, namespace.name);
 argv.setArg(flags.nodeAliasesUnparsed, 'node1');
-argv.setArg(flags.clusterRef, TEST_CLUSTER);
+argv.setArg(flags.clusterRef, getTestCluster());
 argv.setArg(flags.soloChartVersion, version.SOLO_CHART_VERSION);
 argv.setArg(flags.generateGossipKeys, true);
 argv.setArg(flags.generateTlsKeys, true);

--- a/test/e2e/integration/core/remote_config_manager.test.ts
+++ b/test/e2e/integration/core/remote_config_manager.test.ts
@@ -7,7 +7,7 @@ import {expect} from 'chai';
 import * as fs from 'fs';
 import {type LocalConfig} from '../../../../src/core/config/local_config.js';
 import {type RemoteConfigManager} from '../../../../src/core/config/remote/remote_config_manager.js';
-import {e2eTestSuite, getTestCacheDir, TEST_CLUSTER} from '../../../test_util.js';
+import {e2eTestSuite, getTestCacheDir, getTestCluster} from '../../../test_util.js';
 import {Flags as flags} from '../../../../src/commands/flags.js';
 import * as version from '../../../../version.js';
 
@@ -30,7 +30,7 @@ argv.setArg(flags.namespace, namespace.name);
 const deploymentName = `${namespace.name}-deployment`;
 argv.setArg(flags.deployment, `${namespace.name}-deployment`);
 argv.setArg(flags.nodeAliasesUnparsed, 'node1');
-argv.setArg(flags.clusterRef, TEST_CLUSTER);
+argv.setArg(flags.clusterRef, getTestCluster());
 argv.setArg(flags.soloChartVersion, version.SOLO_CHART_VERSION);
 argv.setArg(flags.generateGossipKeys, true);
 argv.setArg(flags.generateTlsKeys, true);

--- a/test/helpers/argv_wrapper.ts
+++ b/test/helpers/argv_wrapper.ts
@@ -2,7 +2,7 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import {Flags as flags} from '../../src/commands/flags.js';
-import {getTestCacheDir, TEST_CLUSTER} from '../test_util.js';
+import {getTestCacheDir, getTestCluster} from '../test_util.js';
 import {K8Client} from '../../src/core/kube/k8_client/k8_client.js';
 import {type NamespaceName} from '../../src/core/kube/resources/namespace/namespace_name.js';
 import {type CommandFlag} from '../../src/types/flag_types.js';
@@ -57,8 +57,8 @@ export class Argv {
     argv.setArg(flags.cacheDir, cacheDir);
     argv.deployment = currentDeployment;
     argv.setArg(flags.deployment, currentDeployment);
-    argv.setArg(flags.clusterRef, TEST_CLUSTER);
-    argv.setArg(flags.deploymentClusters, [TEST_CLUSTER]);
+    argv.setArg(flags.clusterRef, getTestCluster());
+    argv.setArg(flags.deploymentClusters, [getTestCluster()]);
     argv.setArg(flags.context, new K8Client(undefined).contexts().readCurrent());
     return argv;
   }

--- a/test/test_add.ts
+++ b/test/test_add.ts
@@ -17,7 +17,7 @@ import * as NodeCommandConfigs from '../src/commands/node/configs.js';
 import {type NodeAlias} from '../src/types/aliases.js';
 import {type NetworkNodeServices} from '../src/core/network_node_services.js';
 import {Duration} from '../src/core/time/duration.js';
-import {LOCAL_HEDERA_PLATFORM_VERSION} from '../version.js';
+import {TEST_LOCAL_HEDERA_PLATFORM_VERSION} from '../version_test.js';
 import {NamespaceName} from '../src/core/kube/resources/namespace/namespace_name.js';
 import {type NetworkNodes} from '../src/core/network_nodes.js';
 import {container} from 'tsyringe-neo';
@@ -43,7 +43,7 @@ export function testNodeAdd(
   argv.setArg(flags.chartDirectory, process.env.SOLO_CHARTS_DIR ?? undefined);
   argv.setArg(
     flags.releaseTag,
-    !localBuildPath || localBuildPath === '' ? HEDERA_PLATFORM_VERSION_TAG : LOCAL_HEDERA_PLATFORM_VERSION,
+    !localBuildPath || localBuildPath === '' ? HEDERA_PLATFORM_VERSION_TAG : TEST_LOCAL_HEDERA_PLATFORM_VERSION,
   );
   argv.setArg(flags.namespace, namespace.name);
   argv.setArg(flags.force, true);

--- a/test/test_util.ts
+++ b/test/test_util.ts
@@ -54,13 +54,20 @@ import {InjectTokens} from '../src/core/dependency_injection/inject_tokens.js';
 import {DeploymentCommand} from '../src/commands/deployment.js';
 import {K8Client} from '../src/core/kube/k8_client/k8_client.js';
 import {Argv} from './helpers/argv_wrapper.js';
-import {type DeploymentName, type NamespaceNameAsString} from '../src/core/config/remote/types.js';
+import {type ClusterRef, type DeploymentName, type NamespaceNameAsString} from '../src/core/config/remote/types.js';
 
-export const SOLO_TEST_CLUSTER = process.env.SOLO_TEST_CLUSTER || 'solo-e2e';
-export const TEST_CLUSTER = SOLO_TEST_CLUSTER.startsWith('kind-') ? SOLO_TEST_CLUSTER : `kind-${SOLO_TEST_CLUSTER}`;
 export const HEDERA_PLATFORM_VERSION_TAG = HEDERA_PLATFORM_VERSION;
 
 export const BASE_TEST_DIR = path.join('test', 'data', 'tmp');
+
+export function getTestCluster(): ClusterRef {
+  const soloTestCluster: ClusterRef =
+    process.env.SOLO_TEST_CLUSTER ||
+    container.resolve<K8Factory>(InjectTokens.K8Factory).default().clusters().readCurrent() ||
+    'solo-e2e';
+
+  return soloTestCluster.startsWith('kind-') ? soloTestCluster : `kind-${soloTestCluster}`;
+}
 
 export function getTestLogger() {
   return container.resolve<SoloLogger>(InjectTokens.SoloLogger);

--- a/test/unit/commands/cluster.test.ts
+++ b/test/unit/commands/cluster.test.ts
@@ -6,7 +6,7 @@ import {beforeEach, describe, it} from 'mocha';
 import {expect} from 'chai';
 
 import {ClusterCommand} from '../../../src/commands/cluster/index.js';
-import {getTestCacheDir, HEDERA_PLATFORM_VERSION_TAG, TEST_CLUSTER, testLocalConfigData} from '../../test_util.js';
+import {getTestCacheDir, getTestCluster, HEDERA_PLATFORM_VERSION_TAG, testLocalConfigData} from '../../test_util.js';
 import {Flags as flags} from '../../../src/commands/flags.js';
 import * as version from '../../../version.js';
 import * as constants from '../../../src/core/constants.js';
@@ -71,7 +71,7 @@ argv.setArg(flags.releaseTag, HEDERA_PLATFORM_VERSION_TAG);
 argv.setArg(flags.nodeAliasesUnparsed, 'node1');
 argv.setArg(flags.generateGossipKeys, true);
 argv.setArg(flags.generateTlsKeys, true);
-argv.setArg(flags.clusterRef, TEST_CLUSTER);
+argv.setArg(flags.clusterRef, getTestCluster());
 argv.setArg(flags.soloChartVersion, version.SOLO_CHART_VERSION);
 argv.setArg(flags.force, true);
 argv.setArg(flags.clusterSetupNamespace, constants.SOLO_SETUP_NAMESPACE.name);

--- a/test/unit/commands/network.test.ts
+++ b/test/unit/commands/network.test.ts
@@ -5,7 +5,7 @@ import sinon from 'sinon';
 import {beforeEach, describe, it} from 'mocha';
 import {expect} from 'chai';
 
-import {HEDERA_PLATFORM_VERSION_TAG, SOLO_TEST_CLUSTER, TEST_CLUSTER} from '../../test_util.js';
+import {getTestCluster, HEDERA_PLATFORM_VERSION_TAG} from '../../test_util.js';
 import {Flags as flags} from '../../../src/commands/flags.js';
 import * as version from '../../../version.js';
 import * as constants from '../../../src/core/constants.js';
@@ -44,7 +44,7 @@ argv.setArg(flags.nodeAliasesUnparsed, 'node1');
 argv.setArg(flags.deployment, 'deployment');
 argv.setArg(flags.generateGossipKeys, true);
 argv.setArg(flags.generateTlsKeys, true);
-argv.setArg(flags.clusterRef, TEST_CLUSTER);
+argv.setArg(flags.clusterRef, getTestCluster());
 argv.setArg(flags.soloChartVersion, version.SOLO_CHART_VERSION);
 argv.setArg(flags.force, true);
 argv.setArg(flags.clusterSetupNamespace, constants.SOLO_SETUP_NAMESPACE.name);
@@ -166,7 +166,7 @@ describe('NetworkCommand unit tests', () => {
 
         await networkCommand.deploy(argv.build());
 
-        expect(opts.chartManager.install.args[0][0].name).to.equal(SOLO_TEST_CLUSTER);
+        expect(opts.chartManager.install.args[0][0].name).to.equal('solo-e2e');
         expect(opts.chartManager.install.args[0][1]).to.equal(constants.SOLO_DEPLOYMENT_CHART);
         expect(opts.chartManager.install.args[0][2]).to.equal(
           constants.SOLO_TESTING_CHART_URL + '/' + constants.SOLO_DEPLOYMENT_CHART,
@@ -187,7 +187,7 @@ describe('NetworkCommand unit tests', () => {
         opts.remoteConfigManager.getClusterRefs = sinon.stub().returns({['solo-e2e']: 'context1'});
         const networkCommand = new NetworkCommand(opts);
         await networkCommand.deploy(argv.build());
-        expect(opts.chartManager.install.args[0][0].name).to.equal(SOLO_TEST_CLUSTER);
+        expect(opts.chartManager.install.args[0][0].name).to.equal('solo-e2e');
         expect(opts.chartManager.install.args[0][1]).to.equal(constants.SOLO_DEPLOYMENT_CHART);
         expect(opts.chartManager.install.args[0][2]).to.equal(
           path.join(ROOT_DIR, 'test-directory', constants.SOLO_DEPLOYMENT_CHART),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,6 +31,7 @@
   "include": [
     "src",
     "version.ts",
+    "version_test.ts",
     "solo.ts",
     "test"
   ],

--- a/version.ts
+++ b/version.ts
@@ -8,9 +8,8 @@
 
 export const HELM_VERSION = 'v3.14.2';
 export const SOLO_CHART_VERSION = '0.45.0';
-export const HEDERA_PLATFORM_VERSION = 'v0.58.10';
-export const LOCAL_HEDERA_PLATFORM_VERSION = 'v0.58.3';
-export const MIRROR_NODE_VERSION = 'v0.122';
-export const HEDERA_EXPLORER_VERSION = '24.12.0';
-export const HEDERA_JSON_RPC_RELAY_VERSION = 'v0.63.2';
+export const HEDERA_PLATFORM_VERSION = 'v0.59.2';
+export const MIRROR_NODE_VERSION = 'v0.124.1';
+export const HEDERA_EXPLORER_VERSION = '24.12.1';
+export const HEDERA_JSON_RPC_RELAY_VERSION = 'v0.66.0';
 export const INGRESS_CONTROLLER_VERSION = '0.14.5';

--- a/version_test.ts
+++ b/version_test.ts
@@ -1,0 +1,4 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+export const TEST_LOCAL_HEDERA_PLATFORM_VERSION = 'v0.58.10';

--- a/version_test.ts
+++ b/version_test.ts
@@ -1,4 +1,4 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-export const TEST_LOCAL_HEDERA_PLATFORM_VERSION = 'v0.58.10';
+export const TEST_LOCAL_HEDERA_PLATFORM_VERSION = 'v0.58.3';

--- a/version_test.ts
+++ b/version_test.ts
@@ -1,4 +1,4 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-export const TEST_LOCAL_HEDERA_PLATFORM_VERSION = 'v0.58.3';
+export const TEST_LOCAL_HEDERA_PLATFORM_VERSION = 'v0.58.10';


### PR DESCRIPTION
## Description

This pull request changes the following:

* update Hedera platform versions to v0.59.2
* upgraded to a custom v0.59 version of yahcli that has a fix for addressbook to include domain name
* moved yahcli due to its size into Git LFS which is now a required install if you need this yahcli.jar
* enabled `addressBook.useRosterLifecycle=true` in `application.properties` which enabled `genesis-network.json` usage
* enabled `networkAdmin.diskNetworkExport=ONLY_FREEZE_BLOCK` for v0.59+ to write a `network.json` file when we freeze the network
* temporarily changed mirror node rest pod check to use wait for pod running phase
* corrected some node update and node delete logic that was broke
* updated node delete and node update test assertion
* added `version_test.ts` to store `TEST_LOCAL_HEDERA_PLATFORM_VERSION`
* updated workflows to pull the Hedera Platform Version from the version.ts and version_test.ts to require less places to change
* removed Lenin from the CODEOWNERS file
* don't fail the copy local build to node if the version can't be found in the local Hedera build path, instead show the user a warning
* disabled the `node-overrides.yaml` until we can get some code to handle it properly

### Related Issues

* Closes #
