### PR TITLE
feat(one-shot): add logic to prompt the user if one-shot is being executed against non-kind cluster

### DIFF
--- a/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
+++ b/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
@@ -206,6 +206,10 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
             config.numberOfConsensusNodes ||= 1;
             config.force = argv.force as boolean;
 
+            // Guard against accidental one-shot deployments to non-Kind Kubernetes contexts.
+            // Quiet mode bypasses the confirmation prompt.
+            await this.confirmNonKindContext(config, task);
+
             // Ensure release tag is set in network configuration so subcommands use the correct version
             const releaseTagKey: string = flags.getFormattedFlagKey(flags.releaseTag);
             const soloChartVersionKey: string = flags.getFormattedFlagKey(flags.soloChartVersion);
@@ -898,5 +902,36 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
   private cacheDeploymentName(context: OneShotSingleDeployContext, outputFile: string): void {
     fs.writeFileSync(outputFile, context.config.deployment);
     this.logger.showUser(chalk.green(`Deployment name (${context.config.deployment}) saved to file: ${outputFile}`));
+  }
+
+  private async confirmNonKindContext(
+    config: OneShotSingleDeployConfigClass,
+    task: SoloListrTaskWrapper<OneShotSingleDeployContext>,
+  ): Promise<void> {
+    if (config.quiet === true || this.isKindContext(config.context)) {
+      return;
+    }
+
+    const proceed: boolean = await task.prompt(ListrInquirerPromptAdapter).run(confirmPrompt, {
+      default: false,
+      message: this.buildNonKindContextWarningMessage(config.context),
+    });
+
+    if (!proceed) {
+      throw new SoloError('Aborted by user');
+    }
+  }
+
+  private isKindContext(context: string): boolean {
+    return context.startsWith('kind-');
+  }
+
+  private buildNonKindContextWarningMessage(context: string): string {
+    return (
+      `Warning: Active Kubernetes context '${context}' is not a local Kind cluster.\n\n` +
+      'one-shot deploy is intended for local development. Deploying into a shared or remote cluster ' +
+      'may install Solo charts, CRDs, namespaces, and other resources into that cluster.\n\n' +
+      'Continue?'
+    );
   }
 }

