### PR TITLE
chore: rename flag `--ledger-id` to `--chain-id`

### DIFF
--- a/examples/one-shot-falcon/falcon-values.yaml
+++ b/examples/one-shot-falcon/falcon-values.yaml
@@ -10,7 +10,7 @@ network:
   --bootstrap-properties: ""
   --genesis-throttles-file: ""
   --cache-dir: ""
-  --ledger-id: ""
+  --chain-id: ""
   --chart-dir: ""
   --solo-chart-version: ""
   --debug-node-alias: ""
@@ -111,7 +111,7 @@ relayNode:
   --values-file: ""
   --node-aliases: ""
   --replica-count: 1
-  --ledger-id: ""
+  --chain-id: ""
   --domain-name: ""
   --operator-id: ""
   --operator-key: ""

--- a/src/commands/flags.ts
+++ b/src/commands/flags.ts
@@ -817,9 +817,9 @@ export class Flags {
 
   public static readonly chainId: CommandFlag = {
     constName: 'chainId',
-    name: 'ledger-id',
+    name: 'chain-id',
     definition: {
-      describe: 'Ledger ID (a.k.a. Chain ID)',
+      describe: 'Chain ID',
       defaultValue: constants.HEDERA_CHAIN_ID, // Ref: https://github.com/hiero-ledger/hiero-json-rpc-relay#configuration
       alias: 'l',
       type: 'string',


### PR DESCRIPTION
## Description

* Renamed flag `--ledger-id` to `--chain-id`
* Renamed referencest and usages of the flag

!BREAKING CHANGE!
Possibly breaking change to users using the old flag name


### Related Issues

* Closes # https://github.com/hiero-ledger/solo/issues/2798