### PR TITLE
fix: capture task exit code when bash set -e is active in examples test workflow

### DIFF
--- a/.github/workflows/flow-examples-test.yaml
+++ b/.github/workflows/flow-examples-test.yaml
@@ -374,8 +374,7 @@ jobs:
           fi
           TASK_PID=$!
           TASK_PGID="$(ps -o pgid= -p "${TASK_PID}" | tr -d '[:space:]' || true)"
-          wait "${TASK_PID}"
-          TASK_RC=$?
+          wait "${TASK_PID}" || TASK_RC=$?
           TASK_PID=""
           TASK_PGID=""
           trap - SIGTERM SIGINT


### PR DESCRIPTION
## Summary

- GitHub Actions runs `bash` with `-e` (exit on error) by default
- When `task` failed, `wait "${TASK_PID}"` caused the script to exit immediately due to `set -e`, before `TASK_RC=$?` could capture the exit code
- This meant the diagnostics log collection block (`if [ "${TASK_RC}" -ne 0 ]`) was **never reached** when the task failed
- Fix: change `wait "${TASK_PID}"` + `TASK_RC=$?` to `wait "${TASK_PID}" || TASK_RC=$?` so the exit code is always captured

The original `set +e; task; TASK_RC=$?; set -e` pattern from before PR #3758 handled this correctly. The background-process rewrite in #3758 forgot to account for `set -e`.

Fixes #3825

