### PR TITLE
fix: updated GitHub Pages docs, fixed `solo deployment create` to prompt for additional flags

### DIFF
--- a/.github/workflows/flow-hugo-publish.yaml
+++ b/.github/workflows/flow-hugo-publish.yaml
@@ -23,7 +23,7 @@ on:
   # Runs on pushes targeting the default branch
   push:
     branches:
-      - main
+      - release/0.35
     paths:
       - '**/*.mjs'
       - '**/*.js'
@@ -102,20 +102,20 @@ jobs:
       # Upload the built site to GitHub Pages
       - name: Upload Pages Artifact
         uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3.0.1
-        if: ${{ endsWith(github.ref, 'main') }}
+        if: ${{ endsWith(github.ref, 'release/0.35') }}
         with:
           path: ./docs/public
 
       # Upload the built site to artifacts for troubleshooting or verification
       - name: Upload Artifact
         uses: actions/upload-artifact@65c4c4a1ddee5b72f698fdd19549f0f0fb45cf08 # v4.6.0
-        if: ${{ !endsWith(github.ref, 'main') }}
+        if: ${{ !endsWith(github.ref, 'release/0.35') }}
         with:
           path: ./docs/public
 
   # Deployment job
   Deploy:
-    if: ${{ endsWith(github.ref, 'main') }}
+    if: ${{ endsWith(github.ref, 'release/0.35') }}
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/script/update_md.sh
+++ b/.github/workflows/script/update_md.sh
@@ -5,12 +5,11 @@
 
 set -xeo pipefail
 
-if [[ -z "${SOLO_TEST_CLUSTER}" && ${SOLO_CLUSTER_NAME} != "" ]]; then
+if [[ -z "${SOLO_TEST_CLUSTER}" ]]; then
   SOLO_CLUSTER_NAME=solo-e2e
 else
   SOLO_CLUSTER_NAME=${SOLO_TEST_CLUSTER}
 fi
-
 export SOLO_NAMESPACE=solo
 export SOLO_DEPLOYMENT=solo-deployment
 export SOLO_CLUSTER_SETUP_NAMESPACE=solo-cluster
@@ -45,6 +44,9 @@ export SOLO_NODE_START_OUTPUT=$( cat node-start.log | tee test.log )
 solo mirror-node deploy --deployment "${SOLO_DEPLOYMENT}" | tee mirror-node-deploy.log
 export SOLO_MIRROR_NODE_DEPLOY_OUTPUT=$( cat mirror-node-deploy.log | tee test.log )
 
+solo explorer deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME} | tee explorer-deploy.log
+export SOLO_EXPLORER_DEPLOY_OUTPUT=$( cat explorer-deploy.log | tee test.log )
+
 solo relay deploy -i node1,node2,node3 --deployment "${SOLO_DEPLOYMENT}" | tee relay-deploy.log
 export SOLO_RELAY_DEPLOY_OUTPUT=$( cat relay-deploy.log | tee test.log )
 
@@ -52,7 +54,7 @@ echo "Generate README.md"
 
 envsubst '$KIND_CREATE_CLUSTER_OUTPUT,$SOLO_INIT_OUTPUT,$SOLO_NODE_KEY_PEM_OUTPUT,$SOLO_CLUSTER_SETUP_OUTPUT, \
 $SOLO_DEPLOYMENT_CREATE_OUTPUT,$SOLO_NETWORK_DEPLOY_OUTPUT,$SOLO_NODE_SETUP_OUTPUT,$SOLO_NODE_START_OUTPUT,\
-$SOLO_MIRROR_NODE_DEPLOY_OUTPUT,$SOLO_RELAY_DEPLOY_OUTPUT'\
+$SOLO_MIRROR_NODE_DEPLOY_OUTPUT,$SOLO_EXPLORER_DEPLOY_OUTPUT,$SOLO_RELAY_DEPLOY_OUTPUT'\
 < docs/content/User/StepByStepGuide.md.template > docs/content/User/StepByStepGuide.md
 
 echo "Remove color codes and lines showing intermediate progress"

--- a/.gitignore
+++ b/.gitignore
@@ -482,3 +482,5 @@ deleteme.yaml
 /docs/.hugo_build.lock
 /docs/public/
 /contextDir/
+/docs/content/User/README/images/DockerDesktop.png
+/docs/content/User/README/index.md

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ nvm use v20.18.0
 
 ## Documentation
 
