### PR TITLE
chore(docs): fix the cli name migration documentation

### DIFF
--- a/docs/site/content/en/docs/cli-migrations.md
+++ b/docs/site/content/en/docs/cli-migrations.md
@@ -38,8 +38,8 @@ type: docs
 
 | **Old Command**            | **New Command**  |
 |----------------------------|------------------|
-| one-shot single deploy  | one shot deploy  |
-| one-shot single destroy | one shot destroy |
+| quick-start single deploy  | one-shot single deploy  |
+| quick-start single destroy | one-shot single destroy |
 
 ## Cluster Reference
 


### PR DESCRIPTION
## Description

* Updated the documentation's migration guide mapping to point to the correct name

### Related Issues

* Closes # https://github.com/hiero-ledger/solo/issues/2797

