### PR TITLE
chore: improve versioned release detection in Hugo workflow for better clarity

### DIFF
--- a/.github/workflows/flow-hugo-publish.yaml
+++ b/.github/workflows/flow-hugo-publish.yaml
@@ -96,10 +96,16 @@ jobs:
           fi
          
           # Only download artifacts and attach docs to a release if this is a workflow_dispatch running with a version tag
-          if [[ "${{ github.ref_name }}" != "main" && "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "Running with a version tag and via workflow_dispatch, this is a versioned release."
-            VERSIONED_RELEASE=true
-            echo "setting: VERSIONED_RELEASE=${VERSIONED_RELEASE}"
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            if [[ "${{ github.ref_name }}" != "main" || "${{ inputs.docs-build-label }}" != "main" ]]; then
+              echo "Running with a version tag and via workflow_dispatch, this is a versioned release."
+              VERSIONED_RELEASE=true
+              echo "setting: VERSIONED_RELEASE=${VERSIONED_RELEASE}"
+            else
+              echo "Running with 'main' branch and not a versioned release."
+              VERSIONED_RELEASE=false
+              echo "setting: VERSIONED_RELEASE=${VERSIONED_RELEASE}"
+            fi
           else
             echo "Running with 'main' or 'release/*' branch."
             VERSIONED_RELEASE=false


### PR DESCRIPTION
## Description

This pull request changes the following:

This pull request updates the workflow logic in `.github/workflows/flow-hugo-publish.yaml` to refine the conditions for determining whether a run is a versioned release. The changes introduce an additional check for the `docs-build-label` input and improve clarity in logging messages.

Workflow logic updates:

* [`.github/workflows/flow-hugo-publish.yaml`](diffhunk://#diff-d5ec53944df3276238a84b403bcc823827d7b0bd6bc5ee2fb56c629a66555752L99-R108): Added a condition to check if the `docs-build-label` input is set to "main" when determining if the workflow is running as a versioned release. Improved logging messages to differentiate between versioned and non-versioned releases.

### Related Issues

* Closes #731
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
