### PR TITLE
fix: mirror-node x block-node integration

### DIFF
--- a/src/commands/mirror-node.ts
+++ b/src/commands/mirror-node.ts
@@ -935,6 +935,7 @@ VALUES (decode('${exchangeRates}', 'hex'), ${timestamp + '000001'}, ${exchangeRa
             const config: MirrorNodeDeployConfigClass = this.configManager.getConfig(
               MirrorNodeCommand.DEPLOY_CONFIGS_NAME,
               allFlags,
+              [],
             ) as MirrorNodeDeployConfigClass;
 
             context_.config = config;

--- a/version.ts
+++ b/version.ts
@@ -20,8 +20,7 @@ export const VFKIT_VERSION: string = 'v0.6.1';
 export const GVPROXY_VERSION: string = 'v0.8.7';
 export const KUBECTL_VERSION: string = 'v1.32.2';
 export const SOLO_CHART_VERSION: string = constants.getEnvironmentVariable('SOLO_CHART_VERSION') || '0.62.0';
-export const HEDERA_PLATFORM_VERSION: string =
-  constants.getEnvironmentVariable('CONSENSUS_NODE_VERSION') || 'v0.72.0-alpha.3';
+export const HEDERA_PLATFORM_VERSION: string = constants.getEnvironmentVariable('CONSENSUS_NODE_VERSION') || 'v0.71.0';
 export const MIRROR_NODE_VERSION: string = constants.getEnvironmentVariable('MIRROR_NODE_VERSION') || 'v0.146.0';
 export const EXPLORER_VERSION: string = constants.getEnvironmentVariable('EXPLORER_VERSION') || '26.0.0';
 export const HEDERA_JSON_RPC_RELAY_VERSION: string = constants.getEnvironmentVariable('RELAY_VERSION') || '0.73.0';


### PR DESCRIPTION
## Description

- Add new flag variant `--force`
   Description: `Force enable block node integration bypassing the version requirements CN >= v0.72.0, BN >= 0.29.0, CN >= 0.150.0`

- Use new flag to forcefully enable the MN x BN integration

### Related Issues

* Closes # 

### Manual Testing

Versions used:
- MN `v0.148.0`
- BN `0.29.0-SNAPSHOT`
- CN `v0.72.0-alpha.3`

#### Port-forwarded mirror-node-rest and used  `/api/v1/blocks` to fetch data

Request:
```bash
$ curl -sS http://127.0.0.1:8080/api/v1/blocks
```

Response:
```json
{
   "blocks":[
      {
         "count":748,
         "hapi_version":"0.72.0",
         "hash":"0xfe539d169a3c214db7157635e7ad0eba2ed7525c130c6178a370580989aed38031b7ee45a001ac200c86e40073dcfebc",
         "name":"000000000000000000000000000000000000.blk",
         "number":0,
         "previous_hash":"0xbec021b4f368e3069134e012c2b4307083d3a9bdd206e24e5f0d86e13d6636655933ec2b413465966817a9c208a11717",
         "size":null,
         "timestamp":{
            "from":"1772185402.889374817",
            "to":"1772185415.503318972"
         },
         "gas_used":0,
         "logs_bloom":"0x"
      }
   ],
   "links":{
      "next":null
   }
```

#### Used query to validate block node integration is working as suggested by MN team

Request:
```bash                                                                                                                     
$ curl -sS http://127.0.0.1:8080/api/v1/blocks | jq -r '.blocks[].name'
```

Response:
```log
000000000000000000000000000000000000.blk
```

