### PR TITLE
fix: add support for --aws-bucket-region flag to override default bucket region

### DIFF
--- a/src/commands/flags.ts
+++ b/src/commands/flags.ts
@@ -2199,6 +2199,18 @@ export class Flags {
     prompt: undefined,
   };
 
+  public static readonly awsBucketRegion: CommandFlag = {
+    constName: 'awsBucketRegion',
+    name: 'aws-bucket-region',
+    definition: {
+        defaultValue: '',
+        describe: 'name of aws bucket region',
+        type: 'string',
+        dataMask: constants.STANDARD_DATAMASK,
+    },
+    prompt: undefined,
+    };
+
   public static readonly awsBucketPrefix: CommandFlag = {
     constName: 'awsBucketPrefix',
     name: 'aws-bucket-prefix',
@@ -2567,6 +2579,7 @@ export class Flags {
     Flags.awsWriteSecrets,
     Flags.awsEndpoint,
     Flags.awsBucket,
+    Flags.awsBucketRegion,
     Flags.awsBucketPrefix,
     Flags.storageReadAccessKey,
     Flags.storageReadSecrets,

--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -117,6 +117,7 @@ export interface NetworkDeployConfigClass {
   awsEndpoint: string;
   awsBucket: string;
   awsBucketPrefix: string;
+  awsBucketRegion: string;
   backupBucket: string;
   backupWriteSecrets: string;
   backupWriteAccessKey: string;
@@ -218,6 +219,7 @@ export class NetworkCommand extends BaseCommand {
       flags.awsWriteSecrets,
       flags.awsEndpoint,
       flags.awsBucket,
+      flags.awsBucketRegion,
       flags.awsBucketPrefix,
       flags.backupBucket,
       flags.backupWriteAccessKey,
@@ -527,6 +529,12 @@ export class NetworkCommand extends BaseCommand {
       for (const clusterReference of clusterReferences) {
         valuesArguments[clusterReference] += ` --set cloud.buckets.streamBucketPrefix=${config.awsBucketPrefix}`;
       }
+    }
+
+    if (config.awsBucketRegion) {
+        for (const clusterReference of clusterReferences) {
+            valuesArguments[clusterReference] += ` --set cloud.buckets.streamBucketRegion=${config.awsBucketRegion}`;
+        }
     }
 
     if (config.backupBucket) {


### PR DESCRIPTION
## Description

- It adds a new flag `--aws-bucket-region` to set the bucket region during network deployment.

### Related Issues

* Closes #2042 
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
