### PR TITLE
feat: add stale issue/pull request closer automation

### DIFF
--- a/.github/workflows/zxf-stale-issue-pr-closer.yaml
+++ b/.github/workflows/zxf-stale-issue-pr-closer.yaml
@@ -1,0 +1,39 @@
+name: 'ZXF: Stale Issue/PR Closer'
+
+on:
+  schedule:
+    - cron: '15 */1 * * *'
+  workflow_dispatch:
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  actions: write
+  issues: write
+  pull-requests: write
+  contents: write
+
+jobs:
+  stale-pull-requests:
+    name: Stale Pull Requests
+    runs-on: hiero-solo-linux-medium
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@f4a75cfd619ee5ce8d5b864b0d183aff3c69b55a # v2.13.1
+        with:
+          egress-policy: audit
+
+      - name: Close Stale Pull Requests
+        uses: actions/stale@3a9db7e6a41a89f618792c92c0e97cc736e1b13f # v10.0.0
+        with:
+          enable-statistics: true
+          delete-branch: true
+          days-before-issue-stale: -1
+          days-before-pr-stale: 14
+          days-before-issue-close: -1
+          days-before-pr-close: 14
+          stale-pr-message: 'This pull request is stale because it has been open 14 days with no activity. Remove stale label or comment on this pull request; otherwise, this pull request will be closed in 14 days.'
+          close-pr-message: 'This pull request was closed because it has been stalled for 14 days with no activity.'
+


### PR DESCRIPTION
## Description

This pull request introduces a new GitHub Actions workflow to automatically close stale pull requests in the repository. The workflow is designed to run hourly and uses the `actions/stale` action to identify and close pull requests that have had no activity for 14 days.

Automation of stale pull request management:

* Added `.github/workflows/zxf-stale-issue-pr-closer.yaml` to define a scheduled workflow that runs every hour and can also be triggered manually.
* Configured the workflow to use the `actions/stale` action, which marks pull requests as stale after 14 days of inactivity and closes them if there is no further activity for another 14 days. Branches associated with closed pull requests are also deleted.
* Set custom messages for marking pull requests as stale and for closing them, to inform contributors about the reason for closure.
* Included permissions and runner hardening steps to ensure secure operation of the workflow.

### Related Issues

* Closes #2666

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[x] This PR added no TODOs or commented out code
* \[x] This PR has no breaking changes
* \[x] Any technical debt has been documented as a separate issue and linked to this PR
* \[x] Any `package.json` changes have been explained to and approved by a repository manager
* \[x] All related issues have been linked to this PR
* \[x] All changes in this PR are included in the description
* \[x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[x] These changes required manual testing that is documented below
* \[x] Anything not tested is documented

The following manual testing was done:

* Ran the workflow using the workflow dispatch trigger and confirmed the desired behavior.

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
