### PR TITLE
fix(rapid-fire): use same gRPC port for all consensus nodes in NLG

### DIFF
--- a/src/commands/rapid-fire.ts
+++ b/src/commands/rapid-fire.ts
@@ -133,7 +133,7 @@ export class RapidFireCommand extends BaseCommand {
                 .pods()
                 .list(context_.config.namespace, ['solo.hedera.com/type=haproxy']);
 
-              let port: number = constants.GRPC_PORT;
+              const port: number = constants.GRPC_PORT;
               const networkProperties: string[] = haproxyPods.map((pod: Pod) => {
                 const accountId = pod.labels['solo.hedera.com/account-id'] ?? 'unknown';
                 // Using multiple backslashes to ensure it is not stripped when the network.properties file is generated


### PR DESCRIPTION
The port variable was incorrectly incremented for each HAProxy pod, causing NLG to attempt connections on ports 50212, 50213, etc. instead of the standard gRPC port 50211 for all nodes.


Fixes #3200 