--- a/test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts
+++ b/test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts
@@ -1,0 +1,206 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import sinon from 'sinon';
+import {DefaultOneShotDeployOrchestrator} from '../../../../../../src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.js';
+import {NamespaceName} from '../../../../../../src/types/namespace/namespace-name.js';
+import {SoloError} from '../../../../../../src/core/errors/solo-error.js';
+import {type OneShotSingleDeployConfigClass} from '../../../../../../src/commands/one-shot/one-shot-single-deploy-config-class.js';
+
+type MockType = any;
+type MockListr = MockType;
+
+function makeOrchestrator(): DefaultOneShotDeployOrchestrator {
+  return new DefaultOneShotDeployOrchestrator(
+    {} as MockType,
+    {} as MockType,
+    {} as MockType,
+    {} as MockType,
+    {} as MockType,
+    {} as MockType,
+    {} as MockType,
+    {} as MockType,
+    {} as MockType,
+    {} as MockType,
+    {} as MockType,
+  );
+}
+
+function makeConfig(overrides: Partial<OneShotSingleDeployConfigClass> = {}): OneShotSingleDeployConfigClass {
+  return {
+    relayNodeConfiguration: {},
+    explorerNodeConfiguration: {},
+    blockNodeConfiguration: {},
+    mirrorNodeConfiguration: {},
+    consensusNodeConfiguration: {},
+    networkConfiguration: {},
+    setupConfiguration: {},
+    valuesFile: '',
+    clusterRef: 'one-shot',
+    context: 'kind-solo',
+    deployment: 'one-shot',
+    namespace: NamespaceName.of('one-shot'),
+    numberOfConsensusNodes: 1,
+    cacheDir: '/tmp/cache',
+    predefinedAccounts: true,
+    minimalSetup: false,
+    deployMirrorNode: true,
+    deployExplorer: true,
+    deployRelay: true,
+    deployMetricsServer: false,
+    force: false,
+    quiet: false,
+    rollback: true,
+    parallelDeploy: false,
+    externalAddress: '',
+    edgeEnabled: false,
+    versions: {
+      soloChart: '',
+      consensus: '',
+      mirror: '',
+      explorer: '',
+      relay: '',
+      blockNode: '',
+    },
+    argv: {_: []},
+    ...overrides,
+  };
+}
+
+function makeTaskWrapper(promptResult: boolean): MockListr {
+  const runStub: sinon.SinonStub = sinon.stub().resolves(promptResult);
+  const promptAdapterStub: sinon.SinonStub = sinon.stub().returns({run: runStub});
+
+  return {
+    prompt: promptAdapterStub,
+  };
+}
+
+describe('DefaultOneShotDeployOrchestrator non-Kind context guard', (): void => {
+  describe('isKindContext', (): void => {
+    it('returns true when the context is a Kind context', (): void => {
+      const orchestrator: DefaultOneShotDeployOrchestrator = makeOrchestrator();
+
+      // @ts-expect-error - to access private method
+      expect(orchestrator.isKindContext('kind-solo')).to.be.true;
+      // @ts-expect-error - to access private method
+      expect(orchestrator.isKindContext('kind-one-shot')).to.be.true;
+      // @ts-expect-error - to access private method
+      expect(orchestrator.isKindContext('kind-local-cluster')).to.be.true;
+    });
+
+    it('returns false when the context is not a Kind context', (): void => {
+      const orchestrator: DefaultOneShotDeployOrchestrator = makeOrchestrator();
+
+      // @ts-expect-error - to access private method
+      expect(orchestrator.isKindContext('gke_mirrornode-non-prod-314918_us-central1_mainnet-staging-na')).to.be.false;
+      // @ts-expect-error - to access private method
+      expect(orchestrator.isKindContext('docker-desktop')).to.be.false;
+      // @ts-expect-error - to access private method
+      expect(orchestrator.isKindContext('minikube')).to.be.false;
+      // @ts-expect-error - to access private method
+      expect(orchestrator.isKindContext('arn:aws:eks:us-east-1:123456789012:cluster/prod')).to.be.false;
+    });
+  });
+
+  describe('buildNonKindContextWarningMessage', (): void => {
+    it('includes the active context and warning details', (): void => {
+      const orchestrator: DefaultOneShotDeployOrchestrator = makeOrchestrator();
+
+      // @ts-expect-error - to access private method
+      const message: string = orchestrator.buildNonKindContextWarningMessage('gke-prod');
+
+      expect(message).to.include("Active Kubernetes context 'gke-prod'");
+      expect(message).to.include('not a local Kind cluster');
+      expect(message).to.include('one-shot deploy is intended for local development');
+      expect(message).to.include('Solo charts, CRDs, namespaces, and other resources');
+      expect(message).to.include('Continue?');
+    });
+  });
+
+  describe('confirmNonKindContext', (): void => {
+    it('does not prompt when quiet mode is enabled', async (): Promise<void> => {
+      const orchestrator: DefaultOneShotDeployOrchestrator = makeOrchestrator();
+      const task: MockListr = makeTaskWrapper(false);
+
+      // @ts-expect-error - to access private method
+      await orchestrator.confirmNonKindContext(
+        makeConfig({
+          context: 'gke-prod',
+          quiet: true,
+        }),
+        task,
+      );
+
+      expect(task.prompt).to.not.have.been.called;
+    });
+
+    it('does not prompt when the context is a Kind context', async (): Promise<void> => {
+      const orchestrator: DefaultOneShotDeployOrchestrator = makeOrchestrator();
+      const task: MockListr = makeTaskWrapper(false);
+
+      // @ts-expect-error - to access private method
+      await orchestrator.confirmNonKindContext(
+        makeConfig({
+          context: 'kind-solo',
+          quiet: false,
+        }),
+        task,
+      );
+
+      expect(task.prompt).to.not.have.been.called;
+    });
+
+    it('prompts when the context is not a Kind context', async (): Promise<void> => {
+      const orchestrator: DefaultOneShotDeployOrchestrator = makeOrchestrator();
+      const task: MockListr = makeTaskWrapper(true);
+
+      // @ts-expect-error - to access private method
+      await orchestrator.confirmNonKindContext(
+        makeConfig({
+          context: 'gke-prod',
+          quiet: false,
+        }),
+        task,
+      );
+
+      expect(task.prompt).to.have.been.calledOnce;
+    });
+
+    it('continues when the user confirms deployment to a non-Kind context', async (): Promise<void> => {
+      const orchestrator: DefaultOneShotDeployOrchestrator = makeOrchestrator();
+      const task: MockListr = makeTaskWrapper(true);
+
+      // @ts-expect-error - to access private method
+      await orchestrator.confirmNonKindContext(
+        makeConfig({
+          context: 'gke-prod',
+          quiet: false,
+        }),
+        task,
+      );
+    });
+
+    it('throws when the user rejects deployment to a non-Kind context', async (): Promise<void> => {
+      const orchestrator: DefaultOneShotDeployOrchestrator = makeOrchestrator();
+      const task: MockListr = makeTaskWrapper(false);
+
+      try {
+        // @ts-expect-error - to access private method
+        await orchestrator.confirmNonKindContext(
+          makeConfig({
+            context: 'gke-prod',
+            quiet: false,
+          }),
+          task,
+        );
+
+        expect.fail('Expected confirmNonKindContext to throw');
+      } catch (error) {
+        expect(error).to.be.instanceOf(SoloError);
+        expect((error as Error).message).to.equal('Aborted by user');
+      }
+    });
+  });
+});

