### PR TITLE
chore(test-pr): return to default staking.periodMins for all application.properties

### DIFF
--- a/examples/custom-network-config/application.properties
+++ b/examples/custom-network-config/application.properties
@@ -11,8 +11,6 @@ contracts.maxNumWithHapiSigsAccess=0
 autoRenew.targetTypes=
 nodes.gossipFqdnRestricted=false
 hedera.profiles.active=TEST
-# TODO: this is a workaround until prepareUpgrade freeze will recalculate the weight prior to writing the config.txt
-# staking.periodMins=1
 nodes.updateAccountIdAllowed=true
 blockStream.streamMode=RECORDS
 nodes.webProxyEndpointsEnabled=true

--- a/examples/local-build-with-custom-config/application.properties
+++ b/examples/local-build-with-custom-config/application.properties
@@ -11,8 +11,6 @@ contracts.maxNumWithHapiSigsAccess=0
 autoRenew.targetTypes=
 nodes.gossipFqdnRestricted=false
 hedera.profiles.active=TEST
-# TODO: this is a workaround until prepareUpgrade freeze will recalculate the weight prior to writing the config.txt
-# staking.periodMins=1
 nodes.updateAccountIdAllowed=true
 blockStream.streamMode=RECORDS
 nodes.webProxyEndpointsEnabled=true

--- a/resources/templates/application.properties
+++ b/resources/templates/application.properties
@@ -11,8 +11,6 @@ contracts.maxNumWithHapiSigsAccess=0
 autoRenew.targetTypes=
 nodes.gossipFqdnRestricted=false
 hedera.profiles.active=TEST
-## TODO: this is a workaround until prepareUpgrade freeze will recalculate the weight prior to writing the config.txt
-# staking.periodMins=1
 nodes.updateAccountIdAllowed=true
 blockStream.streamMode=RECORDS
 # TODO: we can remove this after we no longer need less than v0.59.x

--- a/scripts/solo-gke-test/application.properties
+++ b/scripts/solo-gke-test/application.properties
@@ -11,8 +11,6 @@ contracts.maxNumWithHapiSigsAccess=0
 autoRenew.targetTypes=
 nodes.gossipFqdnRestricted=false
 hedera.profiles.active=TEST
-# # TODO: this is a workaround until prepareUpgrade freeze will recalculate the weight prior to writing the config.txt
-# staking.periodMins=1
 nodes.updateAccountIdAllowed=true
 blockStream.streamMode=RECORDS
 

--- a/test/data/application.properties
+++ b/test/data/application.properties
@@ -11,7 +11,6 @@ contracts.maxNumWithHapiSigsAccess=0
 autoRenew.targetTypes=
 nodes.gossipFqdnRestricted=false
 hedera.profiles.active=TEST
-# staking.periodMins=1
 nodes.updateAccountIdAllowed=true
 blockStream.streamMode=BOTH
 networkAdmin.exportCandidateRoster=true


### PR DESCRIPTION
## Description

Remove `staking.periodMins=1` from `application.properties`, this changes the behavior from 1 min to 60 mins

### Related Issues

* Closes #

