### PR TITLE
fix: remove requirement for clusterRef flag in mirror node deploy command

### DIFF
--- a/src/commands/mirror-node.ts
+++ b/src/commands/mirror-node.ts
@@ -58,7 +58,7 @@ interface MirrorNodeDeployConfigClass {
   cacheDir: string;
   chartDirectory: string;
   clusterContext: string;
-  clusterRef: ClusterReferenceName;
+  clusterReference: ClusterReferenceName;
   namespace: NamespaceName;
   enableIngress: boolean;
   ingressControllerValueFile: string;
@@ -120,10 +120,11 @@ export class MirrorNodeCommand extends BaseCommand {
   private static readonly DEPLOY_CONFIGS_NAME = 'deployConfigs';
 
   private static readonly DEPLOY_FLAGS_LIST = {
-    required: [flags.clusterRef],
+    required: [],
     optional: [
       flags.cacheDir,
       flags.chartDirectory,
+      flags.clusterRef,
       flags.deployment,
       flags.enableIngress,
       flags.ingressControllerValueFile,
@@ -391,13 +392,17 @@ export class MirrorNodeCommand extends BaseCommand {
 
             context_.config.namespace = namespace;
 
+            context_.config.clusterReference =
+              (this.configManager.getFlag<string>(flags.clusterRef) as string) ??
+              this.k8Factory.default().clusters().readCurrent();
+
             // predefined values first
             context_.config.valuesArg += helpers.prepareValuesFiles(constants.MIRROR_NODE_VALUES_FILE);
             // user defined values later to override predefined values
             context_.config.valuesArg += await self.prepareValuesArg(context_.config);
 
-            context_.config.clusterContext = context_.config.clusterRef
-              ? this.localConfig.configuration.clusterRefs.get(context_.config.clusterRef)?.toString()
+            context_.config.clusterContext = context_.config.clusterReference
+              ? this.localConfig.configuration.clusterRefs.get(context_.config.clusterReference)?.toString()
               : this.k8Factory.default().contexts().readCurrent();
 
             const deploymentName: DeploymentName = self.configManager.getFlag<DeploymentName>(flags.deployment);
@@ -1010,13 +1015,13 @@ export class MirrorNodeCommand extends BaseCommand {
       title: 'Add mirror node to remote config',
       skip: context_ => !this.remoteConfig.isLoaded() || context_.config.isChartInstalled,
       task: async (context_): Promise<void> => {
-        const {namespace, clusterRef} = context_.config;
-        if (!clusterRef) {
+        const {namespace, clusterReference} = context_.config;
+        if (!clusterReference) {
           throw new SoloError('Cluster reference is not defined');
         }
 
         this.remoteConfig.configuration.components.addNewComponent(
-          this.componentFactory.createNewMirrorNodeComponent(clusterRef, namespace),
+          this.componentFactory.createNewMirrorNodeComponent(clusterReference, namespace),
           ComponentTypes.MirrorNode,
         );
 


### PR DESCRIPTION
## Description

Improves the fix from #2228 by removing the required flag `clusterRef` in `solo mirror-node deploy`, thus avoiding adding a potential breaking change in the next solo version.

### Related Issues

* Closes #
* Related to #2228 

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[x] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

```
rm ~/.solo/local-config.yaml
rm -rf ~/.solo/cache
kind create cluster -n solo-e2e
npm run solo -- init
npm run solo -- cluster-ref connect --cluster-ref kind-solo-e2e --context kind-solo-e2e
npm run solo -- deployment create --deployment solo-e2e --namespace solo-e2e --realm 0 --shard 0
npm run solo -- deployment add-cluster --deployment solo-e2e --cluster-ref kind-solo-e2e --num-consensus-nodes 1
npm run solo -- cluster-ref setup --cluster-ref kind-solo-e2e
npm run solo -- node keys --gossip-keys --tls-keys --deployment solo-e2e -i node1
npm run solo -- network deploy --deployment solo-e2e --pvcs true
npm run solo -- node setup --deployment solo-e2e -i node1
npm run solo -- node start --deployment solo-e2e -i node1
npm run solo -- mirror-node deploy --deployment solo-e2e
npm run solo -- mirror-node destroy --deployment solo-e2e
npm run solo -- mirror-node deploy --deployment solo-e2e
```

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
