### PR TITLE
fix(windows): helm `--set-file` fails on Windows when deploying consensus node >= v0.72.0

### DIFF
--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -708,9 +708,12 @@ export class NetworkCommand extends BaseCommand {
     );
 
     if (config.resolvedThrottlesFile) {
+      // repairing the path, this avoid helm failing when running on windows
+      const throttlesFilePath: string = config.resolvedThrottlesFile.replaceAll('\\', '/');
+
       for (const clusterReference of clusterReferences) {
         valuesArguments[clusterReference] +=
-          ` --set-file "hedera.configMaps.genesisThrottlesJson=${config.resolvedThrottlesFile}"`;
+          ` --set-file "hedera.configMaps.genesisThrottlesJson=${throttlesFilePath}"`;
       }
     }
 


### PR DESCRIPTION
## Description

When running on windows the path of the `resolvedThrottlesFile` wont be properly recognized by the helm cli, resulting in an error. This PR attempts to repair the path before passing it to `--set-file`

### Related Issues

* Closes # https://github.com/hiero-ledger/solo/issues/4220