--- a/test/unit/core/network/port-utilities.test.ts
+++ b/test/unit/core/network/port-utilities.test.ts
@@ -14,34 +14,34 @@ describe('Port Utils', (): void => {
   describe('findAvailablePort', (): void => {
     it('should find the next available port when the initial port is in use', async (): Promise<void> => {
       // Create a server to occupy a port
-      const server = net.createServer();
-      const basePort = 8000; // Use a port that's likely to be available for testing
+      const server: net.Server = net.createServer();
+      const basePort: number = 8000; // Use a port that's likely to be available for testing
 
       // Start the server on the base port
-      await new Promise<void>(resolve => {
-        server.listen(basePort, '127.0.0.1', () => {
+      await new Promise<void>((resolve): void => {
+        server.listen(basePort, '127.0.0.1', (): void => {
           resolve();
         });
       });
 
       try {
         // Verify the port is actually in use
-        const isBasePortAvailable = await PortUtilities.isPortAvailable(basePort);
+        const isBasePortAvailable: boolean = await PortUtilities.isPortAvailable(basePort);
         expect(isBasePortAvailable).to.be.false;
 
         // Call findAvailablePort with the occupied port
-        const availablePort = await PortUtilities.findAvailablePort(basePort, 5000, mockLogger);
+        const availablePort: number = await PortUtilities.findAvailablePort(basePort, 5000, mockLogger);
 
         // Verify that the returned port is the next port (basePort + 1)
         expect(availablePort).to.equal(basePort + 1);
 
         // Verify that the returned port is actually available
-        const isNextPortAvailable = await PortUtilities.isPortAvailable(basePort + 1);
+        const isNextPortAvailable: boolean = await PortUtilities.isPortAvailable(basePort + 1);
         expect(isNextPortAvailable).to.be.true;
       } finally {
         // Clean up: close the server
-        await new Promise<void>(resolve => {
-          server.close(() => {
+        await new Promise<void>((resolve): void => {
+          server.close((): void => {
             resolve();
           });
         });
@@ -49,14 +49,14 @@ describe('Port Utils', (): void => {
     });
 
     it('should return the initial port if it is available', async (): Promise<void> => {
-      const basePort = 9000; // Use a different port for this test
+      const basePort: number = 9000; // Use a different port for this test
 
       // Verify the port is available first
-      const isBasePortAvailable = await PortUtilities.isPortAvailable(basePort);
+      const isBasePortAvailable: boolean = await PortUtilities.isPortAvailable(basePort);
       expect(isBasePortAvailable).to.be.true;
 
       // Call findAvailablePort with an available port
-      const availablePort = await PortUtilities.findAvailablePort(basePort, 5000, mockLogger);
+      const availablePort: number = await PortUtilities.findAvailablePort(basePort, 5000, mockLogger);
 
       // Verify that the returned port is the same as the input port
       expect(availablePort).to.equal(basePort);


### PR DESCRIPTION
## Description

When one shot is executed against a remote cluster the user will now get a promp asking him for confirmation, this can be bypassed by running in quiet mode.


Message: 
```
`Warning: Active Kubernetes context '${context}' is not a local Kind cluster.\n\n` +
'one-shot deploy is intended for local development. Deploying into a shared or remote cluster ' +
'may install Solo charts, CRDs, namespaces, and other resources into that cluster.\n\n' +
'Continue?'
```

### Related Issues

* Closes # https://github.com/hiero-ledger/solo/issues/4358
