### PR TITLE
chore(docs): update presentation layer cli architecture doc

### DIFF
--- a/docs/design/architecture/system/presentation_layer_cli_architecture.md
+++ b/docs/design/architecture/system/presentation_layer_cli_architecture.md
@@ -41,7 +41,7 @@ platform.
     * [Cluster](#cluster)
     * [Config](#config-1)
     * [State](#state-1)
-    * [Diagnostic](#diagnostic)
+    * [Diagnostics](#diagnostics)
   * [Explorer](#explorer-1)
     * [Node](#node-2)
   * [Keys](#keys-1)
@@ -132,30 +132,30 @@ flags may be specified at any level of the command hierarchy.
 
 ### Final Vision
 
-| Group       | Resource               | Operation(s)                                                                       |
-|-------------|------------------------|------------------------------------------------------------------------------------|
-| block       | node                   | < list & info & logs & add & upgrade & destroy >                                   |
-| cluster-ref | config                 | < list & info & connect & disconnect >                                             |
-| consensus   | network                | < info & deploy & freeze & upgrade & destroy >                                     |
-| consensus   | node                   | < list & info & logs & add & update & destroy & start & stop & restart & refresh > |
-| consensus   | state                  | < list & download & upload >                                                       |
-| consensus   | dev-node-add           | < prepare & submit-transactions & execute >                                        |
-| consensus   | dev-node-update        | < prepare & submit-transactions & execute >                                        |
-| consensus   | dev-node-upgrade       | < prepare & submit-transactions & execute >                                        |
-| consensus   | dev-node-delete        | < prepare & submit-transactions & execute >                                        |
-| consensus   | dev-freeze             | < prepare-upgrade & freeze-upgrade >                                               |
-| deployment  | config                 | < list & info & create & delete & import >                                         |
-| deployment  | cluster                | < list & info & attach & detach >                                                  |
-| deployment  | state                  | < info & destroy >                                                                 |
-| deployment  | diagnostic             | < logs & configs & all & connections >                                             |
-| explorer    | node                   | < list & info & logs & add & upgrade & destroy >                                   |
-| keys        | consensus              | < generate >                                                                       |
-| ledger      | system                 | < init & accounts-rekey & staking-setup >                                          |
-| ledger      | account                | < list & info & create & update & delete & import >                                |
-| ledger      | crypto                 | < transfer & balance >                                                             |
-| ledger      | file                   | < create & update >                                                                |
-| mirror      | node                   | < list & info & logs & add & upgrade & destroy >                                   |
-| relay       | node                   | < list & info & logs & add & upgrade & destroy >                                   |
+| Group       | Resource           | Operation(s)                                                                       |
+|-------------|--------------------|------------------------------------------------------------------------------------|
+| block       | node               | < list & info & logs & add & upgrade & destroy >                                   |
+| cluster-ref | config             | < list & info & connect & disconnect >                                             |
+| consensus   | network            | < info & deploy & freeze & upgrade & destroy >                                     |
+| consensus   | node               | < list & info & logs & add & update & destroy & start & stop & restart & refresh > |
+| consensus   | state              | < list & download & upload >                                                       |
+| consensus   | dev-node-add       | < prepare & submit-transactions & execute >                                        |
+| consensus   | dev-node-update    | < prepare & submit-transactions & execute >                                        |
+| consensus   | dev-node-upgrade   | < prepare & submit-transactions & execute >                                        |
+| consensus   | dev-node-delete    | < prepare & submit-transactions & execute >                                        |
+| consensus   | dev-freeze         | < prepare-upgrade & freeze-upgrade >                                               |
+| deployment  | config             | < list & info & create & delete & import >                                         |
+| deployment  | cluster            | < list & info & attach & detach >                                                  |
+| deployment  | state              | < info & destroy >                                                                 |
+| deployment  | diagnostics        | < logs & configs & all & connections >                                             |
+| explorer    | node               | < list & info & logs & add & upgrade & destroy >                                   |
+| keys        | consensus          | < generate >                                                                       |
+| ledger      | system             | < init & accounts-rekey & staking-setup >                                          |
+| ledger      | account            | < list & info & create & update & delete & import >                                |
+| ledger      | crypto             | < transfer & balance >                                                             |
+| ledger      | file               | < create & update >                                                                |
+| mirror      | node               | < list & info & logs & add & upgrade & destroy >                                   |
+| relay       | node               | < list & info & logs & add & upgrade & destroy >                                   |
 | one-shot    | < single & multi > | < info & deploy & destroy >                                                        |
 
 #### Example Commands
@@ -273,12 +273,12 @@ associated with each group.
 
 ### Deployment
 
-| Resource Name  | Command Syntax | Description                                                                                                                                       |
-|----------------|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
-| **Cluster**    | `cluster`      | View and manage Solo cluster references used by a deployment.                                                                                     |
-| **Config**     | `config`       | List, view, create, delete, and import deployments. These commands affect the local configuration only.                                           |
-| **State**      | `state`        | View the actual state of the deployment on the Kubernetes clusters or teardown/destroy all remote and local configuration for a given deployment. |
-| **Diagnostic** | `diagnostic`   | Capture diagnostic information such as logs, signed states, and ledger/network/node configurations.                                               |
+| Resource Name   | Command Syntax | Description                                                                                                                                       |
+|-----------------|----------------|---------------------------------------------------------------------------------------------------------------------------------------------------|
+| **Cluster**     | `cluster`      | View and manage Solo cluster references used by a deployment.                                                                                     |
+| **Config**      | `config`       | List, view, create, delete, and import deployments. These commands affect the local configuration only.                                           |
+| **State**       | `state`        | View the actual state of the deployment on the Kubernetes clusters or teardown/destroy all remote and local configuration for a given deployment. |
+| **Diagnostics** | `diagnostics`  | Capture diagnostic information such as logs, signed states, and ledger/network/node configurations.                                               |
 
 <p align="right">
 :arrow_up_small: <a href="#table-of-contents">Back to top</a>
@@ -432,7 +432,7 @@ operations associated with each resource.
 :arrow_up_small: <a href="#table-of-contents">Back to top</a>
 </p>
 
-#### Diagnostic
+#### diagnostics
 
 | Operation Name  | Command Syntax | Description                                                                |
 |-----------------|----------------|----------------------------------------------------------------------------|

--- a/src/commands/command-definitions/deployment-command-definition.ts
+++ b/src/commands/command-definitions/deployment-command-definition.ts
@@ -43,7 +43,7 @@ export class DeploymentCommandDefinition extends BaseCommandDefinition {
     'View the actual state of the deployment on the Kubernetes clusters or ' +
     'teardown/destroy all remote and local configuration for a given deployment.';
 
-  public static readonly DIAGNOSTIC_SUBCOMMAND_NAME = 'diagnostics';
+  public static readonly DIAGNOSTICS_SUBCOMMAND_NAME = 'diagnostics';
   private static readonly DIAGNOSTIC_SUBCOMMAND_DESCRIPTION =
     'Capture diagnostic information such as logs, signed states, and ledger/network/node configurations.';
 
@@ -67,7 +67,7 @@ export class DeploymentCommandDefinition extends BaseCommandDefinition {
     `${DeploymentCommandDefinition.COMMAND_NAME} ${DeploymentCommandDefinition.CONFIG_SUBCOMMAND_NAME} ${DeploymentCommandDefinition.CONFIG_DELETE}` as const;
 
   public static readonly CONNECTIONS_COMMAND =
-    `${DeploymentCommandDefinition.COMMAND_NAME} ${DeploymentCommandDefinition.DIAGNOSTIC_SUBCOMMAND_NAME} ${DeploymentCommandDefinition.DIAGNOSTIC_CONNECTIONS}` as const;
+    `${DeploymentCommandDefinition.COMMAND_NAME} ${DeploymentCommandDefinition.DIAGNOSTICS_SUBCOMMAND_NAME} ${DeploymentCommandDefinition.DIAGNOSTIC_CONNECTIONS}` as const;
 
   public getCommandDefinition(): CommandDefinition {
     return new CommandBuilder(
@@ -128,7 +128,7 @@ export class DeploymentCommandDefinition extends BaseCommandDefinition {
       )
       .addCommandGroup(
         new CommandGroup(
-          DeploymentCommandDefinition.DIAGNOSTIC_SUBCOMMAND_NAME,
+          DeploymentCommandDefinition.DIAGNOSTICS_SUBCOMMAND_NAME,
           DeploymentCommandDefinition.DIAGNOSTIC_SUBCOMMAND_DESCRIPTION,
         )
           .addSubcommand(

--- a/test/e2e/commands/tests/base-command-test.ts
+++ b/test/e2e/commands/tests/base-command-test.ts
@@ -60,7 +60,7 @@ export class BaseCommandTest {
       argv.setArg(Flags.deployment, deployment);
       argv.setCommand(
         DeploymentCommandDefinition.COMMAND_NAME,
-        DeploymentCommandDefinition.DIAGNOSTIC_SUBCOMMAND_NAME,
+        DeploymentCommandDefinition.DIAGNOSTICS_SUBCOMMAND_NAME,
         DeploymentCommandDefinition.DIAGNOSTIC_LOGS,
       );
 

--- a/test/e2e/commands/tests/node-test.ts
+++ b/test/e2e/commands/tests/node-test.ts
@@ -272,7 +272,7 @@ export class NodeTest extends BaseCommandTest {
     const argv: string[] = newArgv();
     argv.push(
       DeploymentCommandDefinition.COMMAND_NAME,
-      DeploymentCommandDefinition.DIAGNOSTIC_SUBCOMMAND_NAME,
+      DeploymentCommandDefinition.DIAGNOSTICS_SUBCOMMAND_NAME,
       DeploymentCommandDefinition.DIAGNOSTIC_CONNECTIONS,
       optionFromFlag(Flags.deployment),
       deployment,

--- a/test/test-utility.ts
+++ b/test/test-utility.ts
@@ -137,7 +137,7 @@ export function startNodesTest(argv: Argv, commandInvoker: CommandInvoker, nodeC
     await commandInvoker.invoke({
       argv: argv,
       command: DeploymentCommandDefinition.COMMAND_NAME,
-      subcommand: DeploymentCommandDefinition.DIAGNOSTIC_SUBCOMMAND_NAME,
+      subcommand: DeploymentCommandDefinition.DIAGNOSTICS_SUBCOMMAND_NAME,
       action: DeploymentCommandDefinition.DIAGNOSTIC_LOGS,
       callback: async (argv): Promise<boolean> => nodeCmd.handlers.logs(argv),
     });


### PR DESCRIPTION
## Description

* add `solo consensus diagnostic connections` command is missing from the CLI architecture documentation.
* rename officially everywhere from `diagnostic` -> `diagnostics`
* update documentation to reflect the move from `solo consensus diagnostic` -> `solo deployment diagnostics`
Issue:

### Related Issues

* Closes # https://github.com/hiero-ledger/solo/issues/2983

