### PR TITLE
ci: add dry run enabled check to publish NPM package step

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -272,9 +272,6 @@ jobs:
       - name: Publish Solo NPM Package
         run: |
           args="--access=public"
-          if [[ "${{ inputs.dry-run-enabled }}" == "true" ]]; then
-            args="${args} --dry-run"
-          fi
           
           package="${{ needs.create-github-release.outputs.npm-artifact-name }}"
           echo "::group::Publishing package: ${package} with args: ${args}"


### PR DESCRIPTION
**Description**:

Add a dry run enabled check to run or skip the publish NPM package step.

**Related Issue(s)**:

Implements #3134

