### PR TITLE
chore(block-node): add support for new block-nodes.json field name for port #3162

### DIFF
--- a/src/core/block-nodes-json-wrapper.ts
+++ b/src/core/block-nodes-json-wrapper.ts
@@ -41,6 +41,10 @@ export class BlockNodesJsonWrapper implements ToJSON {
   }
 
   public toJSON(): string {
+    return JSON.stringify(this.buildBlockNodesJsonStructure());
+  }
+
+  public buildBlockNodesJsonStructure(): BlockNodesJsonStructure {
     const blockNodeConnectionData: BlockNodeConnectionData[] = [];
 
     for (const [id, priority] of this.blockNodeMap) {
@@ -77,11 +81,9 @@ export class BlockNodesJsonWrapper implements ToJSON {
       );
     }
 
-    const data: BlockNodesJsonStructure = {
+    return {
       nodes: blockNodeConnectionData,
       blockItemBatchSize: constants.BLOCK_ITEM_BATCH_SIZE,
     };
-
-    return JSON.stringify(data);
   }
 }

--- a/version.ts
+++ b/version.ts
@@ -44,8 +44,7 @@ export const MINIMUM_HIERO_BLOCK_NODE_VERSION_FOR_NEW_LIVENESS_CHECK_PORT: SemVe
 
 export const MINIMUM_HIERO_PLATFORM_VERSION_FOR_BLOCK_NODE: string = 'v0.64.0';
 export const MINIMUM_HIERO_PLATFORM_VERSION_FOR_GRPC_WEB_ENDPOINTS: string = 'v0.62.0';
-export const MINIMUM_HIERO_CONSENSUS_NODE_VERSION_FOR_LEGACY_PORT_NAME_FOR_BLOCK_NODES_JSON_FILE: string =
-  constants.getEnvironmentVariable('PROMETHEUS_OPERATOR_CRDS_VERSION') || '0.70.0';
+export const MINIMUM_HIERO_CONSENSUS_NODE_VERSION_FOR_LEGACY_PORT_NAME_FOR_BLOCK_NODES_JSON_FILE: string = '0.70.0';
 
 export function getSoloVersion(): Version {
   if (process.env.npm_package_version) {


### PR DESCRIPTION
## Description

There is an update to the `block-nodes.json` file inside the consensus node starting verison `0.70.0` where the `port` field is renamed to `streamingPort`. This PR adds logic to figure out the field name and produce the updated schema if requried.


### Related Issues

* Closes # https://github.com/hiero-ledger/solo/issues/3162
