### PR TITLE
fix: predefined AccountIds in one-shot deploy

### DIFF
--- a/src/commands/one-shot/default-one-shot.ts
+++ b/src/commands/one-shot/default-one-shot.ts
@@ -549,7 +549,7 @@ export class DefaultOneShotCommand extends BaseCommand implements OneShotCommand
                           TopicId.fromString(entityId(realm, shard, 1001)),
                         );
                         await entity1001Query.execute(client);
-                      } catch (error: any) {
+                      } catch (error) {
                         try {
                           if (error.message.includes('INVALID_TOPIC_ID')) {
                             const bufferTopic: TopicCreateTransaction = new TopicCreateTransaction().setTopicMemo(


### PR DESCRIPTION
## Description

The predefined accounts created during `solo one-shot single deploy` are supposed to start from `0.0.1002`, but a recent change shifted them to start from `0.0.1001`. It's better to start from 1002 because the predefined accounts are supposed to have the exact same accountIds and Private Keys every time, any change may break users' tests and scripts. The keys and AccountIds are the exact same as the ones in Hedera Local Node, so making sure they remain the same will improve the transition process for users.

Upon investigating the issue I found that originally the entity at 0.0.1001 was a topic created by the Mirror node when it is deployed. The account creation process was recently moved to be executed before the mirror node deployment.

This PR checks if there is a topic at 0.0.1001 and if there isn't one, it creates a buffer topic to bump the next EntityId.

### Related Issues

* Closes #
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
