### PR TITLE
fix: update semantic release version found and add upload skip

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -217,19 +217,6 @@ jobs:
           
           npx semantic-release --no-sign ${FLAGS}
 
-      - name: Inspect Folders
-        run: |
-          echo "::group::Inspecting Folders"
-          echo "Output folder:"
-          ls -al ./output
-          echo "-----"
-          echo "Workflow root:"
-          ls -al .
-          echo "-----"
-          echo "Finding artifact: ${{ steps.set-publish-data.outputs.artifact-name }}"
-          find . -name "${{ steps.set-publish-data.outputs.artifact-name }}"
-          echo "::endgroup::"
-
       # Upload the artifact
       - name: Upload Solo Package Artifact
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0

--- a/.releaserc
+++ b/.releaserc
@@ -48,7 +48,7 @@
   ],
   "branches":[
     {
-      "name": "3132-fix-semantic-release"
+      "name": "main"
     },
     {
       "name": "release/([0-9]+).([0-9]+)",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hashgraph/solo",
-  "version": "0.53.0-beta.1",
+  "version": "0.53.0",
   "description": "An opinionated CLI tool to deploy and manage private Hedera Networks.",
   "main": "./dist/src/index.js",
   "type": "module",


### PR DESCRIPTION
## Description

This PR changes two items:
1. The way semantic release version is found. We generate a VERSION file using semantic release dry run, then use that calculated version in all steps of the release workflow.
2. We skip the `Upload Solo Package Artifacts` on a dry run.

### Related Issues

* Closes #3132 

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

- Many dry-runs on private branch. Will also dry run on `main` branch once PR has merged.

