### PR TITLE
chore(ci): update commit analyzer to use conventionalcommits preset

### DIFF
--- a/.releaserc
+++ b/.releaserc
@@ -1,11 +1,16 @@
 {
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits"
+      }
+    ],
     [
       "@semantic-release/release-notes-generator",
       {
         "preset": "conventionalcommits"
-      },
+      }
     ],
     "@semantic-release/npm",
     "@semantic-release/git",


### PR DESCRIPTION
**Description**:

Update the releaserc file commit analyzer plugin to use the conventional commits preset.

**Related Issue(s)**:

Fixes #2877
