### PR TITLE
chore(ci): add scheduled GCS bucket reaper and harden cleanup

### DIFF
--- a/.github/workflows/flow-gcs-bucket-reaper.yaml
+++ b/.github/workflows/flow-gcs-bucket-reaper.yaml
@@ -2,7 +2,7 @@ name: "Cron: GCS Bucket Reaper"
 
 on:
   schedule:
-    - cron: '0 */6 * * *'
+    - cron: '0 0 * * *'
   workflow_dispatch:
     inputs:
       retention-hours:

--- a/.github/workflows/flow-gcs-test.yaml
+++ b/.github/workflows/flow-gcs-test.yaml
@@ -198,10 +198,16 @@ jobs:
             local bucket_name="$1"
             local target="gs://${bucket_name}/${JOB_PREFIX}"
             local deleted=1
+            local has_objects=""
 
             echo "Attempting cleanup for ${target}"
 
-            if ! gcloud storage ls "${target}/**" --project="${PROJECT_ID}" >/dev/null 2>&1; then
+            has_objects="$(
+              gcloud storage objects list "${target}/" --project="${PROJECT_ID}" --limit=1 --format='value(name)' \
+                2>/dev/null || true
+            )"
+
+            if [[ -z "${has_objects}" ]]; then
               echo "No objects found for ${target}, skipping"
               return 0
             fi

--- a/.github/workflows/script/gcs_bucket_reaper.sh
+++ b/.github/workflows/script/gcs_bucket_reaper.sh
@@ -34,7 +34,7 @@ get_latest_activity_epoch_for_prefix() {
   local latest_updated
 
   latest_updated="$(
-    gcloud storage objects list "gs://${bucket}/${prefix}/**" --project="${PROJECT_ID}" --format='value(updated)' \
+    gcloud storage objects list "gs://${bucket}/${prefix}/" --project="${PROJECT_ID}" --format='value(updated)' \
       2>/dev/null \
       | sort \
       | tail -n1 || true


### PR DESCRIPTION
## Description
This PR improves CI cleanup for GCS test artifacts and adds a scheduled janitor workflow.

Changes:
- Hardened per-job cleanup in `.github/workflows/flow-gcs-test.yaml`
  - cleanup runs with `always()` for GCS/AWS modes
  - cleanup is idempotent
  - each bucket cleanup is retried and handled independently
- Added new scheduled workflow `.github/workflows/flow-gcs-bucket-reaper.yaml`
  - runs every 24 hours
  - supports manual dispatch with `retention-hours` and `dry-run` inputs
- Added janitor script `.github/workflows/script/gcs_bucket_reaper.sh`
  - scans `solo-ci-backups` and `solo-ci-test-streams`
  - deletes stale prefixes based on retention (default 24h)

Closes #3669

