### PR TITLE
fix: Create Example Asset Archives

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -358,38 +358,52 @@ jobs:
             jf npm publish
           fi
 
-      - name: Create Example Asset Archives and Upload to Release
+      - name: Create Example Asset Archives
         if: ${{ needs.prepare-release.outputs.need-hg-release == 'true' && !cancelled() && !failure() }}
         env:
           GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
         run: |
-          DRY_RUN="${{ inputs.dry-run-enabled }}"
+          RELEASE_TAG="v${{ needs.prepare-release.outputs.version }}"
+          echo "Creating example asset archives..."
+          task -t scripts/Taskfile.examples.yml create-example-asset-archives UPLOAD_TO_RELEASE=false RELEASE_TAG="${RELEASE_TAG}" CLEAN_UP=false
+          echo "Example assets created."
+
+      - name: Upload Example Asset Archives to Release
+        if: ${{ needs.prepare-release.outputs.need-hg-release == 'true' && inputs.dry-run-enabled != true && !cancelled() && !failure() }}
+        env:
+          GH_TOKEN: ${{ secrets.GH_ACCESS_TOKEN }}
+        run: |
           RELEASE_TAG="v${{ needs.prepare-release.outputs.version }}"
           REPO="${{ github.repository }}"
-          if [[ "${DRY_RUN}" == "true" ]]; then
-            echo "Dry run enabled: creating example archives without release upload."
-            task -t scripts/Taskfile.examples.yml create-example-asset-archives UPLOAD_TO_RELEASE=false RELEASE_TAG="${RELEASE_TAG}" CLEAN_UP=true
-            echo "Example assets created (dry run mode)."
-          else
-            echo "Ensuring GitHub release exists for ${RELEASE_TAG}..."
-            for attempt in {1..12}; do
-              if gh release view "${RELEASE_TAG}" --repo "${REPO}" >/dev/null 2>&1; then
-                echo "Release ${RELEASE_TAG} is available."
-                break
-              fi
-              if [ "${attempt}" -eq 12 ]; then
-                echo "Release ${RELEASE_TAG} not visible after waiting; creating it now."
-                gh release create "${RELEASE_TAG}" --repo "${REPO}" --title "${RELEASE_TAG}" --notes "Automated release bootstrap for example asset upload."
-                break
-              fi
-              echo "Release ${RELEASE_TAG} not visible yet (attempt ${attempt}/12). Waiting 10s..."
-              sleep 10
-            done
 
-            echo "Creating example asset archives for release..."
-            task -t scripts/Taskfile.examples.yml create-example-asset-archives UPLOAD_TO_RELEASE=true RELEASE_TAG="${RELEASE_TAG}" CLEAN_UP=true
-            echo "Example assets created and uploaded to release."
-          fi
+          echo "Ensuring GitHub release exists for ${RELEASE_TAG}..."
+          for attempt in {1..12}; do
+            if gh release view "${RELEASE_TAG}" --repo "${REPO}" >/dev/null 2>&1; then
+              echo "Release ${RELEASE_TAG} is available."
+              break
+            fi
+            if [ "${attempt}" -eq 12 ]; then
+              echo "ERROR: Release ${RELEASE_TAG} not found after waiting."
+              exit 1
+            fi
+            echo "Release ${RELEASE_TAG} not visible yet (attempt ${attempt}/12). Waiting 10s..."
+            sleep 10
+          done
+
+          echo "Uploading example archives to ${RELEASE_TAG}..."
+          for zip in solo-examples/*.zip; do
+            if [[ ! -f "${zip}" ]]; then
+              echo "ERROR: no example zip files found under solo-examples/"
+              exit 1
+            fi
+            gh release upload --clobber "${RELEASE_TAG}" "${zip}" --repo "${REPO}"
+          done
+          echo "Example assets uploaded."
+
+      - name: Cleanup Example Asset Archives
+        if: ${{ needs.prepare-release.outputs.need-hg-release == 'true' && !cancelled() && !failure() }}
+        run: |
+          rm -rf solo-examples
 
       - name: Create Hashgraph NPM Package
         if: ${{ needs.prepare-release.outputs.need-hg-release == 'true' }}


### PR DESCRIPTION
## Description

This pull request updates the release workflow so dry-run and non-dry-run paths execute the same archive-generation logic, while only non-dry-run performs release uploads.

### What changed

- Refactored `flow-deploy-release-artifact.yaml` example asset flow into 3 steps:
  1. `Create Example Asset Archives` (always runs when `need-hg-release == true`)
  2. `Upload Example Asset Archives to Release` (non-dry-run only)
  3. `Cleanup Example Asset Archives` (always runs when `need-hg-release == true`)
- Removed automatic `gh release create ...` fallback from the asset-upload path.
  - Upload step now only waits for release visibility and fails explicitly if missing.
- Normalized dry-run usage to `inputs.dry-run-enabled` in this path (removed mixed `github.event.inputs` usage).

### Why

- Dry-run on main/non-main should exercise the same archive creation path.
- Release upload should be the only behavior gated by dry-run mode.
- Avoid creating releases from a secondary step and preserve semantic-release as the release owner.

### Related Issues

- Related to CI release workflow stability regressions around example asset upload timing.

### Pull request (PR) checklist

- [ ] This PR added tests (unit, integration, and/or end-to-end)
- [x] This PR updated documentation
- [x] This PR added no TODOs or commented out code
- [x] This PR has no breaking changes
- [x] Any technical debt has been documented as a separate issue and linked to this PR
- [x] Any `package.json` changes have been explained to and approved by a repository manager
- [x] All related issues have been linked to this PR
- [x] All changes in this PR are included in the description
- [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

- [ ] This PR added unit tests
- [ ] This PR added integration/end-to-end tests
- [x] These changes required manual testing that is documented below
- [x] Anything not tested is documented

The following manual testing was done:

- `task build`
- `task format`
- `task check`

The following was not tested:

- Full end-to-end GitHub Actions run on main with real publish credentials in this local session.