### PR TITLE
chore: update README node.js requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,8 @@ Every quarter a version will be designated as LTS (Long-Term Support) and will b
 
 | Solo Version | Node.js               | Kind       | Solo Chart | Hedera   | Kubernetes | Kubectl    | Helm    | k9s        | Docker Resources         | Release Date | End of Support |
 |--------------|-----------------------|------------|------------|----------|------------|------------|---------|------------|--------------------------|--------------|----------------|
-| 0.47.0       | >= 20.18.0 (lts/iron) | >= v0.26.0 | v0.56.0    | v0.66.0+ | >= v1.27.3 | >= v1.27.3 | v3.14.2 | >= v0.27.4 | Memory >= 12GB, CPU >= 4 | 2025-10-16   | 2025-11-16     |
-| 0.46.0 (LTS) | >= 20.18.0 (lts/iron) | >= v0.26.0 | v0.56.0    | v0.65.1+ | >= v1.27.3 | >= v1.27.3 | v3.14.2 | >= v0.27.4 | Memory >= 12GB, CPU >= 4 | 2025-10-02   | 2026-01-02     |
+| 0.47.0       | >= 20.19.0 (lts/iron) | >= v0.26.0 | v0.56.0    | v0.66.0+ | >= v1.27.3 | >= v1.27.3 | v3.14.2 | >= v0.27.4 | Memory >= 12GB, CPU >= 4 | 2025-10-16   | 2025-11-16     |
+| 0.46.0 (LTS) | >= 20.19.0 (lts/iron) | >= v0.26.0 | v0.56.0    | v0.65.1+ | >= v1.27.3 | >= v1.27.3 | v3.14.2 | >= v0.27.4 | Memory >= 12GB, CPU >= 4 | 2025-10-02   | 2026-01-02     |
 
 To see a list of legacy releases, please check the [legacy versions documentation page](docs/legacy-versions.md).
 


### PR DESCRIPTION
## Description

* Updates the Node.js version from `20.18.0` to `20.19.0` to fix unsupported engine. npm warning:

```
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'yargs@18.0.0',
npm warn EBADENGINE   required: { node: '^20.19.0 || ^22.12.0 || >=23' },
npm warn EBADENGINE   current: { node: 'v20.18.0', npm: '10.8.2' }
npm warn EBADENGINE }
npm warn EBADENGINE Unsupported engine {
npm warn EBADENGINE   package: 'yargs-parser@22.0.0',
npm warn EBADENGINE   required: { node: '^20.19.0 || ^22.12.0 || >=23' },
npm warn EBADENGINE   current: { node: 'v20.18.0', npm: '10.8.2' }
npm warn EBADENGINE }
```

* Confirmed that bumping the version removes the warning

### Related Issues

* Closes # https://github.com/hiero-ledger/solo/issues/2749