### PR TITLE
chore(test): migrate `block-node.test.ts` to invoking via main()

### DIFF
--- a/test/e2e/commands/block-node.test.ts
+++ b/test/e2e/commands/block-node.test.ts
@@ -19,6 +19,7 @@ import {DeploymentTest} from './tests/deployment-test.js';
 import {NodeTest} from './tests/node-test.js';
 import {NetworkTest} from './tests/network-test.js';
 import {BlockNodeTest} from './tests/block-node-test.js';
+import {sleep} from '../../../src/core/helpers.js';
 
 const testName: string = 'block-node-test';
 
@@ -61,6 +62,8 @@ new EndToEndTestSuiteBuilder()
         resetForTest(namespace.name, testCacheDirectory, false);
         testLogger.info(`${testName}: finished resetting containers for each test`);
       });
+
+      afterEach(async (): Promise<void> => await sleep(Duration.ofMillis(5)));
 
       InitTest.init(options);
       ClusterReferenceTest.connect(options);

--- a/test/e2e/commands/tests/block-node-test.ts
+++ b/test/e2e/commands/tests/block-node-test.ts
@@ -74,7 +74,6 @@ export class BlockNodeTest extends BaseCommandTest {
   public static add(options: BaseTestOptions): void {
     const {testName, deployment, clusterReferenceNameArray, localBuildReleaseTag, enableLocalBuildPathTesting} =
       options;
-
     const {soloBlockNodeDeployArgv} = BlockNodeTest;
 
     it(`${testName}: block node add`, async (): Promise<void> => {


### PR DESCRIPTION
## Description

migrate `block-node.test.ts` to invoking via main() instead of command invoker

### Related Issues

* Closes # https://github.com/hiero-ledger/solo/issues/2971
