### PR TITLE
fix(node/upgrade): stop nodes after freeze to prevent JAR-staging race

### DIFF
--- a/src/commands/node/handlers.ts
+++ b/src/commands/node/handlers.ts
@@ -282,6 +282,7 @@ export class NodeCommandHandlers extends CommandHandler {
   private upgradeExecuteTasks(): SoloListrTask<NodeUpgradeContext>[] {
     return [
       this.tasks.checkAllNodesAreFrozen('existingNodeAliases'),
+      this.tasks.stopNodes('existingNodeAliases'),
       this.tasks.downloadNodeUpgradeFiles(),
       this.tasks.getNodeLogsAndConfigs(),
       this.tasks.upgradeNodeConfigurationFilesWithChart(),

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -2246,7 +2246,7 @@ export class NodeCommandTasks {
 
   public stopNodes(
     nodeAliasesProperty: string,
-  ): SoloListrTask<NodeStopContext | NodeFreezeContext | NodeDestroyContext> {
+  ): SoloListrTask<NodeStopContext | NodeFreezeContext | NodeDestroyContext | NodeUpgradeContext> {
     return {
       title: 'Stopping nodes',
       task: async (context_, task): Promise<any> => {


### PR DESCRIPTION
## Summary

`upgradeExecuteTasks()` did not stop the consensus-node JVMs between `checkAllNodesAreFrozen` and `fetchPlatformSoftware`. Reaching `FREEZE_COMPLETE` puts the platform in a stopped state, but the `network-node-lifecycle` autostart marker stays enabled, so s6 re-launches the JVM as soon as it exits. The re-launched JVM expands `-cp data/lib/*` concurrently with `fetchPlatformSoftware`'s `rm`-then-`cp` of the local-build JARs, producing a `URLClassLoader` that references files deleted mid-startup.

- Closes https://github.com/hiero-ledger/solo/issues/4424

## Observed symptoms

Running `solo consensus network upgrade --local-build-path <path> --upgrade-version <vX>` on a 4-CN kind cluster (Solo 0.73.0), 1–2 of 4 nodes per run would either:

- **die during startup** in `Log4jSetup`:
  ```
  java.io.UncheckedIOException: Property file semantic-version.properties could not be found
    at com.hedera.node.config.sources.PropertyConfigSource.loadProperties:53
    at com.hedera.node.app.Hedera.<init>:519
    at com.hedera.node.app.ServicesMain.main:169
  ```
  The pod stayed `Running` (probes don't catch a crashed JVM) and Solo's `Check all nodes are ACTIVE` task exhausted its 300-attempt budget, exiting non-zero.

- **come up but be subtly broken**: every lazy `ServiceLoader` iteration over `META-INF/services/*` (e.g. `PcesModule` during `SignedStateFileWriter.copyPcesFiles`, `ReconnectModule` during fall-behind reconnect) would fail with `ServiceConfigurationError` caused by `NoSuchFileException` for a `consensus-*-impl-<old-release-tag>.jar` that had been deleted by the `rm` step but was still in the JVM's classpath URL list.

Both symptoms point at the same race: the JVM's wildcard-expanded classpath was captured while the JAR set was mid-replacement.

## Fix

Call `stopNodes('existingNodeAliases')` right after `checkAllNodesAreFrozen` so the JVM is hard-stopped and its autostart marker disabled before any JAR mutation. The disk then has a single writer for the duration of `fetchPlatformSoftware`, and `startNodes` later brings the JVM up exactly once against the final JAR layout. This mirrors the existing pattern in `handlers.freeze`, which also calls `stopNodes` after `checkAllNodesAreFrozen`.

Also widens `NodeCommandTasks.stopNodes` return-type union to include `NodeUpgradeContext` so the upgrade flow can call it without a cast. The function body already only accesses fields present on `CheckedNodesConfigClass`, which `NodeUpgradeConfigClass` extends.

## Verified

Reproducer: isolated 0.75 → 0.76-local-build upgrade script against a fresh kind cluster, exercising `solo consensus network upgrade --local-build-path ... --application-properties ... --application-env ...`.

- **Before the fix:** Solo's upgrade returned `rc=1` (`node 'nodeX' is not ACTIVE [attempt = 13/300]`), required a workaround in the caller to `kubectl delete pod` stuck nodes; even after re-roll, multiple nodes were silently broken with `ServiceConfigurationError` on every state-snapshot attempt.
- **After the fix:** Solo's upgrade returns `rc=0`, all 4 CNs progress from `FREEZE_COMPLETE` → `REPLAYING_EVENTS` → `OBSERVING` → `CHECKING` → `ACTIVE` cleanly in a single startup, zero `semantic-version.properties` errors and zero `ServiceConfigurationError` across all four nodes.

## Test plan

- [ ] `solo consensus network upgrade --local-build-path <path> --upgrade-version <tag>` on a multi-CN kind cluster, repeatedly, with the same `<tag>` differing from the originally-deployed tag.
- [ ] Verify Solo's `Check all nodes are ACTIVE` task succeeds without retries.
- [ ] Verify `data/lib/` on each pod contains only the new release's JARs (no leftover `*-<old-tag>.jar`).
- [ ] Grep each pod's `swirlds.log` for `ServiceConfigurationError` — expect 0 hits.
- [ ] Grep each pod's `swirlds.log` for `semantic-version.properties could not be found` — expect 0 hits.