### PR TITLE
chore: harden cli entrypoint safety

### DIFF
--- a/solo.ts
+++ b/solo.ts
@@ -9,12 +9,12 @@ import {InjectTokens} from './src/core/dependency-injection/inject-tokens.js';
 import {container} from 'tsyringe-neo';
 import {type ErrorHandler} from './src/core/error-handler.js';
 
-const context: {logger: SoloLogger} = {logger: undefined};
+const context: { logger?: SoloLogger } = {};
 
 await fnm
   .main(process.argv, context)
   .then((): void => {
-    context.logger.info('Solo CLI completed, via entrypoint');
+    context.logger?.info('Solo CLI completed, via entrypoint');
   })
   .catch((error): void => {
     const errorHandler: ErrorHandler = container.resolve(InjectTokens.ErrorHandler);
@@ -22,4 +22,4 @@ await fnm
   });
 // Exit with the proper exit code and force close any open handles that prevent Solo from exiting
 // eslint-disable-next-line n/no-process-exit
-process.exit(process.exitCode);
+process.exit(process.exitCode ?? 0);


### PR DESCRIPTION
Make CLI entrypoint more robust by avoiding undefined logger access and guarding process exit code