### PR TITLE
fix: pin down metallib version

### DIFF
--- a/examples/multicluster-backup-restore/Taskfile.yml
+++ b/examples/multicluster-backup-restore/Taskfile.yml
@@ -105,6 +105,7 @@ tasks:
           helm upgrade --install metallb metallb/metallb \
             --kube-context kind-solo-e2e-c1 \
             --namespace metallb-system --create-namespace --atomic --wait \
+            --version 0.15.3 \
             --set speaker.frr.enabled=true
       - cmd: kubectl apply -f metallb-cluster-1.yaml --context kind-solo-e2e-c1
 
@@ -118,6 +119,7 @@ tasks:
           helm upgrade --install metallb metallb/metallb \
             --kube-context kind-solo-e2e-c2 \
             --namespace metallb-system --create-namespace --atomic --wait \
+            --version 0.15.3 \
             --set speaker.frr.enabled=true
       - cmd: kubectl apply -f metallb-cluster-2.yaml --context kind-solo-e2e-c2
 

--- a/test/e2e/dual-cluster/setup-dual-e2e.sh
+++ b/test/e2e/dual-cluster/setup-dual-e2e.sh
@@ -10,6 +10,7 @@ export PATH=~/.solo/bin:${PATH}
 SCRIPT_PATH=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 readonly SCRIPT_PATH
 readonly KIND_CONFIG_RENDERER="${SCRIPT_PATH}/../../../.github/workflows/script/render_kind_config.sh"
+readonly METALLB_CHART_VERSION="0.15.3"
 
 readonly KIND_IMAGE="kindest/node:v1.31.4@sha256:2cb39f7295fe7eafee0842b1052a599a4fb0f8bcf3f83d96c7f4864c357c6c30"
 
@@ -140,6 +141,7 @@ for i in $(seq 1 "${SOLO_CLUSTER_DUALITY}"); do
   if [[ "${SOLO_CLUSTER_DUALITY}" -gt 1 && "${SOLO_SKIP_METALLB}" != "1" ]]; then
     helm upgrade --install metallb metallb/metallb \
       --namespace metallb-system --create-namespace --atomic --wait \
+      --version "${METALLB_CHART_VERSION}" \
       --set speaker.frr.enabled=true
 
     kubectl apply -f "${SCRIPT_PATH}/metallb-cluster-${i}.yaml"

--- a/test/helpers/helm-metal-load-balancer.ts
+++ b/test/helpers/helm-metal-load-balancer.ts
@@ -13,7 +13,7 @@ export class HelmMetalLoadBalancer {
   public static readonly REPOSITORY_NAME: string = 'metallb';
   public static readonly REPOSITORY_URL: string = 'https://metallb.github.io/metallb/';
   public static readonly INSTALL_ARGS: string = '--set speaker.frr.enabled=true';
-  public static readonly VERSION: string = ''; // latest version
+  public static readonly VERSION: string = '0.15.3';
 
   public static async installMetalLoadBalancer(testName: string): Promise<void> {
     try {


### PR DESCRIPTION
## Description

This pull request changes the following:

* pin down metallib version

Avoid error such as due to metallb chart 0.16.0
```
     Error: one-shot-single-minimal: failed to install metallb: failed to install chart metallb: Helm command failed with exit code 1. Command: 'helm install --atomic --create-namespace --wait --output json --kube-context kind-kind --namespace metallb-system --set speaker.frr.enabled=true metallb metallb/metallb'. Error: Error: INSTALLATION FAILED: template: metallb/charts/frr-k8s/templates/service-monitor.yaml:1:14: executing "metallb/charts/frr-k8s/templates/service-monitor.yaml" at <.Values.prometheus.serviceMonitor.enabled>: nil pointer evaluating interface {}.serviceMonitor
      at Function.installMetalLoadBalancer (/home/runner/work/solo/solo/test/helpers/helm-metal-load-balancer.ts:35:13)
      at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
      at Context.<anonymous> (/home/runner/work/solo/solo/test/e2e/commands/one-shot-single.test.ts:119:11)
 ```
 
 

### Related Issues

* Closes #
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
