### PR TITLE
feat: add env `SOLO_DEV_OUTPUT` which when set will enable the `--dev` flag

### DIFF
--- a/src/commands/flags.ts
+++ b/src/commands/flags.ts
@@ -145,7 +145,7 @@ export class Flags {
     name: 'dev',
     definition: {
       describe: 'Enable developer mode',
-      defaultValue: false,
+      defaultValue: constants.SOLO_DEV_OUTPUT,
       type: 'boolean',
     },
     prompt: undefined,

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -35,6 +35,8 @@ export const KUBECTL = 'kubectl';
 export const DEFAULT_CLUSTER = 'solo-cluster';
 export const RESOURCES_DIR = PathEx.joinWithRealPath(ROOT_DIR, 'resources');
 
+export const SOLO_DEV_OUTPUT: boolean = Boolean(getEnvironmentVariable('SOLO_DEV_OUTPUT')) || false;
+
 export const ROOT_CONTAINER = ContainerName.of('root-container');
 export const SOLO_REMOTE_CONFIGMAP_NAME = 'solo-remote-config';
 export const SOLO_REMOTE_CONFIGMAP_LABELS = {'solo.hedera.com/type': 'remote-config'};


### PR DESCRIPTION
## Description

Added new environmental variable `SOLO_DEV_OUTPUT` when set it will act as if `--dev` flag is passed to each command

### Related Issues

* Closes # https://github.com/hiero-ledger/solo/issues/2755