-[Getting Started](https://hashgraph.github.io/solo/)
+[Getting Started](https://hashgraph.github.io/solo/User/StepByStepGuide)
 
 ## Support
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,6 @@
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/83a423a3a1c942459127b3aec62ab0b5)](https://app.codacy.com/gh/hashgraph/solo/dashboard?utm_source=gh\&utm_medium=referral\&utm_content=\&utm_campaign=Badge_grade)
 [![codecov](https://codecov.io/gh/hashgraph/solo/graph/badge.svg?token=hBkQdB1XO5)](https://codecov.io/gh/hashgraph/solo)
 
-> \[!WARNING]
-> SPECIAL NOTICE: Introducing v0.32.0 comes with BREAKING CHANGES.  We have removed caching of the flags in the solo config file.  All commands will need required flags or user will need to answer the prompts.  See more details in our release notes: [release/tag/v0.32.0](https://github.com/hashgraph/solo/releases/tag/v0.32.0)
-
 An opinionated CLI tool to deploy and manage standalone test networks.
 
 ## Requirements

--- a/docs/content/Developer/Development/TaskTool.md
+++ b/docs/content/Developer/Development/TaskTool.md
@@ -1,6 +1,6 @@
 ## Use the Task tool to launch Solo
 
-For users who want to quickly deploy a standalone solo network without need to know what is under the hood,
+For developers who want to quickly deploy a standalone solo network without need to know what is under the hood,
 they can use the Task tool to launch the network with a single command.
 
 First, install the cluster tool `kind` with this [link](https://kind.sigs.k8s.io/docs/user/quick-start#installation)
@@ -11,7 +11,7 @@ Then, install the task tool `task` with this [link](https://taskfile.dev/install
 
 ### Start solo network
 
-User can use one of the following three commands to quickly deploy a standalone solo network.
+The developer can use one of the following three commands to quickly deploy a standalone solo network.
 
 ```bash
 # Option 1) deploy solo network with two nodes `task` is the same as `task default`

--- a/docs/content/User/AccessHederaServices.md
+++ b/docs/content/User/AccessHederaServices.md
@@ -1,5 +1,8 @@
 ## Access Hedera Network Services
 
+> **⚠️ Warning**
+> This document is out of date for the current release.  See [Step-by-step Guide](./StepByStepGuide.md) for the updated base commands to run that can be augmented with the extra flags and values provided in this guide. Hedera services and Platform SDK have moved to hiero-consensus-node repo <https://github.com/hiero-ledger/hiero-consensus-node>
+
 Once the nodes are up, you may now expose various services (using `k9s` (shift-f) or `kubectl port-forward`) and access. Below are most used services that you may expose.
 
 * Node services: `network-<node ID>-svc`

--- a/docs/content/User/DebugLog/index.md
+++ b/docs/content/User/DebugLog/index.md
@@ -1,5 +1,8 @@
 ## How to debug Hedera Services and Platform SDK
 
+> **⚠️ Warning**
+> This document is out of date for the current release.  See [Step-by-step Guide](../StepByStepGuide.md) for the updated base commands to run that can be augmented with the extra flags and values provided in this guide. Hedera services and Platform SDK have moved to hiero-consensus-node repo <https://github.com/hiero-ledger/hiero-consensus-node>
+
 ### 1. Using k9s to access running network nodes logs
 
 Running the command `k9s -A` in terminal, and select one of the network nodes:

--- a/docs/content/User/FAQ.md
+++ b/docs/content/User/FAQ.md
@@ -1,3 +1,6 @@
+> **⚠️ Warning**
+> This document is out of date for the current release.  See [Step-by-step Guide](./StepByStepGuide.md) for the updated base commands to run that can be augmented with the extra flags and values provided in this guide. Hedera services and Platform SDK have moved to hiero-consensus-node repo <https://github.com/hiero-ledger/hiero-consensus-node>
+
 ### How can I avoid using genesis keys ?
 
 You can run `solo account init` anytime after `solo node start`

--- a/docs/content/User/GetStarted.md
+++ b/docs/content/User/GetStarted.md
@@ -2,7 +2,7 @@
 
 Quick start:
 
-* [Start solo network with single command](TaskTool.md)
+* [Start solo network with single command](../Developer/Development/TaskTool.md)
 
 For Developers working on Hedera Application and platform development:
 

--- a/docs/content/User/HederaDeveloper.md
+++ b/docs/content/User/HederaDeveloper.md
@@ -1,5 +1,8 @@
 ### Use solo with local build hedera service code
 
+> **⚠️ Warning**
+> This document is out of date for the current release.  See [Step-by-step Guide](./StepByStepGuide.md) for the updated base commands to run that can be augmented with the extra flags and values provided in this guide. Hedera services and Platform SDK have moved to hiero-consensus-node repo <https://github.com/hiero-ledger/hiero-consensus-node>
+
 First, please clone hedera service repo `https://github.com/hashgraph/hedera-services/` and build the code
 with `./gradlew assemble`. If need to running multiple nodes with different versions or releases, please duplicate the repo or build directories in
 multiple directories, checkout to the respective version and build the code.

--- a/docs/content/User/PlatformDeveloper.md
+++ b/docs/content/User/PlatformDeveloper.md
@@ -1,5 +1,8 @@
 ### Use solo with local build platform code
 
+> **⚠️ Warning**
+> This document is out of date for the current release.  See [Step-by-step Guide](./StepByStepGuide.md) for the updated base commands to run that can be augmented with the extra flags and values provided in this guide. Hedera services and Platform SDK have moved to hiero-consensus-node repo <https://github.com/hiero-ledger/hiero-consensus-node>
+
 First, please clone hedera service repo `https://github.com/hashgraph/hedera-services/` and build the code
 with `./gradlew assemble`. If need to running nodes with different versions or releases, please duplicate the repo or build directories in
 multiple directories, checkout to the respective version and build the code.

--- a/docs/content/User/SDK.md
+++ b/docs/content/User/SDK.md
@@ -1,5 +1,8 @@
 # Using Solo with Hedera JavaScript SDK
 
+> **⚠️ Warning**
+> This document is out of date for the current release.  See [Step-by-step Guide](./StepByStepGuide.md) for the updated base commands to run that can be augmented with the extra flags and values provided in this guide. Hedera services and Platform SDK have moved to hiero-consensus-node repo <https://github.com/hiero-ledger/hiero-consensus-node>
+
 First, please follow solo repository README to install solo and Docker Desktop.
 You also need to install the Taskfile tool following the instructions [here](https://taskfile.dev/installation/).
 

--- a/docs/content/User/SoloCLI.md
+++ b/docs/content/User/SoloCLI.md
@@ -1,5 +1,8 @@
 # Solo command line user manual
 
+> **⚠️ Warning**
+> This document is out of date for the current release.  See [Step-by-step Guide](./StepByStepGuide.md) for the updated base commands to run that can be augmented with the extra flags and values provided in this guide. Hedera services and Platform SDK have moved to hiero-consensus-node repo <https://github.com/hiero-ledger/hiero-consensus-node>
+
 Solo has a series of commands to use, and some commands have subcommands.
 User can get help information by running with the following methods:
 

--- a/docs/content/User/SoloWithMirrorNode.md
+++ b/docs/content/User/SoloWithMirrorNode.md
@@ -24,7 +24,7 @@ kubectl port-forward svc/hedera-explorer -n "${SOLO_NAMESPACE}" 8080:80 > /dev/n
 
 Then you can access the hedera explorer at `http://localhost:8080`
 
-Or you can use Task tool to deploy solo network with mirror node with a single command [link](TaskTool.md)
+Or you can use Task tool to deploy solo network with mirror node with a single command [link](../Developer/Development/TaskTool.md)
 
 Next, you can try to create a few accounts with solo and see the transactions in the explorer.
 

--- a/docs/content/User/SoloWithMirrorNode.md
+++ b/docs/content/User/SoloWithMirrorNode.md
@@ -1,5 +1,8 @@
 ## Using Solo with mirror node
 
+> **⚠️ Warning**
+> This document is out of date for the current release.  See [Step-by-step Guide](./StepByStepGuide.md) for the updated base commands to run that can be augmented with the extra flags and values provided in this guide. Hedera services and Platform SDK have moved to hiero-consensus-node repo <https://github.com/hiero-ledger/hiero-consensus-node>
+
 User can deploy a solo network with mirror node by running the following command:
 
 ```bash

--- a/docs/content/User/StepByStepGuide.md
+++ b/docs/content/User/StepByStepGuide.md
@@ -4,6 +4,7 @@ For those who would like to have more control or need some customized setups, he
 NOTE: for cleanup from previous runs, you may need to run the following command:
 ```
 rm -Rf ~/.solo
+kind delete cluster -n "${SOLO_CLUSTER_NAME}"
 ```
 
 ### Setup Kubernetes cluster
@@ -55,7 +56,7 @@ You can now use your cluster with:
 
 kubectl cluster-info --context kind-solo-e2e
 
-Have a question, bug, or feature request? Let us know! https://kind.sigs.k8s.io/#community 🙂
+Not sure what to do next? 😅  Check out https://kind.sigs.k8s.io/docs/user/quick-start/
 ```
 
 You may now view pods in your cluster using `k9s -A` as below:
@@ -104,7 +105,7 @@ solo init
 ```
 
 ******************************* Solo *********************************************
-Version			: 0.35.1
+Version			: 0.35.2
 Kubernetes Context	: kind-solo-e2e
 Kubernetes Cluster	: kind-solo-e2e
 Current Command		: init
@@ -137,7 +138,7 @@ solo node keys --gossip-keys --tls-keys -i node1,node2,node3
 ```
 
 ******************************* Solo *********************************************
-Version			: 0.35.1
+Version			: 0.35.2
 Kubernetes Context	: kind-solo-e2e
 Kubernetes Cluster	: kind-solo-e2e
 Current Command		: node keys --gossip-keys --tls-keys --node-aliases node1,node2,node3
@@ -160,9 +161,9 @@ Current Command		: node keys --gossip-keys --tls-keys --node-aliases node1,node2
 ❯ TLS key for node: node2
 ❯ TLS key for node: node3
 ✔ Backup old files
-✔ TLS key for node: node2
 ✔ TLS key for node: node3
 ✔ TLS key for node: node1
+✔ TLS key for node: node2
 ✔ Generate gRPC TLS Keys
 ❯ Finalize
 ✔ Finalize
@@ -178,7 +179,7 @@ hedera-node2.key    hedera-node4.key    s-private-node4.pem s-public-node4.pem
 * Create a deployment in the specified clusters, generate RemoteConfig and LocalConfig objects.
 
 ```
-solo deployment create -n "${SOLO_NAMESPACE}" --context kind-${SOLO_CLUSTER_SETUP_NAMESPACE} --email "${SOLO_EMAIL}" --deployment-clusters kind-${SOLO_CLUSTER_SETUP_NAMESPACE} --deployment "${SOLO_DEPLOYMENT}"
+solo deployment create -n "${SOLO_NAMESPACE}" --context kind-${SOLO_CLUSTER_NAME} --email "${SOLO_EMAIL}" --deployment-clusters kind-${SOLO_CLUSTER_NAME} --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 * Example output
@@ -186,7 +187,7 @@ solo deployment create -n "${SOLO_NAMESPACE}" --context kind-${SOLO_CLUSTER_SETU
 ```
 
 ******************************* Solo *********************************************
-Version			: 0.35.1
+Version			: 0.35.2
 Kubernetes Context	: kind-solo-e2e
 Kubernetes Cluster	: kind-solo-e2e
 Current Command		: deployment create --node-aliases node1,node2,node3 --namespace solo --context kind-solo-e2e --email john@doe.com --deployment-clusters kind-solo-e2e --deployment solo-deployment
@@ -227,7 +228,7 @@ solo cluster setup -s "${SOLO_CLUSTER_SETUP_NAMESPACE}"
 ```
 
 ******************************* Solo *********************************************
-Version			: 0.35.1
+Version			: 0.35.2
 Kubernetes Context	: kind-solo-e2e
 Kubernetes Cluster	: kind-solo-e2e
 Current Command		: cluster setup --cluster-setup-namespace solo-cluster
@@ -257,7 +258,7 @@ solo network deploy -i node1,node2,node3 --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 ******************************* Solo *********************************************
-Version			: 0.35.1
+Version			: 0.35.2
 Kubernetes Context	: kind-solo-e2e
 Kubernetes Cluster	: kind-solo-e2e
 Current Command		: network deploy --node-aliases node1,node2,node3 --deployment solo-deployment
@@ -284,9 +285,9 @@ Current Command		: network deploy --node-aliases node1,node2,node3 --deployment 
 ❯ Copy Gossip keys
 ❯ Copy Gossip keys
 ❯ Copy Gossip keys
+✔ Copy TLS keys
 ✔ Copy Gossip keys
 ✔ Node: node1, cluster: kind-solo-e2e
-✔ Copy TLS keys
 ✔ Copy Gossip keys
 ✔ Node: node2, cluster: kind-solo-e2e
 ✔ Copy Gossip keys
@@ -314,11 +315,11 @@ Current Command		: network deploy --node-aliases node1,node2,node3 --deployment 
 ❯ Check Envoy Proxy for: node2, cluster: kind-solo-e2e
 ❯ Check Envoy Proxy for: node3, cluster: kind-solo-e2e
 ✔ Check Envoy Proxy for: node3, cluster: kind-solo-e2e
-✔ Check HAProxy for: node3, cluster: kind-solo-e2e
 ✔ Check HAProxy for: node2, cluster: kind-solo-e2e
-✔ Check Envoy Proxy for: node1, cluster: kind-solo-e2e
 ✔ Check HAProxy for: node1, cluster: kind-solo-e2e
+✔ Check HAProxy for: node3, cluster: kind-solo-e2e
 ✔ Check Envoy Proxy for: node2, cluster: kind-solo-e2e
+✔ Check Envoy Proxy for: node1, cluster: kind-solo-e2e
 ✔ Check proxy pods are running
 ❯ Check auxiliary pods are ready
 ❯ Check MinIO
@@ -340,7 +341,7 @@ solo node setup -i node1,node2,node3 --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 ******************************* Solo *********************************************
-Version			: 0.35.1
+Version			: 0.35.2
 Kubernetes Context	: kind-solo-e2e
 Kubernetes Cluster	: kind-solo-e2e
 Current Command		: node setup --node-aliases node1,node2,node3 --deployment solo-deployment
@@ -370,8 +371,8 @@ Current Command		: node setup --node-aliases node1,node2,node3 --deployment solo
 ❯ Update node: node2 [ platformVersion = v0.58.10, context = kind-solo-e2e ]
 ❯ Update node: node3 [ platformVersion = v0.58.10, context = kind-solo-e2e ]
 ✔ Update node: node1 [ platformVersion = v0.58.10, context = kind-solo-e2e ]
-✔ Update node: node3 [ platformVersion = v0.58.10, context = kind-solo-e2e ]
 ✔ Update node: node2 [ platformVersion = v0.58.10, context = kind-solo-e2e ]
+✔ Update node: node3 [ platformVersion = v0.58.10, context = kind-solo-e2e ]
 ✔ Fetch platform software into network nodes
 ❯ Setup network nodes
 ❯ Node: node1
@@ -408,7 +409,7 @@ solo node start -i node1,node2,node3 --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 ******************************* Solo *********************************************
-Version			: 0.35.1
+Version			: 0.35.2
 Kubernetes Context	: kind-solo-e2e
 Kubernetes Cluster	: kind-solo-e2e
 Current Command		: node start --node-aliases node1,node2,node3 --deployment solo-deployment
@@ -429,8 +430,8 @@ Current Command		: node start --node-aliases node1,node2,node3 --deployment solo
 ❯ Check network pod: node1
 ❯ Check network pod: node2
 ❯ Check network pod: node3
-✔ Check network pod: node2
 ✔ Check network pod: node1
+✔ Check network pod: node2
 ✔ Check network pod: node3
 ✔ Identify existing network nodes
 ❯ Upload state files network nodes
@@ -439,9 +440,9 @@ Current Command		: node start --node-aliases node1,node2,node3 --deployment solo
 ❯ Start node: node1
 ❯ Start node: node2
 ❯ Start node: node3
-✔ Start node: node2
-✔ Start node: node3
 ✔ Start node: node1
+✔ Start node: node3
+✔ Start node: node2
 ✔ Starting nodes
 ❯ Enable port forwarding for JVM debugger
 ↓ Enable port forwarding for JVM debugger [SKIPPED: Enable port forwarding for JVM debugger]
@@ -449,9 +450,9 @@ Current Command		: node start --node-aliases node1,node2,node3 --deployment solo
 ❯ Check network pod: node1 
 ❯ Check network pod: node2 
 ❯ Check network pod: node3 
+✔ Check network pod: node2  - status ACTIVE, attempt: 18/300
+✔ Check network pod: node3  - status ACTIVE, attempt: 18/300
 ✔ Check network pod: node1  - status ACTIVE, attempt: 18/300
-✔ Check network pod: node2  - status ACTIVE, attempt: 19/300
-✔ Check network pod: node3  - status ACTIVE, attempt: 19/300
 ✔ Check all nodes are ACTIVE
 ❯ Check node proxies are ACTIVE
 ❯ Check proxy for node: node1
@@ -484,7 +485,7 @@ solo mirror-node deploy --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 ******************************* Solo *********************************************
-Version			: 0.35.1
+Version			: 0.35.2
 Kubernetes Context	: kind-solo-e2e
 Kubernetes Cluster	: kind-solo-e2e
 Current Command		: mirror-node deploy --deployment solo-deployment
@@ -505,9 +506,9 @@ Current Command		: mirror-node deploy --deployment solo-deployment
 ❯ Check GRPC
 ❯ Check Monitor
 ❯ Check Importer
-✔ Check Monitor
 ✔ Check Postgres DB
 ✔ Check GRPC
+✔ Check Monitor
 ✔ Check Importer
 ✔ Check REST API
 ✔ Check pods are ready
@@ -517,6 +518,40 @@ Current Command		: mirror-node deploy --deployment solo-deployment
 ✔ Seed DB data
 ❯ Add mirror node to remote config
 ✔ Add mirror node to remote config
+```
+
+* Deploy Hedera Explorer
+
+```
+solo explorer deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME}
+```
+
+* Example output
+
+```
+
+******************************* Solo *********************************************
+Version			: 0.35.2
+Kubernetes Context	: kind-solo-e2e
+Kubernetes Cluster	: kind-solo-e2e
+Current Command		: explorer deploy --deployment solo-deployment --cluster-ref kind-solo-e2e
+**********************************************************************************
+❯ Initialize
+❯ Acquire lease
+✔ Acquire lease - lease acquired successfully, attempt: 1/10
+✔ Initialize
+❯ Load remote config
+✔ Load remote config
+❯ Upgrade solo-setup chart
+↓ Upgrade solo-setup chart [SKIPPED: Upgrade solo-setup chart]
+❯ Install explorer
+✔ Install explorer
+❯ Check explorer pod is ready
+✔ Check explorer pod is ready
+❯ Check haproxy ingress controller pod is ready
+↓ Check haproxy ingress controller pod is ready [SKIPPED: Check haproxy ingress controller pod is ready]
+❯ Add explorer to remote config
+✔ Add explorer to remote config
 ```
 
 * Deploy a JSON RPC relay
@@ -530,7 +565,7 @@ solo relay deploy -i node1,node2,node3 --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 ******************************* Solo *********************************************
-Version			: 0.35.1
+Version			: 0.35.2
 Kubernetes Context	: kind-solo-e2e
 Kubernetes Cluster	: kind-solo-e2e
 Current Command		: relay deploy --node-aliases node1,node2,node3 --deployment solo-deployment

--- a/docs/content/User/StepByStepGuide.md
+++ b/docs/content/User/StepByStepGuide.md
@@ -31,19 +31,25 @@ kind create cluster -n "${SOLO_CLUSTER_NAME}"
 Example output
 
 ```
-Creating cluster "solo-update-readme-13489128394-1" ...
- ✓ Ensuring node image (kindest/node:v1.32.0) 🖼
+Creating cluster "solo-e2e" ...
+ • Ensuring node image (kindest/node:v1.32.2) 🖼  ...
+ ✓ Ensuring node image (kindest/node:v1.32.2) 🖼
+ • Preparing nodes 📦   ...
  ✓ Preparing nodes 📦 
+ • Writing configuration 📜  ...
  ✓ Writing configuration 📜
+ • Starting control-plane 🕹️  ...
  ✓ Starting control-plane 🕹️
+ • Installing CNI 🔌  ...
  ✓ Installing CNI 🔌
+ • Installing StorageClass 💾  ...
  ✓ Installing StorageClass 💾
-Set kubectl context to "kind-solo-update-readme-13489128394-1"
+Set kubectl context to "kind-solo-e2e"
 You can now use your cluster with:
 
-kubectl cluster-info --context kind-solo-update-readme-13489128394-1
+kubectl cluster-info --context kind-solo-e2e
 
-Not sure what to do next? 😅  Check out https://kind.sigs.k8s.io/docs/user/quick-start/
+Have a question, bug, or feature request? Let us know! https://kind.sigs.k8s.io/#community 🙂
 ```
 
 You may now view pods in your cluster using `k9s -A` as below:
@@ -93,20 +99,25 @@ solo init
 
 ******************************* Solo *********************************************
 Version			: 0.35.1
-Kubernetes Context	: kind-solo-update-readme-13489128394-1
-Kubernetes Cluster	: kind-solo-update-readme-13489128394-1
+Kubernetes Context	: kind-solo-e2e
+Kubernetes Cluster	: kind-solo-e2e
 Current Command		: init
 **********************************************************************************
-✔ Setup home directory and cache
-✔ Check dependency: helm [OS: linux, Release: 5.15.0-131-generic, Arch: x64]
-✔ Check dependencies
-✔ Setup chart manager
+❯ Setup home directory and cache
+✔ Setup home directory and cache
+❯ Check dependencies
+❯ Check dependency: helm [OS: darwin, Release: 23.6.0, Arch: arm64]
+✔ Check dependency: helm [OS: darwin, Release: 23.6.0, Arch: arm64]
+✔ Check dependencies
+❯ Setup chart manager
+✔ Setup chart manager
+❯ Copy templates in '/Users/user/.solo/cache'
 
 ***************************************************************************************
-Note: solo stores various artifacts (config, logs, keys etc.) in its home directory: /home/runner/.solo
+Note: solo stores various artifacts (config, logs, keys etc.) in its home directory: /Users/user/.solo
 If a full reset is needed, delete the directory or relevant sub-directories before running 'solo init'.
 ***************************************************************************************
-✔ Copy templates in '/home/runner/.solo/cache'
+✔ Copy templates in '/Users/user/.solo/cache'
 ```
 
 * Generate `pem` formatted node keys
@@ -121,22 +132,34 @@ solo node keys --gossip-keys --tls-keys -i node1,node2,node3
 
 ******************************* Solo *********************************************
 Version			: 0.35.1
-Kubernetes Context	: kind-solo-update-readme-13489128394-1
-Kubernetes Cluster	: kind-solo-update-readme-13489128394-1
+Kubernetes Context	: kind-solo-e2e
+Kubernetes Cluster	: kind-solo-e2e
 Current Command		: node keys --gossip-keys --tls-keys --node-aliases node1,node2,node3
 **********************************************************************************
-✔ Initialize
-✔ Backup old files
-✔ Gossip key for node: node1
-✔ Gossip key for node: node2
-✔ Gossip key for node: node3
-✔ Generate gossip keys
-✔ Backup old files
-✔ TLS key for node: node1
-✔ TLS key for node: node3
-✔ TLS key for node: node2
-✔ Generate gRPC TLS Keys
-✔ Finalize
+❯ Initialize
+✔ Initialize
+❯ Generate gossip keys
+❯ Backup old files
+✔ Backup old files
+❯ Gossip key for node: node1
+✔ Gossip key for node: node1
+❯ Gossip key for node: node2
+✔ Gossip key for node: node2
+❯ Gossip key for node: node3
+✔ Gossip key for node: node3
+✔ Generate gossip keys
+❯ Generate gRPC TLS Keys
+❯ Backup old files
+❯ TLS key for node: node1
+❯ TLS key for node: node2
+❯ TLS key for node: node3
+✔ Backup old files
+✔ TLS key for node: node2
+✔ TLS key for node: node3
+✔ TLS key for node: node1
+✔ Generate gRPC TLS Keys
+❯ Finalize
+✔ Finalize
 ```
 PEM key files are generated in `~/.solo/keys` directory.
 ```
@@ -158,22 +181,33 @@ solo deployment create -n "${SOLO_NAMESPACE}" --context kind-${SOLO_CLUSTER_SETU
 
 ******************************* Solo *********************************************
 Version			: 0.35.1
-Kubernetes Context	: kind-solo-update-readme-13489128394-1
-Kubernetes Cluster	: kind-solo-update-readme-13489128394-1
-Current Command		: deployment create --node-aliases node1,node2,node3 --namespace solo --context kind-solo-update-readme-13489128394-1 --email john@doe.com --deployment-clusters kind-solo-update-readme-13489128394-1 --deployment solo-deployment
+Kubernetes Context	: kind-solo-e2e
+Kubernetes Cluster	: kind-solo-e2e
+Current Command		: deployment create --node-aliases node1,node2,node3 --namespace solo --context kind-solo-e2e --email john@doe.com --deployment-clusters kind-solo-e2e --deployment solo-deployment
 Kubernetes Namespace	: solo
 **********************************************************************************
-✔ Initialize
-✔ Setup home directory
-✔ Prompt local configuration
-✔ Add new deployment to local config
-✔ Resolve context for remote cluster
-✔ Validate context- validated context kind-solo-update-readme-13489128394-1
-✔ Update local configuration
-✔ Testing connection to cluster: kind-solo-update-readme-13489128394-1
-✔ Validate cluster connections
-✔ Create remote config in cluster: kind-solo-update-readme-13489128394-1
-✔ Create remoteConfig in clusters
+❯ Initialize
+✔ Initialize
+❯ Setup home directory
+✔ Setup home directory
+❯ Prompt local configuration
+✔ Prompt local configuration
+❯ Add new deployment to local config
+✔ Add new deployment to local config
+❯ Resolve context for remote cluster
+✔ Resolve context for remote cluster
+❯ Validate context
+✔ Validate context- validated context kind-solo-e2e
+❯ Update local configuration
+✔ Update local configuration
+❯ Validate cluster connections
+❯ Testing connection to cluster: kind-solo-e2e
+✔ Testing connection to cluster: kind-solo-e2e
+✔ Validate cluster connections
+❯ Create remoteConfig in clusters
+❯ Create remote config in cluster: kind-solo-e2e
+✔ Create remote config in cluster: kind-solo-e2e
+✔ Create remoteConfig in clusters
 ```
 
 * Setup cluster with shared components
@@ -188,13 +222,16 @@ solo cluster setup -s "${SOLO_CLUSTER_SETUP_NAMESPACE}"
 
 ******************************* Solo *********************************************
 Version			: 0.35.1
-Kubernetes Context	: kind-solo-update-readme-13489128394-1
-Kubernetes Cluster	: kind-solo-update-readme-13489128394-1
+Kubernetes Context	: kind-solo-e2e
+Kubernetes Cluster	: kind-solo-e2e
 Current Command		: cluster setup --cluster-setup-namespace solo-cluster
 **********************************************************************************
-✔ Initialize
-✔ Prepare chart values
-✔ Install 'solo-cluster-setup' chart
+❯ Initialize
+✔ Initialize
+❯ Prepare chart values
+✔ Prepare chart values
+❯ Install 'solo-cluster-setup' chart
+✔ Install 'solo-cluster-setup' chart
 ```
 
 In a separate terminal, you may run `k9s` to view the pod status.
@@ -215,39 +252,74 @@ solo network deploy -i node1,node2,node3 --deployment "${SOLO_DEPLOYMENT}"
 
 ******************************* Solo *********************************************
 Version			: 0.35.1
-Kubernetes Context	: kind-solo-update-readme-13489128394-1
-Kubernetes Cluster	: kind-solo-update-readme-13489128394-1
+Kubernetes Context	: kind-solo-e2e
+Kubernetes Cluster	: kind-solo-e2e
 Current Command		: network deploy --node-aliases node1,node2,node3 --deployment solo-deployment
 **********************************************************************************
-✔ Acquire lease - lease acquired successfully, attempt: 1/10
-✔ Initialize
-✔ Check if cluster setup chart is installed
-✔ Copy Gossip keys to staging
-✔ Copy gRPC TLS keys to staging
-✔ Prepare staging directory
-✔ Copy TLS keys
-✔ Copy Gossip keys
-✔ Node: node1, cluster: kind-solo-update-readme-13489128394-1
-✔ Copy Gossip keys
-✔ Node: node3, cluster: kind-solo-update-readme-13489128394-1
-✔ Copy Gossip keys
-✔ Node: node2, cluster: kind-solo-update-readme-13489128394-1
-✔ Copy node keys to secrets
-✔ Install chart 'solo-deployment'
-✔ Check Node: node1, Cluster: kind-solo-update-readme-13489128394-1
-✔ Check Node: node2, Cluster: kind-solo-update-readme-13489128394-1
-✔ Check Node: node3, Cluster: kind-solo-update-readme-13489128394-1
-✔ Check node pods are running
-✔ Check HAProxy for: node2, cluster: kind-solo-update-readme-13489128394-1
-✔ Check HAProxy for: node1, cluster: kind-solo-update-readme-13489128394-1
-✔ Check HAProxy for: node3, cluster: kind-solo-update-readme-13489128394-1
-✔ Check Envoy Proxy for: node1, cluster: kind-solo-update-readme-13489128394-1
-✔ Check Envoy Proxy for: node3, cluster: kind-solo-update-readme-13489128394-1
-✔ Check Envoy Proxy for: node2, cluster: kind-solo-update-readme-13489128394-1
-✔ Check proxy pods are running
-✔ Check MinIO
-✔ Check auxiliary pods are ready
-✔ Add node and proxies to remote config
+❯ Initialize
+❯ Acquire lease
+✔ Acquire lease - lease acquired successfully, attempt: 1/10
+✔ Initialize
+❯ Copy gRPC TLS Certificates
+↓ Copy gRPC TLS Certificates [SKIPPED: Copy gRPC TLS Certificates]
+❯ Check if cluster setup chart is installed
+✔ Check if cluster setup chart is installed
+❯ Prepare staging directory
+❯ Copy Gossip keys to staging
+✔ Copy Gossip keys to staging
+❯ Copy gRPC TLS keys to staging
+✔ Copy gRPC TLS keys to staging
+✔ Prepare staging directory
+❯ Copy node keys to secrets
+❯ Copy TLS keys
+❯ Node: node1, cluster: kind-solo-e2e
+❯ Node: node2, cluster: kind-solo-e2e
+❯ Node: node3, cluster: kind-solo-e2e
+❯ Copy Gossip keys
+❯ Copy Gossip keys
+❯ Copy Gossip keys
+✔ Copy Gossip keys
+✔ Node: node1, cluster: kind-solo-e2e
+✔ Copy TLS keys
+✔ Copy Gossip keys
+✔ Node: node2, cluster: kind-solo-e2e
+✔ Copy Gossip keys
+✔ Node: node3, cluster: kind-solo-e2e
+✔ Copy node keys to secrets
+❯ Install chart 'solo-deployment'
+✔ Install chart 'solo-deployment'
+❯ Check for load balancer
+↓ Check for load balancer [SKIPPED: Check for load balancer]
+❯ Redeploy chart with external IP address config
+↓ Redeploy chart with external IP address config [SKIPPED: Redeploy chart with external IP address config]
+❯ Check node pods are running
+❯ Check Node: node1, Cluster: kind-solo-e2e
+✔ Check Node: node1, Cluster: kind-solo-e2e
+❯ Check Node: node2, Cluster: kind-solo-e2e
+✔ Check Node: node2, Cluster: kind-solo-e2e
+❯ Check Node: node3, Cluster: kind-solo-e2e
+✔ Check Node: node3, Cluster: kind-solo-e2e
+✔ Check node pods are running
+❯ Check proxy pods are running
+❯ Check HAProxy for: node1, cluster: kind-solo-e2e
+❯ Check HAProxy for: node2, cluster: kind-solo-e2e
+❯ Check HAProxy for: node3, cluster: kind-solo-e2e
+❯ Check Envoy Proxy for: node1, cluster: kind-solo-e2e
+❯ Check Envoy Proxy for: node2, cluster: kind-solo-e2e
+❯ Check Envoy Proxy for: node3, cluster: kind-solo-e2e
+✔ Check Envoy Proxy for: node3, cluster: kind-solo-e2e
+✔ Check HAProxy for: node3, cluster: kind-solo-e2e
+✔ Check HAProxy for: node2, cluster: kind-solo-e2e
+✔ Check Envoy Proxy for: node1, cluster: kind-solo-e2e
+✔ Check HAProxy for: node1, cluster: kind-solo-e2e
+✔ Check Envoy Proxy for: node2, cluster: kind-solo-e2e
+✔ Check proxy pods are running
+❯ Check auxiliary pods are ready
+❯ Check MinIO
+✔ Check MinIO
+✔ Check auxiliary pods are ready
+❯ Add node and proxies to remote config
+✔ Add node and proxies to remote config
 ```
 
 * Setup node with Hedera platform software.
@@ -263,35 +335,60 @@ solo node setup -i node1,node2,node3 --deployment "${SOLO_DEPLOYMENT}"
 
 ******************************* Solo *********************************************
 Version			: 0.35.1
-Kubernetes Context	: kind-solo-update-readme-13489128394-1
-Kubernetes Cluster	: kind-solo-update-readme-13489128394-1
+Kubernetes Context	: kind-solo-e2e
+Kubernetes Cluster	: kind-solo-e2e
 Current Command		: node setup --node-aliases node1,node2,node3 --deployment solo-deployment
 **********************************************************************************
-✔ Acquire lease - lease acquired successfully, attempt: 1/10
-✔ Initialize
-✔ Validating state for node node1 - valid state: requested
-✔ Validating state for node node2 - valid state: requested
-✔ Validating state for node node3 - valid state: requested
-✔ Validate nodes states
-✔ Check network pod: node1
-✔ Check network pod: node2
-✔ Check network pod: node3
-✔ Identify network pods
-✔ Update node: node3 [ platformVersion = v0.58.10, context = kind-solo-update-readme-13489128394-1 ]
-✔ Update node: node2 [ platformVersion = v0.58.10, context = kind-solo-update-readme-13489128394-1 ]
-✔ Update node: node1 [ platformVersion = v0.58.10, context = kind-solo-update-readme-13489128394-1 ]
-✔ Fetch platform software into network nodes
-✔ Copy configuration files
-✔ Copy configuration files
-✔ Copy configuration files
-✔ Set file permissions
-✔ Node: node3
-✔ Set file permissions
-✔ Node: node1
-✔ Set file permissions
-✔ Node: node2
-✔ Setup network nodes
-✔ Change node state to setup in remote config
+❯ Initialize
+❯ Acquire lease
+✔ Acquire lease - lease acquired successfully, attempt: 1/10
+✔ Initialize
+❯ Validate nodes states
+❯ Validating state for node node1
+✔ Validating state for node node1 - valid state: requested
+❯ Validating state for node node2
+✔ Validating state for node node2 - valid state: requested
+❯ Validating state for node node3
+✔ Validating state for node node3 - valid state: requested
+✔ Validate nodes states
+❯ Identify network pods
+❯ Check network pod: node1
+❯ Check network pod: node2
+❯ Check network pod: node3
+✔ Check network pod: node1
+✔ Check network pod: node2
+✔ Check network pod: node3
+✔ Identify network pods
+❯ Fetch platform software into network nodes
+❯ Update node: node1 [ platformVersion = v0.58.10, context = kind-solo-e2e ]
+❯ Update node: node2 [ platformVersion = v0.58.10, context = kind-solo-e2e ]
+❯ Update node: node3 [ platformVersion = v0.58.10, context = kind-solo-e2e ]
+✔ Update node: node1 [ platformVersion = v0.58.10, context = kind-solo-e2e ]
+✔ Update node: node3 [ platformVersion = v0.58.10, context = kind-solo-e2e ]
+✔ Update node: node2 [ platformVersion = v0.58.10, context = kind-solo-e2e ]
+✔ Fetch platform software into network nodes
+❯ Setup network nodes
+❯ Node: node1
+❯ Node: node2
+❯ Node: node3
+❯ Copy configuration files
+❯ Copy configuration files
+❯ Copy configuration files
+✔ Copy configuration files
+❯ Set file permissions
+✔ Copy configuration files
+❯ Set file permissions
+✔ Copy configuration files
+❯ Set file permissions
+✔ Set file permissions
+✔ Node: node3
+✔ Set file permissions
+✔ Node: node1
+✔ Set file permissions
+✔ Node: node2
+✔ Setup network nodes
+❯ Change node state to setup in remote config
+✔ Change node state to setup in remote config
 ```
 
 * Start the nodes
@@ -306,37 +403,68 @@ solo node start -i node1,node2,node3 --deployment "${SOLO_DEPLOYMENT}"
 
 ******************************* Solo *********************************************
 Version			: 0.35.1
-Kubernetes Context	: kind-solo-update-readme-13489128394-1
-Kubernetes Cluster	: kind-solo-update-readme-13489128394-1
+Kubernetes Context	: kind-solo-e2e
+Kubernetes Cluster	: kind-solo-e2e
 Current Command		: node start --node-aliases node1,node2,node3 --deployment solo-deployment
 **********************************************************************************
-✔ Acquire lease - lease acquired successfully, attempt: 1/10
-✔ Initialize
-✔ Validating state for node node1 - valid state: setup
-✔ Validating state for node node2 - valid state: setup
-✔ Validating state for node node3 - valid state: setup
-✔ Validate nodes states
-✔ Check network pod: node1
-✔ Check network pod: node2
-✔ Check network pod: node3
-✔ Identify existing network nodes
-✔ Start node: node1
-✔ Start node: node2
-✔ Start node: node3
-✔ Starting nodes
-✔ Check network pod: node1  - status ACTIVE, attempt: 20/300
-✔ Check network pod: node2  - status ACTIVE, attempt: 20/300
-✔ Check network pod: node3  - status ACTIVE, attempt: 20/300
-✔ Check all nodes are ACTIVE
-✔ Check proxy for node: node1
-✔ Check proxy for node: node2
-✔ Check proxy for node: node3
-✔ Check node proxies are ACTIVE
-✔ Change node state to started in remote config
-✔ Adding stake for node: node1
-✔ Adding stake for node: node2
-✔ Adding stake for node: node3
-✔ Add node stakes
+❯ Initialize
+❯ Acquire lease
+✔ Acquire lease - lease acquired successfully, attempt: 1/10
+✔ Initialize
+❯ Validate nodes states
+❯ Validating state for node node1
+✔ Validating state for node node1 - valid state: setup
+❯ Validating state for node node2
+✔ Validating state for node node2 - valid state: setup
+❯ Validating state for node node3
+✔ Validating state for node node3 - valid state: setup
+✔ Validate nodes states
+❯ Identify existing network nodes
+❯ Check network pod: node1
+❯ Check network pod: node2
+❯ Check network pod: node3
+✔ Check network pod: node2
+✔ Check network pod: node1
+✔ Check network pod: node3
+✔ Identify existing network nodes
+❯ Upload state files network nodes
+↓ Upload state files network nodes [SKIPPED: Upload state files network nodes]
+❯ Starting nodes
+❯ Start node: node1
+❯ Start node: node2
+❯ Start node: node3
+✔ Start node: node2
+✔ Start node: node3
+✔ Start node: node1
+✔ Starting nodes
+❯ Enable port forwarding for JVM debugger
+↓ Enable port forwarding for JVM debugger [SKIPPED: Enable port forwarding for JVM debugger]
+❯ Check all nodes are ACTIVE
+❯ Check network pod: node1 
+❯ Check network pod: node2 
+❯ Check network pod: node3 
+✔ Check network pod: node1  - status ACTIVE, attempt: 18/300
+✔ Check network pod: node2  - status ACTIVE, attempt: 19/300
+✔ Check network pod: node3  - status ACTIVE, attempt: 19/300
+✔ Check all nodes are ACTIVE
+❯ Check node proxies are ACTIVE
+❯ Check proxy for node: node1
+✔ Check proxy for node: node1
+❯ Check proxy for node: node2
+✔ Check proxy for node: node2
+❯ Check proxy for node: node3
+✔ Check proxy for node: node3
+✔ Check node proxies are ACTIVE
+❯ Change node state to started in remote config
+✔ Change node state to started in remote config
+❯ Add node stakes
+❯ Adding stake for node: node1
+✔ Adding stake for node: node1
+❯ Adding stake for node: node2
+✔ Adding stake for node: node2
+❯ Adding stake for node: node3
+✔ Adding stake for node: node3
+✔ Add node stakes
 ```
 
 * Deploy mirror node
@@ -351,24 +479,38 @@ solo mirror-node deploy --deployment "${SOLO_DEPLOYMENT}"
 
 ******************************* Solo *********************************************
 Version			: 0.35.1
-Kubernetes Context	: kind-solo-update-readme-13489128394-1
-Kubernetes Cluster	: kind-solo-update-readme-13489128394-1
+Kubernetes Context	: kind-solo-e2e
+Kubernetes Cluster	: kind-solo-e2e
 Current Command		: mirror-node deploy --deployment solo-deployment
 **********************************************************************************
-✔ Acquire lease - lease acquired successfully, attempt: 1/10
-✔ Initialize
-✔ Prepare address book
-✔ Deploy mirror-node
-✔ Enable mirror-node
-✔ Check Postgres DB
-✔ Check GRPC
-✔ Check REST API
-✔ Check Importer
-✔ Check Monitor
-✔ Check pods are ready
-✔ Insert data in public.file_data
-✔ Seed DB data
-✔ Add mirror node to remote config
+❯ Initialize
+❯ Acquire lease
+✔ Acquire lease - lease acquired successfully, attempt: 1/10
+✔ Initialize
+❯ Enable mirror-node
+❯ Prepare address book
+✔ Prepare address book
+❯ Deploy mirror-node
+✔ Deploy mirror-node
+✔ Enable mirror-node
+❯ Check pods are ready
+❯ Check Postgres DB
+❯ Check REST API
+❯ Check GRPC
+❯ Check Monitor
+❯ Check Importer
+✔ Check Monitor
+✔ Check Postgres DB
+✔ Check GRPC
+✔ Check Importer
+✔ Check REST API
+✔ Check pods are ready
+❯ Seed DB data
+❯ Insert data in public.file_data
+✔ Insert data in public.file_data
+✔ Seed DB data
+❯ Add mirror node to remote config
+✔ Add mirror node to remote config
 ```
 
 * Deploy a JSON RPC relay
@@ -383,16 +525,22 @@ solo relay deploy -i node1,node2,node3 --deployment "${SOLO_DEPLOYMENT}"
 
 ******************************* Solo *********************************************
 Version			: 0.35.1
-Kubernetes Context	: kind-solo-update-readme-13489128394-1
-Kubernetes Cluster	: kind-solo-update-readme-13489128394-1
+Kubernetes Context	: kind-solo-e2e
+Kubernetes Cluster	: kind-solo-e2e
 Current Command		: relay deploy --node-aliases node1,node2,node3 --deployment solo-deployment
 **********************************************************************************
-✔ Acquire lease - lease acquired successfully, attempt: 1/10
-✔ Initialize
-✔ Prepare chart values
-✔ Deploy JSON RPC Relay
-✔ Check relay is ready
-✔ Add relay component in remote config
+❯ Initialize
+❯ Acquire lease
+✔ Acquire lease - lease acquired successfully, attempt: 1/10
+✔ Initialize
+❯ Prepare chart values
+✔ Prepare chart values
+❯ Deploy JSON RPC Relay
+✔ Deploy JSON RPC Relay
+❯ Check relay is ready
+✔ Check relay is ready
+❯ Add relay component in remote config
+✔ Add relay component in remote config
 ```
 
 You may view the list of pods using `k9s` as below:

--- a/docs/content/User/StepByStepGuide.md
+++ b/docs/content/User/StepByStepGuide.md
@@ -1,5 +1,11 @@
 ## Advanced User Guide
 For those who would like to have more control or need some customized setups, here are some step by step instructions of how to setup and deploy a solo network.
+
+NOTE: for cleanup from previous runs, you may need to run the following command:
+```
+rm -Rf ~/.solo
+```
+
 ### Setup Kubernetes cluster
 
 #### Remote cluster

--- a/docs/content/User/StepByStepGuide.md.template
+++ b/docs/content/User/StepByStepGuide.md.template
@@ -4,6 +4,7 @@ For those who would like to have more control or need some customized setups, he
 NOTE: for cleanup from previous runs, you may need to run the following command:
 ```
 rm -Rf ~/.solo
+kind delete cluster -n "${SOLO_CLUSTER_NAME}"
 ```
 
 ### Setup Kubernetes cluster
@@ -109,7 +110,7 @@ hedera-node2.key    hedera-node4.key    s-private-node4.pem s-public-node4.pem
 * Create a deployment in the specified clusters, generate RemoteConfig and LocalConfig objects.
 
 ```
-solo deployment create -n "${SOLO_NAMESPACE}" --context kind-${SOLO_CLUSTER_SETUP_NAMESPACE} --email "${SOLO_EMAIL}" --deployment-clusters kind-${SOLO_CLUSTER_SETUP_NAMESPACE} --deployment "${SOLO_DEPLOYMENT}"
+solo deployment create -n "${SOLO_NAMESPACE}" --context kind-${SOLO_CLUSTER_NAME} --email "${SOLO_EMAIL}" --deployment-clusters kind-${SOLO_CLUSTER_NAME} --deployment "${SOLO_DEPLOYMENT}"
 ```
 
 * Example output
@@ -183,6 +184,18 @@ solo mirror-node deploy --deployment "${SOLO_DEPLOYMENT}"
 
 ```
 $SOLO_MIRROR_NODE_DEPLOY_OUTPUT
+```
+
+* Deploy Hedera Explorer
+
+```
+solo explorer deploy --deployment "${SOLO_DEPLOYMENT}" --cluster-ref kind-${SOLO_CLUSTER_NAME}
+```
+
+* Example output
+
+```
+$SOLO_EXPLORER_DEPLOY_OUTPUT
 ```
 
 * Deploy a JSON RPC relay

--- a/docs/content/User/StepByStepGuide.md.template
+++ b/docs/content/User/StepByStepGuide.md.template
@@ -1,5 +1,11 @@
 ## Advanced User Guide
 For those who would like to have more control or need some customized setups, here are some step by step instructions of how to setup and deploy a solo network.
+
+NOTE: for cleanup from previous runs, you may need to run the following command:
+```
+rm -Rf ~/.solo
+```
+
 ### Setup Kubernetes cluster
 
 #### Remote cluster

--- a/docs/data/menu/main.yml
+++ b/docs/data/menu/main.yml
@@ -2,8 +2,8 @@
 main:
   - name: Getting Started
     ref: "/User/README/index.md"
-  - name: Start solo network with single command
-    ref: "/User/TaskTool.md"
+  - name: Step-by-step guide
+    ref: "/User/StepByStepGuide.md"
   - name: Hedera Developer
     ref: "HederaDeveloper.md"
   - name: Platform Developer
@@ -20,12 +20,12 @@ main:
     ref: "/User/Env.md"
   - name: FAQ
     ref: "/User/FAQ.md"
-  - name: Step-by-step guide
-    ref: "/User/StepByStepGuide.md"
   - name: Solo CLI manual
     ref: "/User/SoloCLI.md"
   - name: Solo Development
     ref: "/Developer/DEV.md"
+  - name: Use 'Task' to Launch Solo
+    ref: "/Developer/Development/TaskTool.md"
   - name: Classes
     ref: "/solo/static/Classes/index.html"
     external: true

--- a/src/commands/deployment.ts
+++ b/src/commands/deployment.ts
@@ -73,7 +73,12 @@ export class DeploymentCommand extends BaseCommand {
             self.configManager.update(argv);
             self.logger.debug('Updated config with argv', {config: self.configManager.config});
 
-            await self.configManager.executePrompt(task, [flags.namespace, flags.deployment, flags.deploymentClusters]);
+            await self.configManager.executePrompt(task, [
+              flags.namespace,
+              flags.deployment,
+              flags.deploymentClusters,
+              flags.nodeAliasesUnparsed,
+            ]);
             const deploymentName = self.configManager.getFlag<DeploymentName>(flags.deployment);
 
             if (self.localConfig.deployments && self.localConfig.deployments[deploymentName]) {

--- a/src/commands/deployment.ts
+++ b/src/commands/deployment.ts
@@ -73,7 +73,14 @@ export class DeploymentCommand extends BaseCommand {
             self.configManager.update(argv);
             self.logger.debug('Updated config with argv', {config: self.configManager.config});
 
-            await self.configManager.executePrompt(task, [flags.namespace, flags.deployment, flags.deploymentClusters]);
+            await self.configManager.executePrompt(task, [
+              flags.namespace,
+              flags.deployment,
+              flags.deploymentClusters,
+              flags.nodeAliasesUnparsed,
+              flags.context,
+              flags.userEmailAddress,
+            ]);
             const deploymentName = self.configManager.getFlag<DeploymentName>(flags.deployment);
 
             if (self.localConfig.deployments && self.localConfig.deployments[deploymentName]) {

--- a/src/commands/deployment.ts
+++ b/src/commands/deployment.ts
@@ -73,14 +73,7 @@ export class DeploymentCommand extends BaseCommand {
             self.configManager.update(argv);
             self.logger.debug('Updated config with argv', {config: self.configManager.config});
 
-            await self.configManager.executePrompt(task, [
-              flags.namespace,
-              flags.deployment,
-              flags.deploymentClusters,
-              flags.nodeAliasesUnparsed,
-              flags.context,
-              flags.userEmailAddress,
-            ]);
+            await self.configManager.executePrompt(task, [flags.namespace, flags.deployment, flags.deploymentClusters]);
             const deploymentName = self.configManager.getFlag<DeploymentName>(flags.deployment);
 
             if (self.localConfig.deployments && self.localConfig.deployments[deploymentName]) {

--- a/src/commands/flags.ts
+++ b/src/commands/flags.ts
@@ -135,18 +135,14 @@ export class Flags {
       type: 'string',
     },
     prompt: async function promptClusterRef(task: ListrTaskWrapper<any, any, any>, input: any) {
-      if (input?.length) {
-        return await Flags.promptText(
-          task,
-          input,
-          Flags.clusterRef.definition.defaultValue,
-          'Enter cluster reference: ',
-          'cluster reference cannot be empty',
-          Flags.clusterRef.name,
-        );
-      } else {
-        return undefined;
-      }
+      return await Flags.promptText(
+        task,
+        input,
+        Flags.clusterRef.definition.defaultValue,
+        'Enter cluster reference: ',
+        'cluster reference cannot be empty',
+        Flags.clusterRef.name,
+      );
     },
   };
 
@@ -1545,18 +1541,14 @@ export class Flags {
       type: 'string',
     },
     prompt: async function promptDeploymentClusters(task: ListrTaskWrapper<any, any, any>, input: any) {
-      if (input?.length) {
-        return await Flags.promptText(
-          task,
-          input,
-          Flags.deploymentClusters.definition.defaultValue,
-          'Enter the Solo deployment cluster names (comma separated): ',
-          null,
-          Flags.deploymentClusters.name,
-        );
-      } else {
-        return undefined;
-      }
+      return await Flags.promptText(
+        task,
+        input,
+        Flags.deploymentClusters.definition.defaultValue,
+        'Enter the Solo deployment cluster names (comma separated): ',
+        null,
+        Flags.deploymentClusters.name,
+      );
     },
   };
 

--- a/src/commands/flags.ts
+++ b/src/commands/flags.ts
@@ -135,14 +135,18 @@ export class Flags {
       type: 'string',
     },
     prompt: async function promptClusterRef(task: ListrTaskWrapper<any, any, any>, input: any) {
-      return await Flags.promptText(
-        task,
-        input,
-        Flags.clusterRef.definition.defaultValue,
-        'Enter cluster reference: ',
-        'cluster reference cannot be empty',
-        Flags.clusterRef.name,
-      );
+      if (input?.length) {
+        return await Flags.promptText(
+          task,
+          input,
+          Flags.clusterRef.definition.defaultValue,
+          'Enter cluster reference: ',
+          'cluster reference cannot be empty',
+          Flags.clusterRef.name,
+        );
+      } else {
+        return undefined;
+      }
     },
   };
 
@@ -1541,14 +1545,18 @@ export class Flags {
       type: 'string',
     },
     prompt: async function promptDeploymentClusters(task: ListrTaskWrapper<any, any, any>, input: any) {
-      return await Flags.promptText(
-        task,
-        input,
-        Flags.deploymentClusters.definition.defaultValue,
-        'Enter the Solo deployment cluster names (comma separated): ',
-        null,
-        Flags.deploymentClusters.name,
-      );
+      if (input?.length) {
+        return await Flags.promptText(
+          task,
+          input,
+          Flags.deploymentClusters.definition.defaultValue,
+          'Enter the Solo deployment cluster names (comma separated): ',
+          null,
+          Flags.deploymentClusters.name,
+        );
+      } else {
+        return undefined;
+      }
     },
   };
 

--- a/src/commands/flags.ts
+++ b/src/commands/flags.ts
@@ -1500,16 +1500,12 @@ export class Flags {
       type: 'string',
     },
     prompt: async function promptContext(task: ListrTaskWrapper<any, any, any>, input: string[], cluster?: string) {
-      if (input?.length) {
-        return await task.prompt(ListrEnquirerPromptAdapter).run({
-          type: 'select',
-          name: 'context',
-          message: 'Select kubectl context' + (cluster ? ` to be associated with cluster: ${cluster}` : ''),
-          choices: input,
-        });
-      } else {
-        return undefined;
-      }
+      return await task.prompt(ListrEnquirerPromptAdapter).run({
+        type: 'select',
+        name: 'context',
+        message: 'Select kubectl context' + (cluster ? ` to be associated with cluster: ${cluster}` : ''),
+        choices: input,
+      });
     },
   };
 

--- a/src/commands/flags.ts
+++ b/src/commands/flags.ts
@@ -1500,12 +1500,16 @@ export class Flags {
       type: 'string',
     },
     prompt: async function promptContext(task: ListrTaskWrapper<any, any, any>, input: string[], cluster?: string) {
-      return await task.prompt(ListrEnquirerPromptAdapter).run({
-        type: 'select',
-        name: 'context',
-        message: 'Select kubectl context' + (cluster ? ` to be associated with cluster: ${cluster}` : ''),
-        choices: input,
-      });
+      if (input?.length) {
+        return await task.prompt(ListrEnquirerPromptAdapter).run({
+          type: 'select',
+          name: 'context',
+          message: 'Select kubectl context' + (cluster ? ` to be associated with cluster: ${cluster}` : ''),
+          choices: input,
+        });
+      } else {
+        return undefined;
+      }
     },
   };
 


### PR DESCRIPTION
## Description

This pull request changes the following:

* `.github/workflows/flow-hugo-publish.yaml` updated to publish `release/0.35` to GitHub Pages
* `.github/workflows/script/update_md.sh` added `solo explorer deploy` command
* fixed getting started infinite loop in docs
* added warnings at top of docs that were out of date
* updated `solo deployment create` to prompt for email, context, and node aliases
