### PR TITLE
fix: make Relay and Explorer independent from Mirror Node

### DIFF
--- a/src/commands/explorer.ts
+++ b/src/commands/explorer.ts
@@ -171,7 +171,6 @@ export class ExplorerCommand extends BaseCommand {
       // Mirror Node
       flags.mirrorNodeId,
       flags.mirrorNamespace,
-      flags.mirrorNodeReleaseName,
     ],
   };
 
@@ -655,9 +654,7 @@ export class ExplorerCommand extends BaseCommand {
             config.ingressReleaseName = this.getIngressReleaseName(config.namespace);
 
             if (this.oneShotState.isActive()) {
-              config.mirrorNodeId = this.configManager.getFlag(flags.mirrorNodeId);
-              config.mirrorNamespace = this.configManager.getFlag(flags.mirrorNamespace);
-              config.mirrorNodeReleaseName = this.configManager.getFlag(flags.mirrorNodeReleaseName);
+              config.mirrorNodeReleaseName = Templates.renderMirrorNodeName(config.mirrorNodeId);
             } else {
               const {mirrorNodeId, mirrorNamespace, mirrorNodeReleaseName} = await this.inferMirrorNodeData(
                 config.namespace,

--- a/src/commands/flags.ts
+++ b/src/commands/flags.ts
@@ -254,16 +254,6 @@ export class Flags {
     prompt: undefined,
   };
 
-  public static readonly mirrorNodeReleaseName: CommandFlag = {
-    constName: 'mirrorNodeReleaseName',
-    name: 'mirror-node-release-name',
-    definition: {
-      describe: 'Helm release name of the mirror node to connect to. Inferred automatically when not provided.',
-      type: 'string',
-    },
-    prompt: undefined,
-  };
-
   /**
    * Parse the values files input string that includes the cluster reference and the values file path
    * <p>It supports input as below:

--- a/src/commands/one-shot/default-one-shot.ts
+++ b/src/commands/one-shot/default-one-shot.ts
@@ -550,8 +550,6 @@ export class DefaultOneShotCommand extends BaseCommand implements OneShotCommand
                                     this.appendConfigToArgv(argv, {
                                       [optionFromFlag(Flags.mirrorNodeId)]: mirrorNodeId,
                                       [optionFromFlag(Flags.mirrorNamespace)]: config.namespace.name,
-                                      [optionFromFlag(Flags.mirrorNodeReleaseName)]:
-                                        Templates.renderMirrorNodeName(mirrorNodeId),
                                       ...config.explorerNodeConfiguration,
                                     });
                                     return argvPushGlobalFlags(argv, config.cacheDir);
@@ -576,8 +574,6 @@ export class DefaultOneShotCommand extends BaseCommand implements OneShotCommand
                                     this.appendConfigToArgv(argv, {
                                       [optionFromFlag(Flags.mirrorNodeId)]: mirrorNodeId,
                                       [optionFromFlag(Flags.mirrorNamespace)]: config.namespace.name,
-                                      [optionFromFlag(Flags.mirrorNodeReleaseName)]:
-                                        Templates.renderMirrorNodeName(mirrorNodeId),
                                       ...config.relayNodeConfiguration,
                                     });
                                     return argvPushGlobalFlags(argv);

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -175,7 +175,6 @@ export class RelayCommand extends BaseCommand {
       // Mirror Node
       flags.mirrorNodeId,
       flags.mirrorNamespace,
-      flags.mirrorNodeReleaseName,
     ],
   };
 
@@ -589,9 +588,7 @@ export class RelayCommand extends BaseCommand {
             );
 
             if (this.oneShotState.isActive()) {
-              config.mirrorNodeId = this.configManager.getFlag(flags.mirrorNodeId);
-              config.mirrorNamespace = this.configManager.getFlag(flags.mirrorNamespace);
-              config.mirrorNodeReleaseName = this.configManager.getFlag(flags.mirrorNodeId);
+              config.mirrorNodeReleaseName = Templates.renderMirrorNodeName(config.mirrorNodeId);
             } else {
               const {mirrorNodeId, mirrorNamespace, mirrorNodeReleaseName} = await this.inferMirrorNodeData(
                 config.namespace,


### PR DESCRIPTION
## Description

This PR passes the following values during `one-shot` to the Relay and Explorer add commands:
- mirrorNodeId
- mirrorNamespace
- mirrorNodeReleaseName

This way, those components do not need to infer the data from the Mirror Node during startup, and thus remove the requirement for the MN to be deployed before Relay and Explorer.

Further changes will need to be made to enable the actual simultaneous deployment of MN, Relay and Explorer.

### Related Issues

* Closes #3767 
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
