### PR TITLE
fix(multi-cluster): make remote config features required

### DIFF
--- a/src/commands/account.ts
+++ b/src/commands/account.ts
@@ -325,10 +325,9 @@ export class AccountCommand extends BaseCommand {
                       const nodeId = Templates.nodeIdFromNodeAlias(nodeAlias);
                       const nodeClient = await self.accountManager.refreshNodeClient(
                         ctx.config.namespace,
-                        nodeAlias,
                         self.remoteConfigManager.getClusterRefs(),
+                        nodeAlias,
                         ctx.config.deployment,
-                        ctx.config.contextName,
                       );
 
                       try {

--- a/src/commands/deployment.ts
+++ b/src/commands/deployment.ts
@@ -402,7 +402,7 @@ export class DeploymentCommand extends BaseCommand {
             ctx.config.numberOfConsensusNodes = this.configManager.getFlag<number>(flags.numberOfConsensusNodes);
           }
 
-          ctx.config.nodeAliases = Templates.renderNodeAliasesFromCount(numberOfConsensusNodes, 0);
+          ctx.config.nodeAliases = Templates.renderNodeAliasesFromCount(ctx.config.numberOfConsensusNodes, 0);
 
           return;
         }
@@ -427,6 +427,7 @@ export class DeploymentCommand extends BaseCommand {
         else if (state === DeploymentStates.PRE_GENESIS && !numberOfConsensusNodes) {
           await this.configManager.executePrompt(task, [flags.numberOfConsensusNodes]);
           ctx.config.numberOfConsensusNodes = this.configManager.getFlag<number>(flags.numberOfConsensusNodes);
+          ctx.config.nodeAliases = Templates.renderNodeAliasesFromCount(ctx.config.numberOfConsensusNodes, 0);
         }
 
         // if the state is post-genesis and '--num-of-consensus-nodes' is specified throw

--- a/src/commands/flags.ts
+++ b/src/commands/flags.ts
@@ -19,6 +19,7 @@ import validator from 'validator';
 import {type AnyListrContext, type AnyObject, type AnyYargs} from '../types/aliases.js';
 import {type ClusterRef} from '../core/config/remote/types.js';
 import {type Optional, type SoloListrTaskWrapper} from '../types/index.js';
+import chalk from 'chalk';
 
 export class Flags {
   public static KEY_COMMON = '_COMMON_';
@@ -2240,7 +2241,25 @@ export class Flags {
       describe: 'Used to specify desired number of consensus nodes for pre-genesis deployments',
       type: 'number',
     },
-    prompt: undefined,
+    prompt: async function promptAmount(task: SoloListrTaskWrapper<AnyListrContext>, input: number): Promise<number> {
+      const promptForInput = (): Promise<number> =>
+        Flags.prompt(
+          'number',
+          task,
+          input,
+          Flags.numberOfConsensusNodes.definition.defaultValue,
+          `Enter number of consensus nodes ${chalk.grey('(must be a positive number)')}:`,
+          null,
+          Flags.numberOfConsensusNodes.name,
+        );
+
+      input = await promptForInput();
+      while (!input) {
+        input = await promptForInput();
+      }
+
+      return input;
+    },
   };
 
   public static readonly dnsBaseDomain: CommandFlag = {

--- a/src/commands/flags.ts
+++ b/src/commands/flags.ts
@@ -2241,14 +2241,14 @@ export class Flags {
       describe: 'Used to specify desired number of consensus nodes for pre-genesis deployments',
       type: 'number',
     },
-    prompt: async function promptAmount(task: SoloListrTaskWrapper<AnyListrContext>, input: number): Promise<number> {
+    prompt: async function (task: SoloListrTaskWrapper<AnyListrContext>, input: number): Promise<number> {
       const promptForInput = (): Promise<number> =>
         Flags.prompt(
           'number',
           task,
           input,
           Flags.numberOfConsensusNodes.definition.defaultValue,
-          `Enter number of consensus nodes ${chalk.grey('(must be a positive number)')}:`,
+          `Enter number of consensus nodes to add to the provided cluster ${chalk.grey('(must be a positive number)')}:`,
           null,
           Flags.numberOfConsensusNodes.name,
         );

--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -633,6 +633,7 @@ export class NetworkCommand extends BaseCommand {
       flags.gcsEndpoint,
       flags.gcsBucket,
       flags.gcsBucketPrefix,
+      flags.nodeAliasesUnparsed,
     ];
 
     // disable the prompts that we don't want to prompt the user for

--- a/src/core/account-manager.ts
+++ b/src/core/account-manager.ts
@@ -180,8 +180,8 @@ export class AccountManager {
    */
   public async loadNodeClient(
     namespace: NamespaceName,
-    clusterRefs?: ClusterRefs,
-    deployment?: DeploymentName,
+    clusterRefs: ClusterRefs,
+    deployment: DeploymentName,
     forcePortForward?: boolean,
     context?: string,
   ) {
@@ -193,7 +193,7 @@ export class AccountManager {
         this.logger.debug(
           `refreshing node client: [!this._nodeClient=${!this._nodeClient}, this._nodeClient.isClientShutDown=${this._nodeClient?.isClientShutDown}]`,
         );
-        await this.refreshNodeClient(namespace, undefined, clusterRefs, deployment, context, forcePortForward);
+        await this.refreshNodeClient(namespace, clusterRefs, undefined, deployment, forcePortForward);
       } else {
         try {
           if (!constants.SKIP_NODE_PING) {
@@ -201,7 +201,7 @@ export class AccountManager {
           }
         } catch {
           this.logger.debug('node client ping failed, refreshing node client');
-          await this.refreshNodeClient(namespace, undefined, clusterRefs, deployment, context, forcePortForward);
+          await this.refreshNodeClient(namespace, clusterRefs, undefined, deployment, forcePortForward);
         }
       }
 
@@ -218,15 +218,13 @@ export class AccountManager {
    * @param skipNodeAlias - the node alias to skip
    * @param [clusterRefs]
    * @param [deployment]
-   * @param [context]
    * @param forcePortForward - whether to force the port forward
    */
   async refreshNodeClient(
     namespace: NamespaceName,
+    clusterRefs: ClusterRefs,
     skipNodeAlias?: NodeAlias,
-    clusterRefs?: ClusterRefs,
     deployment?: DeploymentName,
-    context?: string,
     forcePortForward?: boolean,
   ) {
     try {

--- a/src/core/config/local-config.ts
+++ b/src/core/config/local-config.ts
@@ -9,7 +9,6 @@ import {MissingArgumentError} from '../errors/missing-argument-error.js';
 import {SoloError} from '../errors/solo-error.js';
 import {type SoloLogger} from '../logging.js';
 import {IsClusterRefs, IsDeployments} from '../validator-decorators.js';
-import {type ConfigManager} from '../config-manager.js';
 import {type EmailAddress, type Version, type ClusterRefs, type ClusterRef} from './remote/types.js';
 import {ErrorMessages} from '../error-messages.js';
 import * as helpers from '../helpers.js';
@@ -20,12 +19,7 @@ import {InjectTokens} from '../dependency-injection/inject-tokens.js';
 
 @injectable()
 export class LocalConfig implements LocalConfigData {
-  @IsEmail(
-    {},
-    {
-      message: ErrorMessages.LOCAL_CONFIG_INVALID_EMAIL,
-    },
-  )
+  @IsEmail({}, {message: ErrorMessages.LOCAL_CONFIG_INVALID_EMAIL})
   userEmailAddress: EmailAddress;
 
   @IsString({message: ErrorMessages.LOCAL_CONFIG_INVALID_SOLO_VERSION})
@@ -34,18 +28,12 @@ export class LocalConfig implements LocalConfigData {
 
   // The string is the name of the deployment, will be used as the namespace,
   // so it needs to be available in all targeted clusters
-  @IsDeployments({
-    message: ErrorMessages.LOCAL_CONFIG_INVALID_DEPLOYMENTS_FORMAT,
-  })
+  @IsDeployments({message: ErrorMessages.LOCAL_CONFIG_INVALID_DEPLOYMENTS_FORMAT})
   @IsNotEmpty()
-  @IsObject({
-    message: ErrorMessages.LOCAL_CONFIG_INVALID_DEPLOYMENTS_FORMAT,
-  })
+  @IsObject({message: ErrorMessages.LOCAL_CONFIG_INVALID_DEPLOYMENTS_FORMAT})
   public deployments: Deployments;
 
-  @IsClusterRefs({
-    message: ErrorMessages.LOCAL_CONFIG_CONTEXT_CLUSTER_MAPPING_FORMAT,
-  })
+  @IsClusterRefs({message: ErrorMessages.LOCAL_CONFIG_CONTEXT_CLUSTER_MAPPING_FORMAT})
   @IsNotEmpty()
   public clusterRefs: ClusterRefs = {};
 
@@ -54,11 +42,9 @@ export class LocalConfig implements LocalConfigData {
   public constructor(
     @inject(InjectTokens.LocalConfigFilePath) private readonly filePath?: string,
     @inject(InjectTokens.SoloLogger) private readonly logger?: SoloLogger,
-    @inject(InjectTokens.ConfigManager) private readonly configManager?: ConfigManager,
   ) {
     this.filePath = patchInject(filePath, InjectTokens.LocalConfigFilePath, this.constructor.name);
     this.logger = patchInject(logger, InjectTokens.SoloLogger, this.constructor.name);
-    this.configManager = patchInject(configManager, InjectTokens.ConfigManager, this.constructor.name);
 
     if (!this.filePath || this.filePath === '') throw new MissingArgumentError('a valid filePath is required');
 
@@ -142,6 +128,10 @@ export class LocalConfig implements LocalConfigData {
     this.logger.info(`Wrote local config to ${this.filePath}: ${yamlContent}`);
   }
 
+  /**
+   * Creates local config without cluster-refs and deployments.
+   * Prompts for email if not supplied or already in local config
+   */
   public createLocalConfigTask(): SoloListrTask<{
     config: {
       quiet: boolean;

--- a/src/core/resolvers.ts
+++ b/src/core/resolvers.ts
@@ -5,17 +5,17 @@ import {type DeploymentName} from './config/remote/types.js';
 import {type ConfigManager} from './config-manager.js';
 import {Flags as flags} from '../commands/flags.js';
 import {NamespaceName} from './kube/resources/namespace/namespace-name.js';
-import {type Optional, type SoloListrTaskWrapper} from '../types/index.js';
+import {type SoloListrTaskWrapper} from '../types/index.js';
 import {input as inputPrompt} from '@inquirer/prompts';
 import {SoloError} from './errors/solo-error.js';
+import {type AnyListrContext} from '../types/aliases.js';
 
 export async function resolveNamespaceFromDeployment(
   localConfig: LocalConfig,
   configManager: ConfigManager,
-  task?: SoloListrTaskWrapper<any>,
+  task?: SoloListrTaskWrapper<AnyListrContext>,
 ): Promise<NamespaceName> {
-  await promptTheUserForDeployment(configManager, task);
-  const deploymentName = configManager.getFlag<DeploymentName>(flags.deployment);
+  const deploymentName: DeploymentName = await promptTheUserForDeployment(configManager, task);
 
   if (!localConfig.deployments.hasOwnProperty(deploymentName)) {
     throw new SoloError(
@@ -28,8 +28,8 @@ export async function resolveNamespaceFromDeployment(
 
 export async function promptTheUserForDeployment(
   configManager: ConfigManager,
-  task?: SoloListrTaskWrapper<any>,
-): Promise<Optional<DeploymentName>> {
+  task?: SoloListrTaskWrapper<AnyListrContext>,
+): Promise<DeploymentName> {
   if (configManager.getFlag(flags.deployment)) {
     return configManager.getFlag<DeploymentName>(flags.deployment);
   }

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -382,8 +382,8 @@ export function balanceQueryShouldSucceed(
 
       await accountManager.refreshNodeClient(
         namespace,
-        skipNodeAlias,
         remoteConfigManager.getClusterRefs(),
+        skipNodeAlias,
         argv.getArg<DeploymentName>(flags.deployment),
       );
       expect(accountManager._nodeClient).not.to.be.null;
@@ -413,8 +413,8 @@ export function accountCreationShouldSucceed(
       const argv = Argv.getDefaultArgv(namespace);
       await accountManager.refreshNodeClient(
         namespace,
-        skipNodeAlias,
         remoteConfigManager.getClusterRefs(),
+        skipNodeAlias,
         argv.getArg<DeploymentName>(flags.deployment),
       );
       expect(accountManager._nodeClient).not.to.be.null;

--- a/test/unit/core/local-config.test.ts
+++ b/test/unit/core/local-config.test.ts
@@ -119,7 +119,7 @@ describe('LocalConfig', () => {
     expect(localConfig.clusterRefs).to.eq(newClusterMappings);
 
     await localConfig.write();
-    const newConfig = new LocalConfig(filePath, getTestLogger(), configManager);
+    const newConfig = new LocalConfig(filePath, getTestLogger());
     expect(newConfig.clusterRefs).to.deep.eq(newClusterMappings);
   });
 


### PR DESCRIPTION
## Description

* Removes conditional logic assuming the remote config and its components might be missing
* Fixes bug when prompting for `--num-consensus-nodes` has no effect 

### Related Issues

* Closes # https://github.com/hashgraph/solo/issues/1663
