### PR TITLE
chore: add new env's to support overriding and omitting `SPRING_PROFILES_ACTIVE` for MN <> BN integration 

### DIFF
--- a/docs/site/content/en/docs/env.md
+++ b/docs/site/content/en/docs/env.md
@@ -122,7 +122,8 @@ User can configure the following environment variables to customize the behavior
 | `CHECK_WRAPS_DIRECTORY_MAX_ATTEMPTS`               | The maximum number of attempts to check for the existance of the wraps directory.                                               | `10`                                                                                               |
 | `CHECK_WRAPS_DIRECTORY_BACKOFF_MS`                 | The backoff period for retrying to check for the existance of the wraps directory.                                              | `2000`                                                                                             |
 | `ENABLE_IMAGE_CACHE`                               | Used to enable the image cache feature during one-shot deployments.                                                             | `2000`                                                                                             |
-
+| `DISABLE_IMPORTER_SPRING_PROFILES`                 | Disable automatic configuration of Mirror Node importer Spring profiles for block-node integration.                             | `false`                                                                                            |
+| `SPRING_PROFILES_ACTIVE`                           | Spring profiles to use for the Mirror Node importer when automatic importer profile configuration is enabled.                   | `blocknode`                                                                                        |
 
 ## Config-System Override Variables
 

--- a/src/commands/mirror-node.ts
+++ b/src/commands/mirror-node.ts
@@ -393,9 +393,11 @@ export class MirrorNodeCommand extends BaseCommand {
       });
     }
 
-    const data: {SPRING_PROFILES_ACTIVE: string} & Record<string, string | number> = {
-      SPRING_PROFILES_ACTIVE: 'blocknode',
-    };
+    const data: {SPRING_PROFILES_ACTIVE?: string} & Record<string, string | number> = {};
+
+    if (!constants.DISABLE_IMPORTER_SPRING_PROFILES) {
+      data.SPRING_PROFILES_ACTIVE = constants.SPRING_PROFILES_ACTIVE;
+    }
 
     for (const [index, node] of blockNodeFqdnList.entries()) {
       data[`HIERO_MIRROR_IMPORTER_BLOCK_NODES_${index}_HOST`] = node.host;
@@ -406,7 +408,7 @@ export class MirrorNodeCommand extends BaseCommand {
 
     const mirrorNodeBlockNodeValues: {
       importer: {
-        env: {SPRING_PROFILES_ACTIVE: string} & Record<string, string | number>;
+        env: {SPRING_PROFILES_ACTIVE?: string} & Record<string, string | number>;
       };
     } = {
       importer: {

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -509,3 +509,7 @@ export const CERT_MANAGER_CRDS: string[] = [
 
 export const TRIGGER_STAKE_WEIGHT_CALCULATE_WAIT_SECONDS: number =
   +getEnvironmentVariable('TRIGGER_STAKE_WEIGHT_CALCULATE_WAIT_SECONDS') || 60;
+
+export const DISABLE_IMPORTER_SPRING_PROFILES: boolean =
+  getEnvironmentVariable('DISABLE_IMPORTER_SPRING_PROFILES') === 'true' || false;
+export const SPRING_PROFILES_ACTIVE: string = getEnvironmentVariable('SPRING_PROFILES_ACTIVE') || 'blocknode';


### PR DESCRIPTION
## Description

Introduce 2 new envs:
- `DISABLE_IMPORTER_SPRING_PROFILES` (default: `false`) allows leaving the `SPRING_PROFILES_ACTIVE` unset, for the mirror node block node integration values.
- `SPRING_PROFILES_ACTIVE` (default: `blocknode`) allows overriding the `SPRING_PROFILES_ACTIVE` for the mirror node block node integration values.

> Default behavior is unchanged 

### Related Issues

* Closes # https://github.com/hiero-ledger/solo/issues/4382

