### PR TITLE
fix: allow ENABLE_S6_IMAGE=false to use systemd for consensus node service

### DIFF
--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -48,7 +48,7 @@ export const KIND_NODE_IMAGE: string =
 
 export const PODMAN_MACHINE_NAME: string = 'podman-machine-default';
 export const SOLO_DEV_OUTPUT: boolean = Boolean(getEnvironmentVariable('SOLO_DEV_OUTPUT')) || false;
-export const ENABLE_S6_IMAGE: boolean = getEnvironmentVariable('ENABLE_S6_IMAGE') === 'true' || true;
+export const ENABLE_S6_IMAGE: boolean = getEnvironmentVariable('ENABLE_S6_IMAGE') !== 'false';
 
 export const ROOT_CONTAINER: ContainerName = ContainerName.of('root-container');
 export const SOLO_REMOTE_CONFIGMAP_NAME: string = 'solo-remote-config';


### PR DESCRIPTION
## Summary
- Fixes `ENABLE_S6_IMAGE` constant in `src/core/constants.ts` which always evaluated to `true` due to `|| true` at the end of the expression
- Changed from `=== 'true' || true` to `!== 'false'` so the default remains `true` but setting `ENABLE_S6_IMAGE=false` correctly enables the systemd/journalctl code path

## The bug
```typescript
// Before: always true regardless of env var
export const ENABLE_S6_IMAGE: boolean = getEnvironmentVariable('ENABLE_S6_IMAGE') === 'true' || true;

// After: defaults to true, but ENABLE_S6_IMAGE=false disables S6
export const ENABLE_S6_IMAGE: boolean = getEnvironmentVariable('ENABLE_S6_IMAGE') !== 'false';
```

## Test plan
- [ ] Default behavior (no env var): S6 service commands used — no change
- [ ] `ENABLE_S6_IMAGE=false`: systemd commands (`systemctl enable/disable --now network-node`) used for start/stop

🤖 Generated with [Claude Code](https://claude.com/claude-code)