### PR TITLE
chore(docs): update .md files and remove deprecated flag

### DIFF
--- a/docs/site/content/en/docs/platform-developer.md
+++ b/docs/site/content/en/docs/platform-developer.md
@@ -52,7 +52,6 @@ If need to provide customized configuration files for Hedera application, please
 * `--api-permission-properties` - to provide custom api-permission.properties file
 * `--bootstrap-properties` - to provide custom bootstrap.properties file
 * `--application-properties` - to provide custom application.properties file
-* `--block-node-cfg` - to configure block node routing for each consensus node
 
 For example:
 
@@ -62,19 +61,12 @@ solo consensus network deploy --deployment "${SOLO_DEPLOYMENT}" -i node1,node2,n
 
 ### Block Node Routing Configuration
 
-For network delay testing and simulating different network topologies, you can configure how each consensus node sends blocks to specific block nodes using the `--block-node-cfg` flag:
+For network delay testing and simulating different network topologies, you can configure how each consensus node sends blocks to specific block nodes using the `--priority-mapping` flag:
 
 ```bash
-# Using JSON string directly
-solo consensus network deploy --deployment "${SOLO_DEPLOYMENT}" \
-  -i node1,node2,node3 \
-  --block-node-cfg '{"node1":[1,3],"node2":[2],"node3":[1,2]}'
-
-# Or using a JSON file
-echo '{"node1":[1,3],"node2":[2],"node3":[1,2]}' > block-config.json
-solo consensus network deploy --deployment "${SOLO_DEPLOYMENT}" \
-  -i node1,node2,node3 \
-  --block-node-cfg block-config.json
+solo block node add --deployment "${SOLO_DEPLOYMENT}" --priority-mapping node1,node2
+solo block node add --deployment "${SOLO_DEPLOYMENT}" --priority-mapping node2,node3
+solo block node add --deployment "${SOLO_DEPLOYMENT}" --priority-mapping node1
 ```
 
 This configuration maps consensus node names to arrays of block node IDs. For example:
@@ -82,3 +74,4 @@ This configuration maps consensus node names to arrays of block node IDs. For ex
 * `node1` sends blocks to block nodes 1 and 3
 * `node2` sends blocks to block node 2
 * `node3` sends blocks to block nodes 1 and 2
+

--- a/examples/network-with-block-node/README.md
+++ b/examples/network-with-block-node/README.md
@@ -62,54 +62,23 @@ You can adjust the number of nodes and other settings by editing the `vars:` sec
 
 ### Advanced: Block Node Routing Configuration
 
-The `--block-node-cfg` flag allows you to configure how each consensus node sends blocks to specific block nodes.
+The `--priority-mapping` flag allows you to configure how each consensus node sends blocks to specific block nodes.
 
 #### Usage
 
-The flag accepts either:
-
-1. **JSON string directly**:
-   ```bash
-   solo consensus network deploy --block-node-cfg '{"node1":[1,3],"node2":[2]}'
-   ```
-
-2. **Path to a JSON file**:
-   ```bash
-   # Create block-config.json
-   echo '{"node1":[1,3],"node2":[2]}' > block-config.json
-
-   # Use the file
-   solo consensus network deploy --block-node-cfg block-config.json
-   ```
-
-#### Configuration Format
-
-The JSON configuration maps consensus node names to arrays of block node IDs:
-
-```json
-{
-  "node1": [1, 3],
-  "node2": [2]
-}
+```bash
+solo block node add --deployment my-network --priority-mapping node1
+solo block node add --deployment my-network --priority-mapping node1,node2=10
 ```
 
 This example means:
-
-* Consensus node `node1` sends blocks to block nodes 1 and 3
+* Consensus node `node1` sends blocks to block nodes 1 and 2
+  * Block node 1 priority is 2
+  * Block node 2 priority is 1
 * Consensus node `node2` sends blocks to block node 2
+  * Block node 1 priority is 1
+  * Block node 2 priority is 10
 
-#### Example: Multi-Node Setup with Custom Routing
+#### Multi-Cluster Setup with Custom Routing
 
-```bash
-# Deploy network with 3 consensus nodes and 3 block nodes
-solo consensus network deploy \
-  --deployment my-network \
-  --number-of-consensus-nodes 3 \
-  --block-node-cfg '{"node1":[1],"node2":[2],"node3":[3]}'
-
-# This creates isolated routing: each consensus node talks to one block node
-```
-
-***
-
-This example is self-contained and does not require any files from outside this directory.
+`block-nodes.json` uses Fully Qualified Domain Names (FQDNs) to route each block node, so it works with multi-cluster setups out of the box.

--- a/src/commands/flags.ts
+++ b/src/commands/flags.ts
@@ -1157,21 +1157,6 @@ export class Flags {
     prompt: undefined,
   };
 
-  public static readonly blockNodeCfg: CommandFlag = {
-    constName: 'blockNodeCfg',
-    name: 'block-node-cfg',
-    definition: {
-      describe:
-        'Configure block node routing for each consensus node. ' +
-        'Maps consensus node names to block node IDs and optional priority (default priority = 1). ' +
-        'Accepts: (1) JSON string: \'{"node1":["1=2","3=1"],"node2":["2"]}\' or (2) path to JSON file: \'block.json\'. ' +
-        'Example: node1 sends blocks to block nodes 1 and 3, node2 sends blocks to block node 2',
-      defaultValue: '',
-      type: 'string',
-    },
-    prompt: undefined,
-  };
-
   public static readonly priorityMapping: CommandFlag = {
     constName: 'priorityMapping',
     name: 'priority-mapping',
@@ -2963,7 +2948,6 @@ export class Flags {
     Flags.domainName,
     Flags.domainNames,
     Flags.blockNodeChartVersion,
-    Flags.blockNodeCfg,
     Flags.priorityMapping,
     Flags.externalBlockNodeAddress,
     Flags.realm,

--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -223,7 +223,6 @@ export class NetworkCommand extends BaseCommand {
       flags.backupRegion,
       flags.backupProvider,
       flags.domainNames,
-      flags.blockNodeCfg,
       flags.serviceMonitor,
       flags.podLog,
       flags.enableMonitoringSupport,


### PR DESCRIPTION
## Description

* Remove the last traces of `--block-nodes-cfg` as it's now unused.
* Update the documentation.