### PR TITLE
feat(logs): add MDC logging

### DIFF
--- a/src/commands/one-shot/default-one-shot.ts
+++ b/src/commands/one-shot/default-one-shot.ts
@@ -368,6 +368,13 @@ export class DefaultOneShotCommand extends BaseCommand implements OneShotCommand
               config.numberOfConsensusNodes = config.numberOfConsensusNodes || 1;
               config.force = argv.force;
 
+              this.logger.addLogBindings({
+                clusterReference: config.clusterRef,
+                context: config.context,
+                deployment: config.deployment,
+                namespace: config.namespace.name,
+              });
+
               // Apply small-memory node configuration only for CN >= 0.72.0 and when not using `one-shot falcon deploy`
               const MINIMUM_CN_VERSION_FOR_SMALL_MEMORY: string = 'v0.72.0-0';
               const MINIMUM_CN_VERSION_FOR_STATE_ON_DISK: string = 'v0.73.0-0';

--- a/src/core/logging/solo-logger.ts
+++ b/src/core/logging/solo-logger.ts
@@ -9,6 +9,38 @@ export interface SoloLogger {
 
   nextTraceId(): void;
 
+  /**
+   * Adds or updates a single structured log binding.
+   *
+   * Log bindings are MDC-style key/value pairs that are automatically attached
+   * to structured log entries written by the logger. This makes fields such as
+   * namespace, deployment, cluster reference, command name, or node alias easier
+   * to query in JSON log files.
+   *
+   * These bindings are intended for file/structured logging only and should not
+   * change user-facing CLI output such as showUser(...), showJSON(...), lists, or
+   * progress messages.
+   *
+   * Passing undefined, null, or an empty string removes the binding.
+   */
+  setLogBinding(key: string, value: unknown): void;
+
+  /**
+   * Adds or updates multiple structured log bindings.
+   *
+   * This is useful once command or task configuration has been resolved and
+   * several common fields should be attached to following structured log entries.
+   */
+  addLogBindings(bindings: Record<string, unknown>): void;
+
+  /**
+   * Clears structured log bindings.
+   *
+   * If keys are provided, only those bindings are removed. If no keys are
+   * provided, all active log bindings are cleared.
+   */
+  clearLogBindings(...keys: string[]): void;
+
   prepMeta(meta?: object | any): object | any;
 
   showUser(message: any, ...arguments_: any): void;

--- a/src/core/logging/solo-pino-logger.ts
+++ b/src/core/logging/solo-pino-logger.ts
@@ -29,6 +29,7 @@ type ChalkColor = typeof chalk.red;
 export class SoloPinoLogger implements SoloLogger {
   private readonly pinoLogger: PinoLogger;
   private traceId?: string;
+  private readonly logBindings: Record<string, unknown> = {};
   private messageGroupMap: Map<string, string[]> = new Map();
   private readonly MINOR_LINE_SEPARATOR: string =
     '-------------------------------------------------------------------------------';
@@ -82,8 +83,11 @@ export class SoloPinoLogger implements SoloLogger {
 
     const baseOptions: LoggerOptions = {
       level: logLevel,
-      // Always include traceId when set via mixin
-      mixin: (): {traceId?: string} => (this.traceId ? {traceId: this.traceId} : {}),
+      // Always include traceId and active log bindings when set via mixin
+      mixin: (): Record<string, unknown> => ({
+        ...this.logBindings,
+        ...(this.traceId ? {traceId: this.traceId} : {}),
+      }),
       // Redact obvious secrets if they sneak into objects
       redact: {
         paths: ['*.authorization', '*.Authorization', '*.accessToken', '*.privateKey', '*.operatorKey'],
@@ -126,6 +130,34 @@ export class SoloPinoLogger implements SoloLogger {
 
   public nextTraceId(): void {
     this.traceId = uuidv4();
+  }
+
+  public setLogBinding(key: string, value: unknown): void {
+    if (value === undefined || value === null || value === '') {
+      delete this.logBindings[key];
+      return;
+    }
+
+    this.logBindings[key] = value;
+  }
+
+  public addLogBindings(bindings: Record<string, unknown>): void {
+    for (const [key, value] of Object.entries(bindings)) {
+      this.setLogBinding(key, value);
+    }
+  }
+
+  public clearLogBindings(...keys: string[]): void {
+    if (keys.length === 0) {
+      for (const key of Object.keys(this.logBindings)) {
+        delete this.logBindings[key];
+      }
+      return;
+    }
+
+    for (const key of keys) {
+      delete this.logBindings[key];
+    }
   }
 
   public prepMeta(meta: Record<string, unknown> = {}): Record<string, unknown> {

--- a/test/unit/commands/node/diagnostics-analyzer.test.ts
+++ b/test/unit/commands/node/diagnostics-analyzer.test.ts
@@ -60,6 +60,9 @@ com.swirlds.platform.system.SystemExitUtils.exitSystem(SystemExitUtils.java:37)
       getMessageGroupKeys: sinon.stub().returns([]),
       showAllMessageGroups: sinon.stub(),
       flush: sinon.stub().callsFake((callback: (error?: Error) => void): void => callback()),
+      setLogBinding: sinon.stub(),
+      addLogBindings: sinon.stub(),
+      clearLogBindings: sinon.stub(),
     };
   });
 


### PR DESCRIPTION
## Description

Introduces new methods to the SoloLogger, allowing us to bind additional data to each log message

```ts 
/**
   * Adds or updates a single structured log binding.
   *
   * Log bindings are MDC-style key/value pairs that are automatically attached
   * to structured log entries written by the logger. This makes fields such as
   * namespace, deployment, cluster reference, command name, or node alias easier
   * to query in JSON log files.
   *
   * These bindings are intended for file/structured logging only and should not
   * change user-facing CLI output such as showUser(...), showJSON(...), lists, or
   * progress messages.
   *
   * Passing undefined, null, or an empty string removes the binding.
   */
  setLogBinding(key: string, value: unknown): void;

  /**
   * Adds or updates multiple structured log bindings.
   *
   * This is useful once command or task configuration has been resolved and
   * several common fields should be attached to following structured log entries.
   */
  addLogBindings(bindings: Record<string, unknown>): void;

  /**
   * Clears structured log bindings.
   *
   * If keys are provided, only those bindings are removed. If no keys are
   * provided, all active log bindings are cleared.
   */
  clearLogBindings(...keys: string[]): void;
```
### Showcase

Logs from the `solo.logs` file

```logs
[12:54:14.742] INFO: Pod condition met for mirror-1-pinger-68b8f894db-kzkwl [type: Ready status: True] [traceId="eca78bf7-c559-4bfc-ad0c-32fdad689921"]
    clusterReference: "one-shot"
    context: "kind-solo-cluster"
    deployment: "one-shot"
    namespace: "one-shot"
[12:54:14.792] INFO: [33mUsing requested port 38081[39m [traceId="eca78bf7-c559-4bfc-ad0c-32fdad689921"]
    clusterReference: "one-shot"
    context: "kind-solo-cluster"
    deployment: "one-shot"
    namespace: "one-shot"
```


### Related Issues

* Closes # https://github.com/hiero-ledger/solo/issues/2479

