### PR TITLE
fix(ci): force eslint re-run on target branch during warning comparison

### DIFF
--- a/.github/workflows/zxc-code-style.yaml
+++ b/.github/workflows/zxc-code-style.yaml
@@ -106,7 +106,7 @@ jobs:
           git fetch origin "$target_branch":"$target_branch"
           git checkout "$target_branch"
           npm ci
-          task check
+          task check --force
           branch_warnings=$(get_warnings eslint-branch.log)
           target_warnings=$(get_warnings eslint.log)
           echo "Warnings on branch: $branch_warnings"


### PR DESCRIPTION
## Description

The `task check` command uses source-file checksums to skip execution when no .ts/.md files changed. In CI, the first run (PR branch) caches checksums, and the second run (target branch) skips if sources are identical — leaving `eslint.log` missing and warnings reported as 0.

### Related Issues

* Closes #3428

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* Ran actions and verified.
Warnings on branch: 2940
Warnings on target (main): 2940
✔ Warnings have not increased

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
