### PR TITLE
ci: Update secrets.NPM_TOKEN to use org level secrets.NPM_HG_TOKEN

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Calculate Next Version
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_HG_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GIT_AUTHOR_NAME: ${{ secrets.GIT_USER_NAME }}
           GIT_AUTHOR_EMAIL: ${{ secrets.GIT_USER_EMAIL }}
@@ -188,7 +188,7 @@ jobs:
 
       - name: Publish Semantic Release
         env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_TOKEN: ${{ secrets.NPM_HG_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
           GIT_AUTHOR_NAME: ${{ secrets.GIT_USER_NAME }}
           GIT_AUTHOR_EMAIL: ${{ secrets.GIT_USER_EMAIL }}


### PR DESCRIPTION
## Description

This pull request updates the environment variables used for NPM authentication in the `.github/workflows/flow-deploy-release-artifact.yaml` GitHub Actions workflow. The main change is switching from the `NPM_TOKEN` secret to the `NPM_HG_TOKEN` secret for steps that require NPM authentication.

Workflow environment variable updates:

* Changed the NPM authentication environment variable from `NPM_TOKEN` to `NPM_HG_TOKEN` in the "Calculate Next Version" job step in `.github/workflows/flow-deploy-release-artifact.yaml`.
* Changed the NPM authentication environment variable from `NPM_TOKEN` to `NPM_HG_TOKEN` in the "Publish Semantic Release" job step in `.github/workflows/flow-deploy-release-artifact.yaml`.

## Related Issue(s)

Closes #2832 