### PR TITLE
chore: added storage backend test coverage

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@hashgraph/solo",
-  "version": "0.35.0",
+  "version": "0.35.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@hashgraph/solo",
-      "version": "0.35.0",
+      "version": "0.35.1",
       "license": "Apache2.0",
       "os": [
         "darwin",

--- a/src/data/backend/impl/file-storage-backend.ts
+++ b/src/data/backend/impl/file-storage-backend.ts
@@ -32,7 +32,7 @@ export class FileStorageBackend implements StorageBackend {
     try {
       stats = lstatSync(basePath);
     } catch (e) {
-      throw new StorageBackendError('basePath must exist be a valid directory', e);
+      throw new StorageBackendError('basePath must exist and be valid', e);
     }
 
     if (!stats || !stats.isDirectory()) {
@@ -71,7 +71,7 @@ export class FileStorageBackend implements StorageBackend {
       throw new IllegalArgumentError('key must not be null, undefined or empty');
     }
 
-    const filePath = path.join(this.basePath, key);
+    const filePath: string = path.join(this.basePath, key);
     try {
       return new Uint8Array(readFileSync(filePath));
     } catch (e) {
@@ -88,7 +88,7 @@ export class FileStorageBackend implements StorageBackend {
       throw new IllegalArgumentError('data must not be null or undefined');
     }
 
-    const filePath = path.join(this.basePath, key);
+    const filePath: string = path.join(this.basePath, key);
     try {
       writeFileSync(filePath, data, {flag: 'w'});
     } catch (e) {
@@ -101,7 +101,7 @@ export class FileStorageBackend implements StorageBackend {
       throw new IllegalArgumentError('key must not be null, undefined or empty');
     }
 
-    const filePath = path.join(this.basePath, key);
+    const filePath: string = path.join(this.basePath, key);
     let stats: Stats;
     try {
       stats = statSync(filePath);

--- a/src/data/backend/impl/yaml-file-storage-backend.ts
+++ b/src/data/backend/impl/yaml-file-storage-backend.ts
@@ -4,7 +4,7 @@ import {type ObjectStorageBackend} from '../api/object-storage-backend.js';
 import {FileStorageBackend} from './file-storage-backend.js';
 import {StorageBackendError} from '../api/storage-backend-error.js';
 import path from 'path';
-import {dumpYaml, loadYaml} from '@kubernetes/client-node';
+import {parse, stringify} from 'yaml';
 import {IllegalArgumentError} from '../../../core/errors/illegal-argument-error.js';
 
 export class YamlFileStorageBackend extends FileStorageBackend implements ObjectStorageBackend {
@@ -25,7 +25,7 @@ export class YamlFileStorageBackend extends FileStorageBackend implements Object
     }
 
     try {
-      return loadYaml<object>(Buffer.from(data.buffer).toString());
+      return parse(Buffer.from(data.buffer).toString());
     } catch (e) {
       throw new StorageBackendError(`error parsing yaml file: ${filePath}`, e);
     }
@@ -38,7 +38,7 @@ export class YamlFileStorageBackend extends FileStorageBackend implements Object
 
     const filePath: string = path.join(this.basePath, key);
     try {
-      const yamlData: string = dumpYaml(data, {sortKeys: true});
+      const yamlData: string = stringify(data, {sortMapEntries: true});
       await this.writeBytes(key, new Uint8Array(Buffer.from(yamlData)));
     } catch (e) {
       throw new StorageBackendError(`error writing yaml file: ${filePath}`, e);

--- a/src/data/backend/impl/yaml-file-storage-backend.ts
+++ b/src/data/backend/impl/yaml-file-storage-backend.ts
@@ -25,7 +25,7 @@ export class YamlFileStorageBackend extends FileStorageBackend implements Object
     }
 
     try {
-      return loadYaml<object>(data.toString());
+      return loadYaml<object>(Buffer.from(data.buffer).toString());
     } catch (e) {
       throw new StorageBackendError(`error parsing yaml file: ${filePath}`, e);
     }

--- a/src/data/backend/impl/yaml-file-storage-backend.ts
+++ b/src/data/backend/impl/yaml-file-storage-backend.ts
@@ -25,7 +25,7 @@ export class YamlFileStorageBackend extends FileStorageBackend implements Object
     }
 
     try {
-      return parse(Buffer.from(data.buffer).toString());
+      return parse(Buffer.from(data.buffer).toString(), {strict: true});
     } catch (e) {
       throw new StorageBackendError(`error parsing yaml file: ${filePath}`, e);
     }

--- a/src/data/backend/impl/yaml-file-storage-backend.ts
+++ b/src/data/backend/impl/yaml-file-storage-backend.ts
@@ -15,7 +15,7 @@ export class YamlFileStorageBackend extends FileStorageBackend implements Object
   public async readObject(key: string): Promise<object> {
     const data: Uint8Array = await this.readBytes(key);
 
-    const filePath = path.join(this.basePath, key);
+    const filePath: string = path.join(this.basePath, key);
     if (!data) {
       throw new StorageBackendError(`failed to read file: ${filePath}`);
     }
@@ -36,9 +36,9 @@ export class YamlFileStorageBackend extends FileStorageBackend implements Object
       throw new IllegalArgumentError('data must not be null or undefined');
     }
 
-    const filePath = path.join(this.basePath, key);
+    const filePath: string = path.join(this.basePath, key);
     try {
-      const yamlData = dumpYaml(data, {sortKeys: true});
+      const yamlData: string = dumpYaml(data, {sortKeys: true});
       await this.writeBytes(key, new Uint8Array(Buffer.from(yamlData)));
     } catch (e) {
       throw new StorageBackendError(`error writing yaml file: ${filePath}`, e);

--- a/test/unit/data/backend/impl/file-storage-backend.test.ts
+++ b/test/unit/data/backend/impl/file-storage-backend.test.ts
@@ -28,7 +28,7 @@ describe('File Storage Backend', () => {
     fs.writeFileSync(temporaryFile, 'test');
     expect(() => {
       new FileStorageBackend(temporaryFile);
-    }).to.throw(`basePath must be a valid directory: ${temporaryFile}`);
+    }).to.throw(`basePath must be a valid directory: ${tempDir}`);
   });
 
   it('test isSupported', () => {
@@ -55,10 +55,11 @@ describe('File Storage Backend', () => {
   });
 
   it('test readBytes', async () => {
-    const temporaryFile: string = path.join(tempDir, `${testName}-file2.txt`);
+    const key: string = `${testName}-file2.txt`;
+    const temporaryFile: string = path.join(tempDir, key);
     fs.writeFileSync(temporaryFile, 'test');
     const backend: FileStorageBackend = new FileStorageBackend(tempDir);
-    const data: Uint8Array = await backend.readBytes(`${testName}-file2.txt`);
+    const data: Uint8Array = await backend.readBytes(key);
     expect(Buffer.from(data.buffer).toString()).to.equal('test');
   });
 
@@ -73,9 +74,10 @@ describe('File Storage Backend', () => {
   });
 
   it('test writeBytes', async () => {
-    const temporaryFile: string = path.join(tempDir, `${testName}-file3.txt`);
+    const key: string = `${testName}-file3.txt`;
+    const temporaryFile: string = path.join(tempDir, key);
     const backend: FileStorageBackend = new FileStorageBackend(tempDir);
-    await backend.writeBytes(`${testName}-file3.txt`, new Uint8Array(Buffer.from('test')));
+    await backend.writeBytes(key, new Uint8Array(Buffer.from('test')));
     expect(fs.readFileSync(temporaryFile, 'utf-8')).to.equal('test');
   });
 
@@ -92,19 +94,19 @@ describe('File Storage Backend', () => {
   });
 
   it('test writeBytes with a file that already exists as a directory', async () => {
-    const temporaryFile: string = path.join(tempDir, `${testName}-file-dir`);
+    const key: string = `${testName}-file-dir`;
+    const temporaryFile: string = path.join(tempDir, key);
     fs.mkdirSync(temporaryFile);
     const backend: FileStorageBackend = new FileStorageBackend(tempDir);
-    await expect(backend.writeBytes(`${testName}-file-dir`, new Uint8Array(Buffer.from('test')))).to.be.rejectedWith(
-      'error writing file',
-    );
+    await expect(backend.writeBytes(key, new Uint8Array(Buffer.from('test')))).to.be.rejectedWith('error writing file');
   });
 
   it('test delete', async () => {
-    const temporaryFile: string = path.join(tempDir, `${testName}-file4.txt`);
+    const key: string = `${testName}-file4.txt`;
+    const temporaryFile: string = path.join(tempDir, key);
     fs.writeFileSync(temporaryFile, 'test');
     const backend: FileStorageBackend = new FileStorageBackend(tempDir);
-    await backend.delete(`${testName}-file4.txt`);
+    await backend.delete(key);
     expect(fs.existsSync(temporaryFile)).to.be.false;
   });
 
@@ -119,9 +121,10 @@ describe('File Storage Backend', () => {
   });
 
   it('test delete with a directory as key', async () => {
-    const temporaryFile: string = path.join(tempDir, `${testName}-file-dir2`);
+    const key: string = `${testName}-file-dir2`;
+    const temporaryFile: string = path.join(tempDir, key);
     fs.mkdirSync(temporaryFile);
     const backend: FileStorageBackend = new FileStorageBackend(tempDir);
-    await expect(backend.delete(`${testName}-file-dir2`)).to.be.rejectedWith('path is not a file');
+    await expect(backend.delete(key)).to.be.rejectedWith('path is not a file');
   });
 });

--- a/test/unit/data/backend/impl/file-storage-backend.test.ts
+++ b/test/unit/data/backend/impl/file-storage-backend.test.ts
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {expect} from 'chai';
+import {FileStorageBackend} from '../../../../../src/data/backend/impl/file-storage-backend.js';
+import {getTmpDir} from '../../../../test-util.js';
+import path from 'path';
+import fs from 'fs';
+import {StorageOperation} from '../../../../../src/data/backend/api/storage-operation.js';
+
+describe('File Storage Backend', () => {
+  const testName: string = 'file-storage-backend';
+  const tempDir: string = getTmpDir();
+
+  it('test empty string constructor', () => {
+    expect(() => {
+      new FileStorageBackend('');
+    }).to.throw('basePath must not be null, undefined or empty');
+  });
+
+  it('test path that does not exist', () => {
+    expect(() => {
+      new FileStorageBackend('/path/does/not/exist');
+    }).to.throw('basePath must exist and be valid');
+  });
+
+  it('test path that is not a directory', () => {
+    const temporaryFile: string = path.join(tempDir, `${testName}-file.txt`);
+    fs.writeFileSync(temporaryFile, 'test');
+    expect(() => {
+      new FileStorageBackend(temporaryFile);
+    }).to.throw(`basePath must be a valid directory: ${temporaryFile}`);
+  });
+
+  it('test isSupported', () => {
+    const backend: FileStorageBackend = new FileStorageBackend(tempDir);
+    expect(backend.isSupported(StorageOperation.List)).to.be.true;
+    expect(backend.isSupported(StorageOperation.ReadBytes)).to.be.true;
+    expect(backend.isSupported(StorageOperation.WriteBytes)).to.be.true;
+    expect(backend.isSupported(StorageOperation.Delete)).to.be.true;
+    expect(backend.isSupported(StorageOperation.ReadObject)).to.be.false;
+  });
+
+  it('test list', async () => {
+    const backend: FileStorageBackend = new FileStorageBackend(tempDir);
+    const files: string[] = await backend.list();
+    expect(files).to.be.an('array');
+  });
+
+  it('test list on new temp directory that is empty', async () => {
+    const tempDir2: string = getTmpDir();
+    const backend: FileStorageBackend = new FileStorageBackend(tempDir2);
+    const files: string[] = await backend.list();
+    expect(files).to.be.an('array');
+    expect(files.length).to.equal(0);
+  });
+
+  it('test readBytes', async () => {
+    const temporaryFile: string = path.join(tempDir, `${testName}-file2.txt`);
+    fs.writeFileSync(temporaryFile, 'test');
+    const backend: FileStorageBackend = new FileStorageBackend(tempDir);
+    const data: Uint8Array = await backend.readBytes(`${testName}-file2.txt`);
+    expect(Buffer.from(data.buffer).toString()).to.equal('test');
+  });
+
+  it('test readBytes with empty key', async () => {
+    const backend: FileStorageBackend = new FileStorageBackend(tempDir);
+    await expect(backend.readBytes('')).to.be.rejectedWith('key must not be null, undefined or empty');
+  });
+
+  it('test readBytes with non-existent file', async () => {
+    const backend: FileStorageBackend = new FileStorageBackend(tempDir);
+    await expect(backend.readBytes('non-existent-file.txt')).to.be.rejectedWith('error reading file');
+  });
+
+  it('test writeBytes', async () => {
+    const temporaryFile: string = path.join(tempDir, `${testName}-file3.txt`);
+    const backend: FileStorageBackend = new FileStorageBackend(tempDir);
+    await backend.writeBytes(`${testName}-file3.txt`, new Uint8Array(Buffer.from('test')));
+    expect(fs.readFileSync(temporaryFile, 'utf-8')).to.equal('test');
+  });
+
+  it('test writeBytes with empty key', async () => {
+    const backend: FileStorageBackend = new FileStorageBackend(tempDir);
+    await expect(backend.writeBytes('', new Uint8Array(Buffer.from('test')))).to.be.rejectedWith(
+      'key must not be null, undefined or empty',
+    );
+  });
+
+  it('test writeBytes with null data', async () => {
+    const backend: FileStorageBackend = new FileStorageBackend(tempDir);
+    await expect(backend.writeBytes('test', null)).to.be.rejectedWith('data must not be null');
+  });
+
+  it('test writeBytes with a file that already exists as a directory', async () => {
+    const temporaryFile: string = path.join(tempDir, `${testName}-file-dir`);
+    fs.mkdirSync(temporaryFile);
+    const backend: FileStorageBackend = new FileStorageBackend(tempDir);
+    await expect(backend.writeBytes(`${testName}-file-dir`, new Uint8Array(Buffer.from('test')))).to.be.rejectedWith(
+      'error writing file',
+    );
+  });
+
+  it('test delete', async () => {
+    const temporaryFile: string = path.join(tempDir, `${testName}-file4.txt`);
+    fs.writeFileSync(temporaryFile, 'test');
+    const backend: FileStorageBackend = new FileStorageBackend(tempDir);
+    await backend.delete(`${testName}-file4.txt`);
+    expect(fs.existsSync(temporaryFile)).to.be.false;
+  });
+
+  it('test delete with empty key', async () => {
+    const backend: FileStorageBackend = new FileStorageBackend(tempDir);
+    await expect(backend.delete('')).to.be.rejectedWith('key must not be null, undefined or empty');
+  });
+
+  it('test delete with non-existent file', async () => {
+    const backend: FileStorageBackend = new FileStorageBackend(tempDir);
+    await expect(backend.delete('non-existent-file.txt')).to.be.rejectedWith('file not found');
+  });
+
+  it('test delete with a directory as key', async () => {
+    const temporaryFile: string = path.join(tempDir, `${testName}-file-dir2`);
+    fs.mkdirSync(temporaryFile);
+    const backend: FileStorageBackend = new FileStorageBackend(tempDir);
+    await expect(backend.delete(`${testName}-file-dir2`)).to.be.rejectedWith('path is not a file');
+  });
+});

--- a/test/unit/data/backend/impl/yaml-file-storage-backend.test.ts
+++ b/test/unit/data/backend/impl/yaml-file-storage-backend.test.ts
@@ -3,17 +3,27 @@
 import {getTmpDir} from '../../../../test-util.js';
 import {YamlFileStorageBackend} from '../../../../../src/data/backend/impl/yaml-file-storage-backend.js';
 import {expect} from 'chai';
+import path from 'path';
+import fs from 'fs';
 
 describe('YAML File Storage Backend', () => {
   const testName: string = 'yaml-file-storage-backend';
   const tempDir: string = getTmpDir();
 
-  it('test writeObject', async () => {
+  it('test readObject and writeObject', async () => {
     const key: string = `${testName}-file.yaml`;
     const backend: YamlFileStorageBackend = new YamlFileStorageBackend(tempDir);
     await backend.writeObject(key, {key: 'value'});
     const data: object = await backend.readObject(key);
     expect(data).to.be.an('object');
     expect(data).to.deep.equal({key: 'value'});
+  });
+
+  it('test readObject with empty file', async () => {
+    const key: string = `${testName}-file2.yaml`;
+    const temporaryFile: string = path.join(tempDir, key);
+    const backend: YamlFileStorageBackend = new YamlFileStorageBackend(tempDir);
+    fs.writeFileSync(temporaryFile, '');
+    await expect(backend.readObject(key)).to.be.rejectedWith('file is empty');
   });
 });

--- a/test/unit/data/backend/impl/yaml-file-storage-backend.test.ts
+++ b/test/unit/data/backend/impl/yaml-file-storage-backend.test.ts
@@ -1,0 +1,19 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {getTmpDir} from '../../../../test-util.js';
+import {YamlFileStorageBackend} from '../../../../../src/data/backend/impl/yaml-file-storage-backend.js';
+import {expect} from 'chai';
+
+describe('YAML File Storage Backend', () => {
+  const testName: string = 'yaml-file-storage-backend';
+  const tempDir: string = getTmpDir();
+
+  it('test writeObject', async () => {
+    const key: string = `${testName}-file.yaml`;
+    const backend: YamlFileStorageBackend = new YamlFileStorageBackend(tempDir);
+    await backend.writeObject(key, {key: 'value'});
+    const data: object = await backend.readObject(key);
+    expect(data).to.be.an('object');
+    expect(data).to.deep.equal({key: 'value'});
+  });
+});

--- a/test/unit/data/backend/impl/yaml-file-storage-backend.test.ts
+++ b/test/unit/data/backend/impl/yaml-file-storage-backend.test.ts
@@ -26,4 +26,24 @@ describe('YAML File Storage Backend', () => {
     fs.writeFileSync(temporaryFile, '');
     await expect(backend.readObject(key)).to.be.rejectedWith('file is empty');
   });
+
+  it('test readObject with invalid yaml file', async () => {
+    const key: string = `${testName}-file3.yaml`;
+    const temporaryFile: string = path.join(tempDir, key);
+    const backend: YamlFileStorageBackend = new YamlFileStorageBackend(tempDir);
+    fs.writeFileSync(temporaryFile, 'playing_playlist: {{ action }} playlist {{ playlist_name }}');
+    await expect(backend.readObject(key)).to.be.rejectedWith('error parsing yaml file');
+  });
+
+  it('test writeObject with null data', async () => {
+    const key: string = `${testName}-file4.yaml`;
+    const backend: YamlFileStorageBackend = new YamlFileStorageBackend(tempDir);
+    await expect(backend.writeObject(key, null)).to.be.rejectedWith('data must not be null');
+  });
+
+  it('test writeObject with invalid key', async () => {
+    const key: string = '';
+    const backend: YamlFileStorageBackend = new YamlFileStorageBackend(tempDir);
+    await expect(backend.writeObject(key, {key: 'value'})).to.be.rejectedWith('error writing yaml file');
+  });
 });

--- a/test/unit/data/schema/model/local/local-config.test.ts
+++ b/test/unit/data/schema/model/local/local-config.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {readFileSync} from 'fs';
-import {dumpYaml, loadYaml} from '@kubernetes/client-node';
+import {parse, stringify} from 'yaml';
 import {expect} from 'chai';
 import {instanceToPlain} from 'class-transformer';
 import {SemVer} from 'semver';
@@ -33,7 +33,7 @@ describe('LocalConfig', () => {
       yamlData = readFileSync(localConfigPath, 'utf8');
       expect(yamlData).to.not.be.undefined.and.to.not.be.null;
 
-      plainObject = loadYaml<object>(yamlData);
+      plainObject = parse(yamlData);
       expect(plainObject).to.not.be.undefined.and.to.not.be.null;
     });
 
@@ -80,10 +80,10 @@ describe('LocalConfig', () => {
       const poClone = instanceToPlain(await schema.transform(plainObject));
       expect(newPlainObject).to.deep.equal(poClone);
 
-      const yaml: string = dumpYaml(newPlainObject, {sortKeys: true});
+      const yaml: string = stringify(newPlainObject, {sortMapEntries: true});
       expect(yaml).to.not.be.undefined.and.to.not.be.null;
       expect(yaml).to.not.be.empty;
-      expect(yaml).to.equal(dumpYaml(poClone, {sortKeys: true}));
+      expect(yaml).to.equal(stringify(poClone, {sortMapEntries: true}));
     });
   });
 });

