### PR TITLE
feat: support for adding config sources to the config after construction

### DIFF
--- a/src/data/configuration/api/config.ts
+++ b/src/data/configuration/api/config.ts
@@ -12,4 +12,26 @@ export interface Config extends ConfigAccessor, Refreshable {
    * All the configuration sources which were used to build this configuration.
    */
   readonly sources: ConfigSource[];
+
+  /**
+   * Adds a configuration source to the configuration.
+   *
+   * This method is not guaranteed to be thread-safe, so it should not be called concurrently with other methods
+   * that modify the configuration. Methods which read the configuration may be called concurrently, but may not
+   * reflect changes made by this method.
+   *
+   * This method is typically used to add configuration sources that have been created or loaded dynamically,
+   * such as configuration files, environment variables, or other sources of configuration data.
+   *
+   * The same {@link ConfigSource} instance can only be added once. If the same source is added again, a
+   * DuplicateConfigSourceError will be thrown. This is to ensure that each configuration source is unique within
+   * the configuration.
+   *
+   * A {@link ConfigSource} with the same name and ordinal as an existing source will be considered a duplicate,
+   * even if it is a different instance.
+   *
+   * @param source - The configuration source to be added.
+   * @throws {DuplicateConfigSourceError} if the configuration source has already been added.
+   */
+  addSource(source: ConfigSource): void;
 }

--- a/src/data/configuration/api/configuration-error.ts
+++ b/src/data/configuration/api/configuration-error.ts
@@ -6,6 +6,13 @@ import {SoloError} from '../../../core/errors/solo-error.js';
  * General purpose error for configuration failures.
  */
 export class ConfigurationError extends SoloError {
+  /**
+   * Creates a new instance of ConfigurationError.
+   *
+   * @param message - The error message.
+   * @param cause - The underlying cause of the error, if any.
+   * @param meta - Additional metadata associated with the error.
+   */
   public constructor(message: string, cause?: Error, meta?: object) {
     super(message, cause, meta);
   }

--- a/src/data/configuration/api/duplicate-config-source-error.ts
+++ b/src/data/configuration/api/duplicate-config-source-error.ts
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {ConfigurationError} from './configuration-error.js';
+import {type ConfigSource} from '../spi/config-source.js';
+
+/**
+ * Error indicating that a configuration source has already been registered.
+ */
+export class DuplicateConfigSourceError extends ConfigurationError {
+  /**
+   * Creates a new instance of DuplicateConfigurationSourceError.
+   *
+   * @param source - The duplicate ConfigSource instance.
+   * @param cause - The underlying cause of the error, if any.
+   * @param meta - Additional metadata associated with the error.
+   */
+  public constructor(source: ConfigSource, cause?: Error, meta?: object) {
+    super(`duplicate config source: ${source.name} (${source.ordinal})`, cause, {
+      name: source.name,
+      ordinal: source.ordinal,
+      prefix: source.prefix,
+      ...meta,
+    });
+  }
+}


### PR DESCRIPTION
## Description

This pull request introduces enhancements to the configuration management system, focusing on adding support for dynamic configuration sources, improving error handling, and refining unit tests. The most significant changes include adding the `addSource` method to manage configuration sources, introducing the `DuplicateConfigSourceError` class, and updating the `LayeredConfig` implementation and its corresponding tests.

### Enhancements to Configuration Management:

* **Addition of `addSource` Method**: 
  - The `Config` interface now includes an `addSource` method to dynamically add configuration sources. This method ensures thread safety for read operations and prevents duplicate sources from being added.
  - The `LayeredConfig` class implements this method, validating sources and sorting them by ordinal values.

* **Error Handling Improvements**:
  - Introduced a new `DuplicateConfigSourceError` class to handle cases where a configuration source is added multiple times or conflicts with existing sources.
  - Updated imports in `LayeredConfig` to include this new error class.

### Refinements to Unit Tests:

* **Tests for `addSource` Method**:
  - Added unit tests to verify the behavior of the `addSource` method, including checks for invalid inputs and duplicate sources.
  - Ensured proper handling of newly added sources and their sorting by ordinal values.

* **General Test Improvements**:
  - Updated test descriptions and added return types for test functions to improve clarity and consistency. [[1]](diffhunk://#diff-ee89ca9120933826a1e97e8ea36d1c715a824ea79079d14425c635e9b14539e8L17-R19) [[2]](diffhunk://#diff-ee89ca9120933826a1e97e8ea36d1c715a824ea79079d14425c635e9b14539e8L26-R28) [[3]](diffhunk://#diff-ee89ca9120933826a1e97e8ea36d1c715a824ea79079d14425c635e9b14539e8L101-R181)

### Code Refinements:

* **Primitive Scalar Updates**:
  - Adjusted the handling of scalar values in `LayeredConfig` to use `undefined` instead of `null` for better type consistency. [[1]](diffhunk://#diff-a9d80be969339c874457e6cb1ef938ea31ffc8e973e00ba52d48875ac578d025L91-R110) [[2]](diffhunk://#diff-a9d80be969339c874457e6cb1ef938ea31ffc8e973e00ba52d48875ac578d025L110-R155)

### Related Issues

* Closes #2092 

### Pull request (PR) checklist

* \[x] This PR added tests (unit, integration, and/or end-to-end)
* \[x] This PR updated documentation
* \[x] This PR added no TODOs or commented out code
* \[x] This PR has no breaking changes
* \[x] Any technical debt has been documented as a separate issue and linked to this PR
* \[x] Any `package.json` changes have been explained to and approved by a repository manager
* \[x] All related issues have been linked to this PR
* \[x] All changes in this PR are included in the description
* \[x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[x] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[x] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
