### PR TITLE
fix: add missing parameter

### DIFF
--- a/.github/workflows/script/gcs_test.sh
+++ b/.github/workflows/script/gcs_test.sh
@@ -95,7 +95,7 @@ npm run solo-test -- deployment add-cluster --deployment "${SOLO_DEPLOYMENT}" --
 
 npm run solo-test -- node keys --gossip-keys --tls-keys -i node1 --deployment "${SOLO_DEPLOYMENT}"
 
-npm run solo-test -- network deploy --deployment "${SOLO_DEPLOYMENT}" \
+npm run solo-test -- network deploy --deployment "${SOLO_DEPLOYMENT}" -i node1 \
   --storage-type "${storageType}" \
   "${STORAGE_OPTIONS[@]}" \
   --backup-bucket "${streamBackupBucket}" \


### PR DESCRIPTION
## Description

This pull request changes the following:

* Fix network deploy command

Previously network deploy does not need nodeAlias parameter

https://github.com/hashgraph/solo/actions/runs/13793917758/job/38580675404?pr=1634#step:14:200

### Related Issues

N/A
