### PR TITLE
fix: add `tss.forceMockSignatures=false` to `application.properties` when `--tss` flag is set

### DIFF
--- a/src/core/profile-manager.ts
+++ b/src/core/profile-manager.ts
@@ -515,7 +515,7 @@ export class ProfileManager {
     }
 
     if (!releaseTag.lessThan(versions.MINIMUM_HIERO_PLATFORM_VERSION_FOR_TSS) && tssEnabled) {
-      lines.push('tss.hintsEnabled=true', 'tss.historyEnabled=true');
+      lines.push('tss.hintsEnabled=true', 'tss.historyEnabled=true', 'tss.forceMockSignatures=false');
 
       if (this.remoteConfig.configuration.state.wrapsEnabled) {
         lines.push('tss.wrapsEnabled=true');


### PR DESCRIPTION
## Description

- When `--tss true` is passed to `solo consensus network deploy`, `tss.forceMockSignatures=false` was missing from `application.properties`, leaving the platform with mock signature behavior even when TSS is explicitly enabled.
- Added `tss.forceMockSignatures=false` alongside the existing `tss.hintsEnabled=true` and `tss.historyEnabled=true` entries in `src/core/profile-manager.ts`.

### Related Issues

- Closes #3889
