### PR TITLE
chore: Create good-first-issue-candidate template

### DIFF
--- a/.github/ISSUE_TEMPLATE/good-first-issue-candidate.yaml
+++ b/.github/ISSUE_TEMPLATE/good-first-issue-candidate.yaml
@@ -1,0 +1,86 @@
+name: Good First Issue Candidate
+description: Suggest an idea for this project
+labels: [ "Good First Issue Candidate" ]
+type: Feature
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## Thanks for submitting a Good First Issue!
+        
+        This issue targets first time contributors to [Hiero](https://hiero.org).
+        We know that creating a pull request (PR) is a major barrier for new contributors.
+        The goal of this issue (and all other issues labeled with) [**'Good First Issue'**](https://github.com/issues?q=is%3Aopen+is%3Aissue+org%3Ahiero-ledger+archived%3Afalse+label%3A%22good+first+issue%22+) is to help you make your first contribution to Hiero.
+
+        Before submitting:
+        * Try searching the existing issues and discussions to see if something similar has been discussed previously.
+        * Try opening a GitHub discussion first to gather feedback and reach consensus.
+        * If this is a major enhancement, please open a [Hiero Improvement Proposal](https://github.com/hiero-ledger/hiero-improvement-proposals).
+
+        ------
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem
+      description: What is the problem you are trying to solve?
+      placeholder: |
+        AT THIS SECTION YOU NEED TO DESCRIBE THE ISSUE IN A WAY THAT IS UNDERSTANDABLE TO NEW CONTRIBUTORS.
+        YOU MUST NOT ASSUME THAT SUCH CONTRIBUTORS HAVE ANY KNOWLEDGE ABOUT THE CODEBASE OR HIERO.
+        IT IS HELPFUL TO ADD LINKS TO THE RELEVANT DOCUMENTATION AND/OR CODE SECTIONS.
+    validations:
+      required: true
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed Solution
+      description: What solution do you propose to solve the problem?
+      placeholder: |
+        AT THIS SECTION YOU NEED TO DESCRIBE THE STEPS NEEDED TO SOLVE THE ISSUE.
+        PLEASE BREAK DOWN THE STEPS AS MUCH AS POSSIBLE AND MAKE SURE THAT THEY ARE EASY TO FOLLOW.
+        IF POSSIBLE, ADD LINKS TO THE RELEVANT DOCUMENTATION AND/OR CODE SECTIONS.
+    validations:
+      required: true
+  - type: textarea
+    id: Implementation
+    attributes:
+      label: Implementation
+      description: What technical steps need to be taken?
+      placeholder: |
+        AT THIS SECTION YOU NEED TO DESCRIBE THE TECHNICAL STEPS NEEDED TO SOLVE THE ISSUE.
+        PLEASE BREAK DOWN THE STEPS AS MUCH AS POSSIBLE AND MAKE SURE THAT THEY ARE EASY TO FOLLOW.
+        IF POSSIBLE, ADD LINKS TO THE RELEVANT DOCUMENTATION AND/OR CODE.
+  - type: markdown
+    attributes:
+      value: |
+        ------
+        
+        ## Making Contributions
+        
+        If you have never contributed to an open source project at GitHub, the following step-by-step guide will introduce you to the workflow.
+        More information and concrete samples for shell commands for each step can be found in our [CONTRIBUTING.md](https://github.com/hiero-ledger/.github/blob/main/CONTRIBUTING.md) file.
+        A more detailed general documentation of the GitHub PR workflow can be found [here](https://github.com/firstcontributions/first-contributions/blob/master/README.md).
+        
+        - [ ] **Claim this issue:** Comment below that you are interested in working on the issue
+        - [ ] **Wait for assignment:** A community member with the given rights will add you as an assignee of the issue
+        - [ ] **Work on the issue:** Follow the detailed description in our [CONTRIBUTING.md](https://github.com/hiero-ledger/.github/blob/main/CONTRIBUTING.md) file.
+        - [ ] **You did it 🎉:** We will merge the fix in the main branch. Thanks for being part of the Hiero community as an open-source contributor!
+
+        ------
+  - type: markdown
+    attributes:
+      value: |
+        ## :jack_o_lantern: Hacktoberfest :jack_o_lantern:
+        
+        At the time of the [Hacktoberfest](https://hacktoberfest.digitalocean.com) event we try to mark all PRs that solve any good first issue with the `hacktoberfest-accepted` label.
+        If you want to resolve this issue as part of Hacktoberfest and we missed adding the label, simply add a comment to the issue or PR, and we will add it.
+        
+        ------
+  - type: markdown
+    attributes:
+      value: |
+        ## Additional Questions
+        
+        If you have any questions about the topic of this issue, please ask us directly by adding a comment below.
+        Additionally, we invite you to join our community on our [Discord](https://discord.gg/kEnnmB9A) server or attend our [public community calls](https://zoom-lfx.platform.linuxfoundation.org/meetings/hiero?view=week).
+        
+        A general manual about open-source contributions can be found [here](https://github.com/firstcontributions/first-contributions/blob/master/README.md).


### PR DESCRIPTION
## Description

This pull request adds a new GitHub issue template designed to help first-time contributors get started with the project. The template provides clear guidance, step-by-step instructions, and helpful resources for submitting a "Good First Issue" candidate.

New contributor support:

* Added `.github/ISSUE_TEMPLATE/good-first-issue-candidate.yaml` to provide a dedicated template for "Good First Issue" submissions, including sections for describing the problem, proposed solution, and implementation steps.
* Included detailed markdown instructions and links to relevant documentation, the project's Discord, community calls, and Hacktoberfest information to make the contribution process more accessible for newcomers.

## Related Issue(s)

Closes #2819