--- a/test/unit/data/schema/model/local/local-config.test.ts
+++ b/test/unit/data/schema/model/local/local-config.test.ts
@@ -7,19 +7,19 @@ import {instanceToPlain} from 'class-transformer';
 import {SemVer} from 'semver';
 import {beforeEach} from 'mocha';
 import os from 'os';
-import {LocalConfig} from '../../../../../src/data/schema/model/local/local-config.js';
-import {Deployment} from '../../../../../src/data/schema/model/local/deployment.js';
-import {LocalConfigSchema} from '../../../../../src/data/schema/migration/impl/local/local-config-schema.js';
-import {CTObjectMapper} from '../../../../../src/data/mapper/impl/ct-object-mapper.js';
-import {ApplicationVersions} from '../../../../../src/data/schema/model/common/application-versions.js';
+import {LocalConfig} from '../../../../../../src/data/schema/model/local/local-config.js';
+import {Deployment} from '../../../../../../src/data/schema/model/local/deployment.js';
+import {LocalConfigSchema} from '../../../../../../src/data/schema/migration/impl/local/local-config-schema.js';
+import {CTObjectMapper} from '../../../../../../src/data/mapper/impl/ct-object-mapper.js';
+import {ApplicationVersions} from '../../../../../../src/data/schema/model/common/application-versions.js';
 import {
   HEDERA_EXPLORER_VERSION,
   HEDERA_JSON_RPC_RELAY_VERSION,
   HEDERA_PLATFORM_VERSION,
   MIRROR_NODE_VERSION,
   SOLO_CHART_VERSION,
-} from '../../../../../version.js';
-import {getSoloVersion} from '../../../../../src/core/helpers.js';
+} from '../../../../../../version.js';
+import {getSoloVersion} from '../../../../../../src/core/helpers.js';
 
 describe('LocalConfig', () => {
   const schema: LocalConfigSchema = new LocalConfigSchema(new CTObjectMapper());

--- a/test/unit/data/schema/model/remote/remote-config.test.ts
+++ b/test/unit/data/schema/model/remote/remote-config.test.ts
@@ -6,9 +6,9 @@ import {expect} from 'chai';
 import {beforeEach} from 'mocha';
 import os from 'os';
 import {instanceToPlain, plainToClass} from 'class-transformer';
-import {RemoteConfig} from '../../../../../src/data/schema/model/remote/remote-config.js';
-import {LedgerPhase} from '../../../../../src/data/schema/model/remote/ledger-phase.js';
-import {DeploymentPhase} from '../../../../../src/data/schema/model/remote/deployment-phase.js';
+import {RemoteConfig} from '../../../../../../src/data/schema/model/remote/remote-config.js';
+import {LedgerPhase} from '../../../../../../src/data/schema/model/remote/ledger-phase.js';
+import {DeploymentPhase} from '../../../../../../src/data/schema/model/remote/deployment-phase.js';
 type MigrationCandidate = any;
 
 function migrateVersionPrefix(version: string): string {

--- a/test/unit/data/schema/model/remote/remote-config.test.ts
+++ b/test/unit/data/schema/model/remote/remote-config.test.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {readFileSync} from 'fs';
-import {loadYaml} from '@kubernetes/client-node';
+import {parse} from 'yaml';
 import {expect} from 'chai';
 import {beforeEach} from 'mocha';
 import os from 'os';
@@ -150,7 +150,7 @@ describe('RemoteConfig', () => {
       yamlData = readFileSync(remoteConfigPath, 'utf8');
       expect(yamlData).to.not.be.undefined.and.to.not.be.null;
 
-      plainObject = loadYaml<MigrationCandidate>(yamlData);
+      plainObject = parse(yamlData) as MigrationCandidate;
       expect(plainObject).to.not.be.undefined.and.to.not.be.null;
 
       migrate(plainObject);


### PR DESCRIPTION
## Description

This pull request changes the following:

* added storage backend test coverage
* switched data layer class usage of `js-yaml` via `@kubernetes/client` import to `yaml` our chosen YAML library for Solo

### Related Issues

* Closes #
