### PR TITLE
ci: remove draft check from hugo docs build step

### DIFF
--- a/.github/workflows/flow-pull-request-checks.yaml
+++ b/.github/workflows/flow-pull-request-checks.yaml
@@ -159,6 +159,10 @@ jobs:
     name: Hugo Docs Build
     uses: ./.github/workflows/zxc-hugo-build.yaml
     # If it is a workflow dispatch AND we are skipping unit test and coverage, skip Hugo Docs Build job
-    if: ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.skip-unit-and-coverage) }}
+    # If it is a PR, check if it's a draft PR. If a draft PR, check if it starts with 'trunk-merge', if true then run Hugo Docs Build job
+    # If it is regular PR, always run Hugo Docs Build job
+    if: >
+      ${{ !(github.event_name == 'workflow_dispatch' && github.event.inputs.skip-unit-and-coverage) ||
+      (github.event_name == 'pull_request' && (github.event.pull_request.draft == false || startsWith(github.event.pull_request.title, 'trunk-merge'))) }}
     with:
       ref: ${{ github.ref }}


### PR DESCRIPTION
**Description**:

Remove the draft PR check from hugo docs build step to fix an issue with mandatory checks not running in Trunk for Merge Queues.

**Related Issue(s)**:

Fixes #3123

## Description

This pull request changes the following:

* TBD

### Related Issues

* Closes #
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[x] This PR added no TODOs or commented out code
* \[x] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[x] All related issues have been linked to this PR
* \[x] All changes in this PR are included in the description
* \[x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[x] Anything not tested is documented

The following was not tested:

* Cannot test this PR until merge because the PR checks run workflows from `main` against PRs.

