### PR TITLE
fix: config provider register method throws inappropriately

### DIFF
--- a/src/data/configuration/impl/layered-config-provider.ts
+++ b/src/data/configuration/impl/layered-config-provider.ts
@@ -39,7 +39,7 @@ export class LayeredConfigProvider implements ConfigProvider {
       throw new IllegalArgumentError('config must not be null or undefined');
     }
 
-    if (!this._config) {
+    if (this._config) {
       throw new ConfigurationError('config already registered');
     }
 

--- a/src/data/configuration/impl/layered-config.ts
+++ b/src/data/configuration/impl/layered-config.ts
@@ -12,13 +12,21 @@ type ObjectMethod<T> = (cls: ClassConstructor<T>, key?: string) => T;
 type ObjectArrayMethod<T> = (cls: ClassConstructor<T>, key?: string) => T[];
 
 export class LayeredConfig implements Config {
+  private readonly _sources: ConfigSource[];
+
   public constructor(
-    public readonly sources: ConfigSource[],
+    sources: ConfigSource[],
     public readonly mergeSourceValues: boolean = false,
   ) {
     if (sources) {
       sources.sort(Comparators.configSource);
     }
+
+    this._sources = sources ?? [];
+  }
+
+  public get sources(): ConfigSource[] {
+    return [...this._sources];
   }
 
   public asBoolean(key: string): boolean | null {

--- a/src/data/mapper/api/object-mapper.ts
+++ b/src/data/mapper/api/object-mapper.ts
@@ -14,7 +14,7 @@ export interface ObjectMapper {
    * Converts a plain javascript object into an instance of the specified class.
    *
    * @param cls - The desired class of the resulting object instance.
-   * @param obj - The plain javascript object to be converted.
+   * @param object - The plain javascript object to be converted.
    * @throws ObjectMappingError if the mapping or a type conversion fails.
    */
   fromObject<T>(cls: ClassConstructor<T>, object: object): T;
@@ -31,7 +31,7 @@ export interface ObjectMapper {
    * Converts an array of plain javascript objects into an array of instances of the specified class.
    *
    * @param cls - The desired class of the resulting object instances.
-   * @param arr - The array of plain javascript objects to be converted.
+   * @param array - The array of plain javascript objects to be converted.
    * @throws ObjectMappingError if the mapping or a type conversion fails.
    */
   fromArray<T>(cls: ClassConstructor<T>, array: object[]): T[];
@@ -55,7 +55,7 @@ export interface ObjectMapper {
   /**
    * Sets the value of a property on an object hierarchy as specified by the key.
    *
-   * @param obj - The object on which to set the property value.
+   * @param object - The object on which to set the property value.
    * @param key - The key specifying the property to set.
    * @param value - The value to set.
    */

--- a/src/data/mapper/impl/class-to-object-mapper.ts
+++ b/src/data/mapper/impl/class-to-object-mapper.ts
@@ -21,15 +21,15 @@ export class ClassToObjectMapper implements ObjectMapper {
     this.flatMapper = new FlatKeyMapper(patchInject(formatter, InjectTokens.KeyFormatter, ClassToObjectMapper.name));
   }
 
-  public fromArray<T extends R, R>(cls: ClassConstructor<T>, array: object[]): R[] {
-    const result: R[] = [];
+  public fromArray<T>(cls: ClassConstructor<T>, array: object[]): T[] {
+    const result: T[] = [];
     for (const item of array) {
       result.push(this.fromObject(cls, item));
     }
     return result;
   }
 
-  public fromObject<T extends R, R>(cls: ClassConstructor<T>, object: object): R {
+  public fromObject<T>(cls: ClassConstructor<T>, object: object): T {
     try {
       return plainToInstance(cls, object);
     } catch (error) {

--- a/test/unit/data/configuration/impl/layered-config-provider.test.ts
+++ b/test/unit/data/configuration/impl/layered-config-provider.test.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {type ConfigProvider} from '../../../../../src/data/configuration/api/config-provider.js';
+import {type Config} from '../../../../../src/data/configuration/api/config.js';
+import {LayeredConfigProvider} from '../../../../../src/data/configuration/impl/layered-config-provider.js';
+import {ClassToObjectMapper} from '../../../../../src/data/mapper/impl/class-to-object-mapper.js';
+import {ConfigKeyFormatter} from '../../../../../src/data/key/config-key-formatter.js';
+import {expect} from 'chai';
+import {ConfigurationError} from '../../../../../src/data/configuration/api/configuration-error.js';
+
+describe('LayeredConfigProvider', (): void => {
+  const mapper: ClassToObjectMapper = new ClassToObjectMapper(ConfigKeyFormatter.instance());
+
+  it('should not throw an error when registering a valid initial config (issue #2094)', (): void => {
+    const provider: ConfigProvider = new LayeredConfigProvider(mapper, 'SOLO');
+    expect(provider).is.not.null.and.not.undefined;
+    expect((): Config => provider.config()).to.throw(ConfigurationError);
+
+    const config: Config = provider.builder().build();
+    expect((): Config => provider.config()).to.throw(ConfigurationError);
+
+    expect((): void => provider.register(config)).to.not.throw();
+    expect((): Config => provider.config()).to.not.throw();
+  });
+});

--- a/test/unit/data/mapper/impl/class-to-object-mapper.test.ts
+++ b/test/unit/data/mapper/impl/class-to-object-mapper.test.ts
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {ClassToObjectMapper} from '../../../../../src/data/mapper/impl/class-to-object-mapper.js';
+import {ConfigKeyFormatter} from '../../../../../src/data/key/config-key-formatter.js';
+import {UserIdentitySchema} from '../../../../../src/data/schema/model/common/user-identity-schema.js';
+import {expect} from 'chai';
+
+describe('ClassToObjectMapper', (): void => {
+  const mapper: ClassToObjectMapper = new ClassToObjectMapper(ConfigKeyFormatter.instance());
+
+  it('should map class to object with missing field', (): void => {
+    const user: object = {
+      name: 'John Doe',
+    };
+
+    const schema: UserIdentitySchema = mapper.fromObject(UserIdentitySchema, user);
+    expect(schema).to.be.not.null;
+    expect(schema).to.be.instanceOf(UserIdentitySchema);
+    expect(schema.name).to.equal('John Doe');
+    expect(schema.hostname).to.be.undefined;
+  });
+});


### PR DESCRIPTION
## Description

This pull request introduces several updates to improve code clarity, enforce consistency in naming conventions, and enhance test coverage for the `LayeredConfigProvider` and `ClassToObjectMapper` implementations. The changes include adjustments to error handling, private property encapsulation, parameter renaming for consistency, and the addition of unit tests.

### Code clarity and error handling improvements:
* [`src/data/configuration/impl/layered-config-provider.ts`](diffhunk://#diff-7272a65e147fc6a2e97940d7f4a436269857d2c17fd549f11eb242a833e82549L42-R42): Adjusted the condition in the `register` method to check `this._config` directly, improving readability and error handling.

### Encapsulation and property management:
* [`src/data/configuration/impl/layered-config.ts`](diffhunk://#diff-a9d80be969339c874457e6cb1ef938ea31ffc8e973e00ba52d48875ac578d025R15-R29): Introduced a private `_sources` property and a public getter for `sources` to encapsulate the configuration sources and prevent direct mutation.

### Consistency in naming conventions:
* [`src/data/mapper/api/object-mapper.ts`](diffhunk://#diff-8306ada3c202cb3a0de10b1413d9df5285d0782ac9b38cb34044791f65c41bc8L17-R17): Renamed parameters (`obj` to `object`, `arr` to `array`) in multiple methods to ensure consistency and improve code readability. [[1]](diffhunk://#diff-8306ada3c202cb3a0de10b1413d9df5285d0782ac9b38cb34044791f65c41bc8L17-R17) [[2]](diffhunk://#diff-8306ada3c202cb3a0de10b1413d9df5285d0782ac9b38cb34044791f65c41bc8L34-R34) [[3]](diffhunk://#diff-8306ada3c202cb3a0de10b1413d9df5285d0782ac9b38cb34044791f65c41bc8L58-R58)

### Type adjustments:
* [`src/data/mapper/impl/class-to-object-mapper.ts`](diffhunk://#diff-d4513cb4d74fa32116a4609dbb111c03550be91b8fe620b216de9a954d097a86L24-R32): Simplified type constraints in the `fromArray` and `fromObject` methods to remove redundant generic type parameters.

### Enhanced test coverage:
* [`test/unit/data/configuration/impl/layered-config-provider.test.ts`](diffhunk://#diff-ff8382e9cee9913eea6b26765fd2583ef81e095dd2b6d3fb887f5d09e730e968R1-R25): Added a unit test for `LayeredConfigProvider` to verify proper handling of initial configuration registration and error scenarios.
* [`test/unit/data/mapper/impl/class-to-object-mapper.test.ts`](diffhunk://#diff-09385b930e66482c74cf0e8251d3c4e958638e728bb01893ea8c558a35d8a2d8R1-R22): Added a unit test for `ClassToObjectMapper` to validate mapping behavior, including handling of missing fields.

### Related Issues

* Closes #2094 

### Pull request (PR) checklist

* \[x] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[x] This PR added no TODOs or commented out code
* \[x] This PR has no breaking changes
* \[x] Any technical debt has been documented as a separate issue and linked to this PR
* \[x] Any `package.json` changes have been explained to and approved by a repository manager
* \[x] All related issues have been linked to this PR
* \[x] All changes in this PR are included in the description
* \[x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[x] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[x] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
