### PR TITLE
fix: remove v1lease usage outside of `kube` folder

### DIFF
--- a/src/commands/node/handlers.ts
+++ b/src/commands/node/handlers.ts
@@ -10,7 +10,7 @@ import {type LeaseManager} from '../../core/lease/lease_manager.js';
 import {type RemoteConfigManager} from '../../core/config/remote/remote_config_manager.js';
 import {SoloError} from '../../core/errors.js';
 import {ComponentType, ConsensusNodeStates} from '../../core/config/remote/enumerations.js';
-import {type Lease} from '../../core/lease/lease.js';
+import {type LeaseService} from '../../core/lease/lease_service.js';
 import {type NodeCommandTasks} from './tasks.js';
 import {NodeSubcommandType} from '../../core/enumerations.js';
 import {NodeHelper} from './helper.js';
@@ -61,7 +61,7 @@ export class NodeCommandHandlers extends CommandHandler {
 
   /** ******** Task Lists **********/
 
-  deletePrepareTaskList(argv: any, lease: Lease) {
+  deletePrepareTaskList(argv: any, lease: LeaseService) {
     return [
       this.tasks.initialize(argv, this.configs.deleteConfigBuilder.bind(this.configs), lease),
       this.validateSingleNodeState({excludedStates: []}),
@@ -104,7 +104,7 @@ export class NodeCommandHandlers extends CommandHandler {
     ];
   }
 
-  addPrepareTasks(argv: any, lease: Lease) {
+  addPrepareTasks(argv: any, lease: LeaseService) {
     return [
       this.tasks.initialize(argv, this.configs.addConfigBuilder.bind(this.configs), lease),
       // TODO instead of validating the state we need to do a remote config add component, and we will need to manually
@@ -159,7 +159,7 @@ export class NodeCommandHandlers extends CommandHandler {
     ];
   }
 
-  updatePrepareTasks(argv, lease: Lease) {
+  updatePrepareTasks(argv, lease: LeaseService) {
     return [
       this.tasks.initialize(argv, this.configs.updateConfigBuilder.bind(this.configs), lease),
       this.validateSingleNodeState({excludedStates: []}),
@@ -203,7 +203,7 @@ export class NodeCommandHandlers extends CommandHandler {
     ];
   }
 
-  upgradePrepareTasks(argv, lease: Lease) {
+  upgradePrepareTasks(argv, lease: LeaseService) {
     return [
       this.tasks.initialize(argv, this.configs.upgradeConfigBuilder.bind(this.configs), lease),
       this.validateAllNodeStates({excludedStates: []}),

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -63,7 +63,7 @@ import {
 import {PodName} from '../../core/kube/resources/pod/pod_name.js';
 import {NodeStatusCodes, NodeStatusEnums, NodeSubcommandType} from '../../core/enumerations.js';
 import {type NodeDeleteConfigClass, type NodeRefreshConfigClass, type NodeUpdateConfigClass} from './configs.js';
-import {type Lease} from '../../core/lease/lease.js';
+import {type LeaseService} from '../../core/lease/lease_service.js';
 import {ListrLease} from '../../core/lease/listr_lease.js';
 import {Duration} from '../../core/time/duration.js';
 import {type NodeAddConfigClass} from './node_add_config.js';
@@ -2074,7 +2074,7 @@ export class NodeCommandTasks {
     });
   }
 
-  initialize(argv: any, configInit: ConfigBuilder, lease: Lease | null, shouldLoadNodeClient = true) {
+  initialize(argv: any, configInit: ConfigBuilder, lease: LeaseService | null, shouldLoadNodeClient = true) {
     const {requiredFlags, requiredFlagsWithDisabledPrompt, optionalFlags} = argv;
     const allRequiredFlags = [...requiredFlags, ...requiredFlagsWithDisabledPrompt];
 

--- a/src/core/command_handler.ts
+++ b/src/core/command_handler.ts
@@ -6,7 +6,7 @@ import {SoloLogger} from './logging.js';
 import {patchInject} from './dependency_injection/container_helper.js';
 import {Listr} from 'listr2';
 import {SoloError} from './errors.js';
-import {type Lease} from './lease/lease.js';
+import {type LeaseService} from './lease/lease_service.js';
 import * as constants from './constants.js';
 import fs from 'fs';
 import {Task} from './task.js';
@@ -34,7 +34,7 @@ export class CommandHandler {
     actionTasks: any,
     options: any,
     errorString: string,
-    lease: Lease | null,
+    lease: LeaseService | null,
   ): Promise<void> {
     const tasks = new Listr([...actionTasks], options);
     try {

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -3,6 +3,7 @@
  */
 
 export class SoloError extends Error {
+  public readonly statusCode: number | undefined;
   /**
    * Create a custom error object
    *
@@ -19,7 +20,7 @@ export class SoloError extends Error {
   ) {
     super(message);
     this.name = this.constructor.name;
-
+    this.statusCode = cause.statusCode;
     Error.captureStackTrace(this, this.constructor);
     if (cause) {
       this.cause = cause;

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -3,7 +3,7 @@
  */
 
 export class SoloError extends Error {
-  public readonly statusCode: number | undefined;
+  public readonly statusCode?: number;
   /**
    * Create a custom error object
    *
@@ -20,7 +20,7 @@ export class SoloError extends Error {
   ) {
     super(message);
     this.name = this.constructor.name;
-    this.statusCode = cause.statusCode;
+    this.statusCode = cause?.statusCode;
     Error.captureStackTrace(this, this.constructor);
     if (cause) {
       this.cause = cause;

--- a/src/core/kube/k8_client/resources/lease/k8_client_lease.ts
+++ b/src/core/kube/k8_client/resources/lease/k8_client_lease.ts
@@ -21,6 +21,8 @@ export class K8ClientLease implements Lease {
       v1Lease.metadata.name,
       v1Lease.spec.holderIdentity,
       v1Lease.spec.leaseDurationSeconds,
+      v1Lease.spec.acquireTime,
+      v1Lease.spec.renewTime,
     );
   }
 
@@ -35,7 +37,8 @@ export class K8ClientLease implements Lease {
     const spec: V1LeaseSpec = new V1LeaseSpec();
     spec.holderIdentity = lease.holderName;
     spec.leaseDurationSeconds = lease.durationSeconds;
-    spec.acquireTime = new V1MicroTime();
+    spec.acquireTime = lease.acquireTime || new V1MicroTime();
+    spec.renewTime = lease.renewTime || new V1MicroTime();
     v1Lease.spec = spec;
 
     return v1Lease;

--- a/src/core/kube/k8_client/resources/lease/k8_client_lease.ts
+++ b/src/core/kube/k8_client/resources/lease/k8_client_lease.ts
@@ -13,6 +13,7 @@ export class K8ClientLease implements Lease {
     public readonly durationSeconds: number,
     public readonly acquireTime?: Date,
     public readonly renewTime?: Date,
+    public readonly resourceVersion?: string,
   ) {}
 
   public static fromV1Lease(v1Lease: V1Lease): Lease {
@@ -23,6 +24,7 @@ export class K8ClientLease implements Lease {
       v1Lease.spec.leaseDurationSeconds,
       v1Lease.spec.acquireTime,
       v1Lease.spec.renewTime,
+      v1Lease.metadata.resourceVersion,
     );
   }
 
@@ -32,6 +34,7 @@ export class K8ClientLease implements Lease {
     const metadata: V1ObjectMeta = new V1ObjectMeta();
     metadata.name = lease.leaseName;
     metadata.namespace = lease.namespace.name;
+    metadata.resourceVersion = lease.resourceVersion;
     v1Lease.metadata = metadata;
 
     const spec: V1LeaseSpec = new V1LeaseSpec();

--- a/src/core/kube/k8_client/resources/lease/k8_client_lease.ts
+++ b/src/core/kube/k8_client/resources/lease/k8_client_lease.ts
@@ -25,14 +25,14 @@ export class K8ClientLease implements Lease {
   }
 
   public static toV1Lease(lease: Lease): V1Lease {
-    const v1Lease = new V1Lease();
+    const v1Lease: V1Lease = new V1Lease();
 
-    const metadata = new V1ObjectMeta();
+    const metadata: V1ObjectMeta = new V1ObjectMeta();
     metadata.name = lease.leaseName;
     metadata.namespace = lease.namespace.name;
     v1Lease.metadata = metadata;
 
-    const spec = new V1LeaseSpec();
+    const spec: V1LeaseSpec = new V1LeaseSpec();
     spec.holderIdentity = lease.holderName;
     spec.leaseDurationSeconds = lease.durationSeconds;
     spec.acquireTime = new V1MicroTime();

--- a/src/core/kube/k8_client/resources/lease/k8_client_lease.ts
+++ b/src/core/kube/k8_client/resources/lease/k8_client_lease.ts
@@ -38,7 +38,7 @@ export class K8ClientLease implements Lease {
     spec.holderIdentity = lease.holderName;
     spec.leaseDurationSeconds = lease.durationSeconds;
     spec.acquireTime = lease.acquireTime || new V1MicroTime();
-    spec.renewTime = lease.renewTime || new V1MicroTime();
+    spec.renewTime = lease.renewTime;
     v1Lease.spec = spec;
 
     return v1Lease;

--- a/src/core/kube/k8_client/resources/lease/k8_client_leases.ts
+++ b/src/core/kube/k8_client/resources/lease/k8_client_leases.ts
@@ -85,7 +85,7 @@ export class K8ClientLeases implements Leases {
   }
 
   public async renew(namespace: NamespaceName, leaseName: string, lease: Lease): Promise<Lease> {
-    const v1Lease = K8ClientLease.toV1Lease(lease);
+    const v1Lease: V1Lease = K8ClientLease.toV1Lease(lease);
     v1Lease.spec.renewTime = new V1MicroTime();
 
     const {response, body} = await this.coordinationApiClient

--- a/src/core/kube/k8_client/resources/lease/k8_client_leases.ts
+++ b/src/core/kube/k8_client/resources/lease/k8_client_leases.ts
@@ -65,7 +65,7 @@ export class K8ClientLeases implements Leases {
     return body as V1Status;
   }
 
-  public async read(namespace: NamespaceName, leaseName: string, timesCalled?: number): Promise<any> {
+  public async read(namespace: NamespaceName, leaseName: string, timesCalled?: number): Promise<Lease> {
     const {response, body} = await this.coordinationApiClient
       .readNamespacedLease(leaseName, namespace.name)
       .catch(e => e);
@@ -81,7 +81,7 @@ export class K8ClientLeases implements Leases {
 
     this.handleKubernetesClientError(response, body, 'Failed to read namespaced lease');
 
-    return body as V1Lease;
+    return K8ClientLease.fromV1Lease(body);
   }
 
   public async renew(namespace: NamespaceName, leaseName: string, lease: Lease): Promise<Lease> {

--- a/src/core/kube/resources/lease/lease.ts
+++ b/src/core/kube/resources/lease/lease.ts
@@ -1,0 +1,16 @@
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+import {type NamespaceName} from '../namespace/namespace_name.js';
+
+/**
+ * SPDX-License-Identifier: Apache-2.0
+ */
+export interface Lease {
+  readonly namespace: NamespaceName;
+  readonly leaseName: string;
+  readonly holderName: string;
+  readonly durationSeconds: number;
+  readonly acquireTime?: Date;
+  readonly renewTime?: Date;
+}

--- a/src/core/kube/resources/lease/lease.ts
+++ b/src/core/kube/resources/lease/lease.ts
@@ -36,4 +36,9 @@ export interface Lease {
    * The time the lease was renewed
    */
   readonly renewTime?: Date;
+
+  /**
+   * The resource version of the lease
+   */
+  readonly resourceVersion?: string;
 }

--- a/src/core/kube/resources/lease/lease.ts
+++ b/src/core/kube/resources/lease/lease.ts
@@ -4,13 +4,36 @@
 import {type NamespaceName} from '../namespace/namespace_name.js';
 
 /**
- * SPDX-License-Identifier: Apache-2.0
+ * Represents a Kubernetes Lease
  */
 export interface Lease {
+  /**
+   * The namespace of the lease
+   */
   readonly namespace: NamespaceName;
+
+  /**
+   * The name of the lease
+   */
   readonly leaseName: string;
+
+  /**
+   * The name of the lease-holder
+   */
   readonly holderName: string;
+
+  /**
+   * The duration of the lease in seconds
+   */
   readonly durationSeconds: number;
+
+  /**
+   * The time the lease was acquired
+   */
   readonly acquireTime?: Date;
+
+  /**
+   * The time the lease was renewed
+   */
   readonly renewTime?: Date;
 }

--- a/src/core/kube/resources/lease/leases.ts
+++ b/src/core/kube/resources/lease/leases.ts
@@ -1,8 +1,9 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-import {type V1Lease, type V1Status} from '@kubernetes/client-node';
+import {type V1Status} from '@kubernetes/client-node';
 import {type NamespaceName} from '../namespace/namespace_name.js';
+import {type Lease} from './lease.js';
 
 export interface Leases {
   /**
@@ -13,7 +14,7 @@ export interface Leases {
    * @param durationSeconds - the duration of the lease in seconds\
    * @returns the created lease
    */
-  create(namespace: NamespaceName, leaseName: string, holderName: string, durationSeconds: number): Promise<V1Lease>;
+  create(namespace: NamespaceName, leaseName: string, holderName: string, durationSeconds: number): Promise<Lease>;
 
   /**
    * Delete a lease
@@ -39,7 +40,7 @@ export interface Leases {
    * @param lease - the lease object
    * @returns the renewed lease
    */
-  renew(namespace: NamespaceName, leaseName: string, lease: V1Lease): Promise<V1Lease>;
+  renew(namespace: NamespaceName, leaseName: string, lease: Lease): Promise<Lease>;
 
   /**
    * Transfer a lease
@@ -47,5 +48,5 @@ export interface Leases {
    * @param newHolderName - the name of the new lease holder
    * @returns the transferred lease
    */
-  transfer(lease: V1Lease, newHolderName: string): Promise<V1Lease>;
+  transfer(lease: Lease, newHolderName: string): Promise<Lease>;
 }

--- a/src/core/kube/resources/lease/leases.ts
+++ b/src/core/kube/resources/lease/leases.ts
@@ -29,9 +29,9 @@ export interface Leases {
    * @param namespace - the namespace to list leases in
    * @param leaseName - the name of the lease
    * @param timesCalled - the number of times this function has been called
-   * @returns a list of lease names
+   * @returns a lease with the specified name
    */
-  read(namespace: NamespaceName, leaseName: string, timesCalled?: number): Promise<any>;
+  read(namespace: NamespaceName, leaseName: string, timesCalled?: number): Promise<Lease>;
 
   /**
    * Renew a lease

--- a/src/core/kube/resources/resource_type.ts
+++ b/src/core/kube/resources/resource_type.ts
@@ -24,4 +24,5 @@ export enum ResourceType {
   CLUSTER_ROLE_BINDING = 'ClusterRoleBinding',
   CLUSTER = 'Cluster',
   CONTAINER = 'Container',
+  LEASE = 'Lease',
 }

--- a/src/core/lease/interval_lease.ts
+++ b/src/core/lease/interval_lease.ts
@@ -2,15 +2,15 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 import {MissingArgumentError, SoloError} from '../errors.js';
-import {type V1Lease} from '@kubernetes/client-node';
 import {type K8Factory} from '../kube/k8_factory.js';
 import {LeaseHolder} from './lease_holder.js';
 import {LeaseAcquisitionError, LeaseRelinquishmentError} from './lease_errors.js';
 import {sleep} from '../helpers.js';
 import {Duration} from '../time/duration.js';
-import {type Lease, type LeaseRenewalService} from './lease.js';
+import {type LeaseService, type LeaseRenewalService} from './lease_service.js';
 import {StatusCodes} from 'http-status-codes';
 import {type NamespaceName} from '../kube/resources/namespace/namespace_name.js';
+import {type Lease} from '../kube/resources/lease/lease.js';
 
 /**
  * Concrete implementation of a Kubernetes based time-based mutually exclusive lock via the Coordination API.
@@ -20,7 +20,7 @@ import {type NamespaceName} from '../kube/resources/namespace/namespace_name.js'
  *
  * @public
  */
-export class IntervalLease implements Lease {
+export class IntervalLease implements LeaseService {
   /** The default duration in seconds for which the lease is to be held before being considered expired. */
   public static readonly DEFAULT_LEASE_DURATION = 20;
 
@@ -137,7 +137,7 @@ export class IntervalLease implements Lease {
       return this.transferLease(lease);
     }
 
-    const otherHolder: LeaseHolder = LeaseHolder.fromJson(lease.spec.holderIdentity);
+    const otherHolder: LeaseHolder = LeaseHolder.fromJson(lease.holderName);
 
     if (this.heldBySameMachineIdentity(lease) && !otherHolder.isProcessAlive()) {
       return this.transferLease(lease);
@@ -213,7 +213,7 @@ export class IntervalLease implements Lease {
 
     if (this.scheduleId) {
       await this.renewalService.cancel(this.scheduleId);
-      // Needed to ensure any pending renewals are truly cancelled before proceeding to delete the Lease.
+      // Needed to ensure any pending renewals are truly cancelled before proceeding to delete the LeaseService.
       // This is required because clearInterval() is not guaranteed to abort any pending interval.
       await sleep(this.renewalService.calculateRenewalDelay(this));
     }
@@ -224,7 +224,7 @@ export class IntervalLease implements Lease {
       return;
     }
 
-    const otherHolder: LeaseHolder = LeaseHolder.fromJson(lease.spec.holderIdentity);
+    const otherHolder: LeaseHolder = LeaseHolder.fromJson(lease.holderName);
 
     if (this.heldBySameProcess(lease) || IntervalLease.checkExpiration(lease)) {
       return await this.deleteLease();
@@ -280,7 +280,7 @@ export class IntervalLease implements Lease {
    * @returns the Kubernetes lease object if it exists; otherwise, null.
    * @throws LeaseAcquisitionError - If an error occurs during retrieval.
    */
-  private async retrieveLease(): Promise<V1Lease> {
+  private async retrieveLease(): Promise<Lease> {
     try {
       return await this.k8Factory.default().leases().read(this.namespace, this.leaseName);
     } catch (e: any) {
@@ -308,7 +308,7 @@ export class IntervalLease implements Lease {
    *
    * @param lease - The lease to be created or renewed.
    */
-  private async createOrRenewLease(lease: V1Lease): Promise<void> {
+  private async createOrRenewLease(lease: Lease): Promise<void> {
     try {
       if (!lease) {
         await this.k8Factory
@@ -335,7 +335,7 @@ export class IntervalLease implements Lease {
    *
    * @param lease - The lease to be transferred.
    */
-  private async transferLease(lease: V1Lease): Promise<void> {
+  private async transferLease(lease: Lease): Promise<void> {
     try {
       await this.k8Factory.default().leases().transfer(lease, this.leaseHolder.toJson());
 
@@ -370,10 +370,10 @@ export class IntervalLease implements Lease {
    * @param lease - The lease to be checked for expiration.
    * @returns true if the lease has expired; otherwise, false.
    */
-  private static checkExpiration(lease: V1Lease): boolean {
+  private static checkExpiration(lease: Lease): boolean {
     const now = Duration.ofMillis(Date.now());
-    const durationSec = lease.spec.leaseDurationSeconds || IntervalLease.DEFAULT_LEASE_DURATION;
-    const lastRenewalTime = lease.spec?.renewTime || lease.spec?.acquireTime;
+    const durationSec = lease.durationSeconds || IntervalLease.DEFAULT_LEASE_DURATION;
+    const lastRenewalTime = lease.renewTime || lease.acquireTime;
     const lastRenewal = Duration.ofMillis(new Date(lastRenewalTime).valueOf());
     const deltaSec = now.minus(lastRenewal).seconds;
     return deltaSec > durationSec;
@@ -386,8 +386,8 @@ export class IntervalLease implements Lease {
    * @param lease - The lease to be checked for ownership.
    * @returns true if the lease is held by the same process; otherwise, false.
    */
-  private heldBySameProcess(lease: V1Lease): boolean {
-    const holder: LeaseHolder = LeaseHolder.fromJson(lease.spec.holderIdentity);
+  private heldBySameProcess(lease: Lease): boolean {
+    const holder: LeaseHolder = LeaseHolder.fromJson(lease.holderName);
     return this.leaseHolder.equals(holder);
   }
 
@@ -398,8 +398,8 @@ export class IntervalLease implements Lease {
    * @param lease - The lease to be checked for ownership.
    * @returns true if the lease is held by the same user and machine; otherwise, false.
    */
-  private heldBySameMachineIdentity(lease: V1Lease): boolean {
-    const holder: LeaseHolder = LeaseHolder.fromJson(lease.spec.holderIdentity);
+  private heldBySameMachineIdentity(lease: Lease): boolean {
+    const holder: LeaseHolder = LeaseHolder.fromJson(lease.holderName);
     return this.leaseHolder.isSameMachineIdentity(holder);
   }
 }

--- a/src/core/lease/interval_lease_renewal.ts
+++ b/src/core/lease/interval_lease_renewal.ts
@@ -1,7 +1,7 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-import {type Lease, type LeaseRenewalService} from './lease.js';
+import {type LeaseService, type LeaseRenewalService} from './lease_service.js';
 import {Duration} from '../time/duration.js';
 import {injectable} from 'tsyringe-neo';
 
@@ -12,13 +12,13 @@ import {injectable} from 'tsyringe-neo';
 @injectable()
 export class IntervalLeaseRenewalService implements LeaseRenewalService {
   /** The internal registry used to track all non-cancelled lease renewals. */
-  private readonly _scheduledLeases: Map<number, Lease>;
+  private readonly _scheduledLeases: Map<number, LeaseService>;
 
   /**
    * Constructs a new interval lease renewal service.
    */
   constructor() {
-    this._scheduledLeases = new Map<number, Lease>();
+    this._scheduledLeases = new Map<number, LeaseService>();
   }
 
   /**
@@ -39,7 +39,7 @@ export class IntervalLeaseRenewalService implements LeaseRenewalService {
    * @param lease - the lease to be renewed.
    * @returns the unique identifier of the scheduled lease renewal. The unique identifier is the ID of the setInterval() timeout.
    */
-  public async schedule(lease: Lease): Promise<number> {
+  public async schedule(lease: LeaseService): Promise<number> {
     const renewalDelay = this.calculateRenewalDelay(lease);
     const timeout = setInterval(() => lease.tryRenew(), renewalDelay.toMillis());
     const scheduleId = Number(timeout);
@@ -90,7 +90,7 @@ export class IntervalLeaseRenewalService implements LeaseRenewalService {
    * @param lease - the lease to be renewed.
    * @returns the delay in milliseconds.
    */
-  public calculateRenewalDelay(lease: Lease): Duration {
+  public calculateRenewalDelay(lease: LeaseService): Duration {
     return Duration.ofSeconds(lease.durationSeconds * 0.5);
   }
 }

--- a/src/core/lease/lease_manager.ts
+++ b/src/core/lease/lease_manager.ts
@@ -5,7 +5,7 @@ import {Flags as flags} from '../../commands/flags.js';
 import {type ConfigManager} from '../config_manager.js';
 import {type K8Factory} from '../kube/k8_factory.js';
 import {type SoloLogger} from '../logging.js';
-import {type Lease, type LeaseRenewalService} from './lease.js';
+import {type LeaseService, type LeaseRenewalService} from './lease_service.js';
 import {IntervalLease} from './interval_lease.js';
 import {LeaseHolder} from './lease_holder.js';
 import {LeaseAcquisitionError} from './lease_errors.js';
@@ -44,7 +44,7 @@ export class LeaseManager {
    *
    * @returns a new lease instance.
    */
-  public async create(): Promise<Lease> {
+  public async create(): Promise<LeaseService> {
     return new IntervalLease(
       this.k8Factory,
       this._renewalService,

--- a/src/core/lease/lease_service.ts
+++ b/src/core/lease/lease_service.ts
@@ -6,7 +6,7 @@ import {type LeaseHolder} from './lease_holder.js';
 import {type Duration} from '../time/duration.js';
 import {type NamespaceName} from '../kube/resources/namespace/namespace_name.js';
 
-export interface Lease {
+export interface LeaseService {
   readonly k8Factory: K8Factory;
   readonly renewalService: LeaseRenewalService;
   readonly leaseName: string;
@@ -109,7 +109,7 @@ export interface LeaseRenewalService {
    * @param lease - the lease to be renewed.
    * @returns the unique identifier of the scheduled lease renewal.
    */
-  schedule(lease: Lease): Promise<number>;
+  schedule(lease: LeaseService): Promise<number>;
 
   /**
    * Cancels a scheduled lease renewal.
@@ -129,5 +129,5 @@ export interface LeaseRenewalService {
    * @param lease - the lease to be renewed.
    * @returns the delay in milliseconds.
    */
-  calculateRenewalDelay(lease: Lease): Duration;
+  calculateRenewalDelay(lease: LeaseService): Duration;
 }

--- a/src/core/lease/listr_lease.ts
+++ b/src/core/lease/listr_lease.ts
@@ -3,7 +3,7 @@
  */
 import {type ListrTaskWrapper} from 'listr2';
 import chalk from 'chalk';
-import {type Lease} from './lease.js';
+import {type LeaseService} from './lease_service.js';
 import {LeaseAcquisitionError} from './lease_errors.js';
 
 /**
@@ -33,7 +33,7 @@ export class ListrLease {
    * @param task - the parent task to which the lease acquisition task will be added.
    * @returns a new Listr2 task for acquiring a lease with retry logic.
    */
-  public static newAcquireLeaseTask(lease: Lease, task: ListrTaskWrapper<any, any, any>) {
+  public static newAcquireLeaseTask(lease: LeaseService, task: ListrTaskWrapper<any, any, any>) {
     return task.newListr(
       [
         {
@@ -60,7 +60,7 @@ export class ListrLease {
    * @param task - the task to be updated with the lease acquisition status.
    * @throws LeaseAcquisitionError if the lease could not be acquired after the maximum number of attempts or an unexpected error occurred.
    */
-  private static async acquireWithRetry(lease: Lease, task: ListrTaskWrapper<any, any, any>): Promise<void> {
+  private static async acquireWithRetry(lease: LeaseService, task: ListrTaskWrapper<any, any, any>): Promise<void> {
     const maxAttempts = +process.env.SOLO_LEASE_ACQUIRE_ATTEMPTS || ListrLease.DEFAULT_LEASE_ACQUIRE_ATTEMPTS;
     const title = task.title;
 

--- a/test/e2e/integration/core/lease.test.ts
+++ b/test/e2e/integration/core/lease.test.ts
@@ -79,7 +79,7 @@ describe('Lease', async () => {
       expect(await lease.isAcquired()).to.be.true;
       expect(await lease.isExpired()).to.be.false;
 
-      expect(newLease.release()).to.be.rejectedWith(LeaseRelinquishmentError);
+      await expect(newLease.release()).to.be.rejectedWith(LeaseRelinquishmentError);
       expect(await lease.isAcquired()).to.be.true;
       expect(await lease.isExpired()).to.be.false;
 

--- a/test/e2e/integration/core/lease_renewal.test.ts
+++ b/test/e2e/integration/core/lease_renewal.test.ts
@@ -7,12 +7,12 @@ import {expect} from 'chai';
 import {IntervalLease} from '../../../../src/core/lease/interval_lease.js';
 import {LeaseHolder} from '../../../../src/core/lease/lease_holder.js';
 import {sleep} from '../../../../src/core/helpers.js';
-import {type V1Lease} from '@kubernetes/client-node';
 import {Duration} from '../../../../src/core/time/duration.js';
 import {container} from 'tsyringe-neo';
 import {NamespaceName} from '../../../../src/core/kube/resources/namespace/namespace_name.js';
 import {InjectTokens} from '../../../../src/core/dependency_injection/inject_tokens.js';
-import {type LeaseRenewalService} from '../../../../src/core/lease/lease.js';
+import {type LeaseRenewalService} from '../../../../src/core/lease/lease_service.js';
+import {type Lease} from '../../../../src/core/kube/resources/lease/lease.js';
 
 const defaultTimeout = Duration.ofMinutes(2).toMillis();
 const leaseDuration = 4;
@@ -70,24 +70,24 @@ describe('LeaseRenewalService', async () => {
     expect(lease.scheduleId).to.not.be.null;
     expect(await renewalService.isScheduled(lease.scheduleId)).to.be.true;
 
-    // @ts-ignore
-    let remoteObject: V1Lease = await lease.retrieveLease();
+    // @ts-expect-error - accessing private method for testing
+    let remoteObject: Lease = await lease.retrieveLease();
     expect(remoteObject).to.not.be.null;
-    expect(remoteObject?.spec?.renewTime).to.be.undefined;
-    expect(remoteObject?.spec?.acquireTime).to.not.be.undefined;
-    expect(remoteObject?.spec?.acquireTime).to.not.be.null;
+    expect(remoteObject?.renewTime).to.be.undefined;
+    expect(remoteObject?.acquireTime).to.not.be.undefined;
+    expect(remoteObject?.acquireTime).to.not.be.null;
 
-    const acquireTime = new Date(remoteObject?.spec?.acquireTime).valueOf();
+    const acquireTime = new Date(remoteObject?.acquireTime).valueOf();
     expect(acquireTime).to.be.greaterThan(0);
 
     await sleep(Duration.ofSeconds(lease.durationSeconds));
-    // @ts-ignore
+    // @ts-expect-error - accessing private method for testing
     remoteObject = await lease.retrieveLease();
     expect(remoteObject).to.not.be.null;
-    expect(remoteObject?.spec?.renewTime).to.not.be.undefined;
-    expect(remoteObject?.spec?.renewTime).to.not.be.null;
+    expect(remoteObject?.renewTime).to.not.be.undefined;
+    expect(remoteObject?.renewTime).to.not.be.null;
 
-    const renewTime = new Date(remoteObject?.spec?.renewTime).valueOf();
+    const renewTime = new Date(remoteObject?.renewTime).valueOf();
     expect(renewTime).to.be.greaterThan(acquireTime);
 
     await lease.release();
@@ -113,21 +113,21 @@ describe('LeaseRenewalService', async () => {
     expect(await renewalService.cancel(lease.scheduleId)).to.be.true;
     expect(await renewalService.isScheduled(lease.scheduleId)).to.be.false;
 
-    // @ts-ignore
-    let remoteObject: V1Lease = await lease.retrieveLease(k8Factory);
+    // @ts-expect-error - accessing private method for testing
+    let remoteObject: Lease = await lease.retrieveLease(k8Factory);
     expect(remoteObject).to.not.be.null;
-    expect(remoteObject?.spec?.renewTime).to.be.undefined;
-    expect(remoteObject?.spec?.acquireTime).to.not.be.undefined;
-    expect(remoteObject?.spec?.acquireTime).to.not.be.null;
+    expect(remoteObject?.renewTime).to.be.undefined;
+    expect(remoteObject?.acquireTime).to.not.be.undefined;
+    expect(remoteObject?.acquireTime).to.not.be.null;
 
-    const acquireTime = new Date(remoteObject?.spec?.acquireTime).valueOf();
+    const acquireTime = new Date(remoteObject?.acquireTime).valueOf();
     expect(acquireTime).to.be.greaterThan(0);
 
     await sleep(Duration.ofSeconds(lease.durationSeconds));
-    // @ts-ignore
+    // @ts-expect-error - accessing private method for testing
     remoteObject = await lease.retrieveLease();
     expect(remoteObject).to.not.be.null;
-    expect(remoteObject?.spec?.renewTime).to.be.undefined;
+    expect(remoteObject?.renewTime).to.be.undefined;
 
     await lease.release();
     expect(await renewalService.isScheduled(lease.scheduleId)).to.be.false;

--- a/test/e2e/integration/core/noop_lease_renewal_service.test.ts
+++ b/test/e2e/integration/core/noop_lease_renewal_service.test.ts
@@ -1,7 +1,7 @@
 /**
  * SPDX-License-Identifier: Apache-2.0
  */
-import {type Lease, type LeaseRenewalService} from '../../../../src/core/lease/lease.js';
+import {type LeaseService, type LeaseRenewalService} from '../../../../src/core/lease/lease_service.js';
 import {Duration} from '../../../../src/core/time/duration.js';
 
 export class NoopLeaseRenewalService implements LeaseRenewalService {
@@ -18,7 +18,7 @@ export class NoopLeaseRenewalService implements LeaseRenewalService {
     return scheduleId > 0;
   }
 
-  public async schedule(lease: Lease): Promise<number> {
+  public async schedule(lease: LeaseService): Promise<number> {
     return Atomics.add(this.counter, 0, 1);
   }
 
@@ -30,7 +30,7 @@ export class NoopLeaseRenewalService implements LeaseRenewalService {
     return new Map<number, boolean>();
   }
 
-  public calculateRenewalDelay(lease: Lease): Duration {
+  public calculateRenewalDelay(lease: LeaseService): Duration {
     return Duration.ofSeconds(10);
   }
 }


### PR DESCRIPTION
## Description

This pull request changes the following:

* remove v1lease usage outside of `kube` folder

### Related Issues

* Closes #1313 
