### PR TITLE
ci(fix): correct double version bump bug

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -237,7 +237,9 @@ jobs:
           npm install -g npm@11.7.0
           npm ci
           echo "VERSION=${{ needs.prepare-release.outputs.version }}"
-          [[ -n "${{ needs.prepare-release.outputs.version }}" ]] && npm version ${{ needs.prepare-release.outputs.version }} -f --no-git-tag-version --allow-same-version
+          if [[ "${{ inputs.dry-run-enabled }}" == "true" ]]; then
+            [[ -n "${{ needs.prepare-release.outputs.version }}" ]] && npm version ${{ needs.prepare-release.outputs.version }} -f --no-git-tag-version --allow-same-version
+          fi
           task build
 
       - name: Upload Logs


### PR DESCRIPTION
**Description**:

Update the release workflow to not double-bump the version number in package and package-lock files.

**Related Issue(s)**:

Fixes #3273
