### PR TITLE
feat: provision RSA bootstrap roster file when adding block nodes

### DIFF
--- a/src/business/utils/k8-helper.ts
+++ b/src/business/utils/k8-helper.ts
@@ -46,4 +46,10 @@ export class K8Helper {
       .list(namespace, Templates.renderBlockNodeLabels(id))
       .then((pods: Pod[]): Pod => pods[0]);
   }
+
+  public async getBlockNodeContainer(namespace: NamespaceName, id: ComponentId): Promise<Container> {
+    return await this.getBlockNodePod(namespace, id)
+      .then((pod): ContainerReference => ContainerReference.of(pod.podReference, constants.BLOCK_NODE_CONTAINER_NAME))
+      .then((containerReference): Container => this.k8.containers().readByRef(containerReference));
+  }
 }

--- a/src/business/utils/k8-helper.ts
+++ b/src/business/utils/k8-helper.ts
@@ -46,10 +46,4 @@ export class K8Helper {
       .list(namespace, Templates.renderBlockNodeLabels(id))
       .then((pods: Pod[]): Pod => pods[0]);
   }
-
-  public async getBlockNodeContainer(namespace: NamespaceName, id: ComponentId): Promise<Container> {
-    return await this.getBlockNodePod(namespace, id)
-      .then((pod): ContainerReference => ContainerReference.of(pod.podReference, constants.BLOCK_NODE_CONTAINER_NAME))
-      .then((containerReference): Container => this.k8.containers().readByRef(containerReference));
-  }
 }

--- a/src/commands/block-node.ts
+++ b/src/commands/block-node.ts
@@ -188,6 +188,7 @@ export class BlockNodeCommand extends BaseCommand {
   private static readonly ADD_EXTERNAL_CONFIGS_NAME: string = 'addExternalConfigs';
 
   private static readonly DELETE_CONFIGS_NAME: string = 'deleteExternalConfigs';
+
   private static readonly MIGRATION_COMPONENT_KEY: string = 'block-node';
 
   public static readonly ADD_FLAGS_LIST: CommandFlags = {
@@ -1470,92 +1471,21 @@ export class BlockNodeCommand extends BaseCommand {
       `${config.releaseName}-rsa-bootstrap-values.yaml`,
     );
 
-    // The block-node chart does not expose a dedicated RSA bootstrap file mount.
-    // Use the existing blockNode.initContainers hook to write the generated roster into
-    // verification-storage before the main JVM starts, then point app.state.rsaBootstrapFilePath
-    // to that file through APP_STATE_RSA_BOOTSTRAP_FILE_PATH.
+    // The block-node chart owns writing the RSA bootstrap roster into the pod before JVM startup.
+    // Solo only supplies the generated roster through chart-native values.
     fs.writeFileSync(
       valuesFile,
       yaml.stringify({
         blockNode: {
-          config: {
-            APP_STATE_RSA_BOOTSTRAP_FILE_PATH: constants.BLOCK_NODE_RSA_BOOTSTRAP_FILE_PATH,
+          rsaBootstrap: {
+            enabled: true,
+            rosterBase64,
           },
-          initContainers: [
-            this.buildDefaultBlockNodeInitStorageDirsContainer(),
-            this.buildRsaBootstrapRosterInitContainer(rosterBase64),
-          ],
         },
       }),
     );
 
     return valuesFile;
-  }
-
-  private buildDefaultBlockNodeInitStorageDirsContainer(): object {
-    // The block-node chart exposes blockNode.initContainers as a replacement list.
-    // Keep the chart's default init-storage-dirs container when adding the RSA bootstrap writer.
-    return {
-      name: 'init-storage-dirs',
-      image: 'busybox',
-      command: [
-        'sh',
-        '-c',
-        [
-          'mkdir -p /live-pvc/live-data && \\',
-          'chown 2000:2000 /live-pvc/live-data && \\',
-          'chmod 700 /live-pvc/live-data && \\',
-          'mkdir -p /archive-pvc/archive-data && \\',
-          'chown 2000:2000 /archive-pvc/archive-data && \\',
-          'chmod 700 /archive-pvc/archive-data && \\',
-          'chown 2000:2000 /verification-pvc && \\',
-          'chmod 700 /verification-pvc',
-        ].join('\n'),
-      ],
-      volumeMounts: [
-        {
-          name: 'live-storage',
-          mountPath: '/live-pvc',
-        },
-        {
-          name: 'archive-storage',
-          mountPath: '/archive-pvc',
-        },
-        {
-          name: 'verification-storage',
-          mountPath: '/verification-pvc',
-        },
-      ],
-    };
-  }
-
-  private buildRsaBootstrapRosterInitContainer(rosterBase64: string): object {
-    return {
-      name: 'write-rsa-bootstrap-roster',
-      image: 'busybox',
-      command: [
-        'sh',
-        '-c',
-        [
-          `mkdir -p ${constants.BLOCK_NODE_RSA_BOOTSTRAP_VERIFICATION_MOUNT_PATH} && \\`,
-          `printf "%s" "$RSA_BOOTSTRAP_ROSTER_BASE64" | base64 -d > ${constants.BLOCK_NODE_RSA_BOOTSTRAP_FILE_PATH} && \\`,
-          `chown 2000:2000 ${constants.BLOCK_NODE_RSA_BOOTSTRAP_FILE_PATH} && \\`,
-          `chmod 0444 ${constants.BLOCK_NODE_RSA_BOOTSTRAP_FILE_PATH}`,
-        ].join('\n'),
-      ],
-      env: [
-        {
-          name: 'RSA_BOOTSTRAP_ROSTER_BASE64',
-          value: rosterBase64,
-        },
-      ],
-      volumeMounts: [
-        {
-          name: 'verification-storage',
-          mountPath: constants.BLOCK_NODE_RSA_BOOTSTRAP_VERIFICATION_MOUNT_PATH,
-        },
-      ],
-    };
   }
 
   public async close(): Promise<void> {} // no-op

--- a/src/commands/block-node.ts
+++ b/src/commands/block-node.ts
@@ -539,7 +539,6 @@ export class BlockNodeCommand extends BaseCommand {
           title: 'Prepare RSA bootstrap roster',
           task: async ({config}): Promise<void> => {
             config.rsaBootstrapValuesFile = await this.prepareRsaBootstrapValuesFile(config);
-            console.log('RSA bootstrap values file:', config.rsaBootstrapValuesFile);
           },
         },
         this.addBlockNodeComponent(),

--- a/src/commands/block-node.ts
+++ b/src/commands/block-node.ts
@@ -53,6 +53,10 @@ import {
   type ComponentUpgradeMigrationStep,
 } from './migrations/component-upgrade-rules.js';
 import {optionFromFlag} from './command-helpers.js';
+import {PathEx} from '../business/utils/path-ex.js';
+import fs from 'node:fs';
+import yaml from 'yaml';
+import {BlockNodeRsaBootstrapRoster} from '../core/block-node-rsa-bootstrap-roster.js';
 
 interface BlockNodeDeployConfigClass {
   chartVersion: string;
@@ -75,6 +79,9 @@ interface BlockNodeDeployConfigClass {
   releaseName: string;
   livenessCheckPort: number;
   priorityMapping: Record<NodeAlias, number>;
+
+  blockNodeRsaBootstrapFile: Optional<string>;
+  rsaBootstrapValuesFile?: string;
 }
 
 interface BlockNodeDeployContext {
@@ -136,6 +143,9 @@ interface BlockNodeAddExternalConfigClass {
   newExternalBlockNodeComponent: ExternalBlockNodeStateSchema;
   namespace: NamespaceName;
   priorityMapping: Record<NodeAlias, number>;
+
+  blockNodeRsaBootstrapFile: Optional<string>;
+  rsaBootstrapValuesFile?: string;
 }
 
 interface BlockNodeAddExternalContext {
@@ -196,6 +206,7 @@ export class BlockNodeCommand extends BaseCommand {
       flags.releaseTag,
       flags.imageTag,
       flags.priorityMapping,
+      flags.blockNodeRsaBootstrapFile,
     ],
   };
 
@@ -244,6 +255,10 @@ export class BlockNodeCommand extends BaseCommand {
 
     if (config.valuesFile) {
       valuesArgument += helpers.prepareValuesFiles(config.valuesFile);
+    }
+
+    if ('rsaBootstrapValuesFile' in config && config.rsaBootstrapValuesFile) {
+      valuesArgument += helpers.prepareValuesFiles(config.rsaBootstrapValuesFile);
     }
 
     valuesArgument += helpers.populateHelmArguments({nameOverride: config.releaseName});
@@ -518,6 +533,13 @@ export class BlockNodeCommand extends BaseCommand {
             );
 
             config.newBlockNodeComponent.metadata.phase = DeploymentPhase.REQUESTED;
+          },
+        },
+        {
+          title: 'Prepare RSA bootstrap roster',
+          task: async ({config}): Promise<void> => {
+            config.rsaBootstrapValuesFile = await this.prepareRsaBootstrapValuesFile(config);
+            console.log('RSA bootstrap values file:', config.rsaBootstrapValuesFile);
           },
         },
         this.addBlockNodeComponent(),
@@ -1409,6 +1431,131 @@ export class BlockNodeCommand extends BaseCommand {
 
         displayHealthcheckCallback(attempt, maxAttempts, 'green', 'success');
       },
+    };
+  }
+
+  private async prepareRsaBootstrapRosterJson(config: BlockNodeDeployConfigClass): Promise<string | undefined> {
+    if (config.blockNodeRsaBootstrapFile) {
+      if (!fs.existsSync(config.blockNodeRsaBootstrapFile)) {
+        throw new SoloError(`Block node RSA bootstrap file does not exist: ${config.blockNodeRsaBootstrapFile}`);
+      }
+
+      return BlockNodeRsaBootstrapRoster.readBlockNodeRsaBootstrapRosterJsonFromFile(config.blockNodeRsaBootstrapFile);
+    }
+
+    return BlockNodeRsaBootstrapRoster.buildBlockNodeRsaBootstrapRosterJsonFromSecrets(
+      this.remoteConfig.getConsensusNodes(),
+      config.namespace,
+      config.context,
+      this.k8Factory,
+      this.logger,
+    );
+  }
+
+  private async prepareRsaBootstrapValuesFile(config: BlockNodeDeployConfigClass): Promise<string | undefined> {
+    const rosterJson: string | undefined = await this.prepareRsaBootstrapRosterJson(config);
+
+    if (!rosterJson) {
+      this.logger.showUser(
+        'Skipping block node RSA bootstrap roster because consensus node gossip signing keys are not available yet. ' +
+          `Deploy block node after consensus node setup, or pass ${optionFromFlag(flags.blockNodeRsaBootstrapFile)}.`,
+      );
+      return undefined;
+    }
+
+    const rosterBase64: string = Buffer.from(rosterJson, 'utf8').toString('base64');
+
+    fs.mkdirSync(constants.SOLO_VALUES_DIR, {recursive: true});
+    const valuesFile: string = PathEx.join(
+      constants.SOLO_VALUES_DIR,
+      `${config.releaseName}-rsa-bootstrap-values.yaml`,
+    );
+
+    // The block-node chart does not expose a dedicated RSA bootstrap file mount.
+    // Use the existing blockNode.initContainers hook to write the generated roster into
+    // verification-storage before the main JVM starts, then point app.state.rsaBootstrapFilePath
+    // to that file through APP_STATE_RSA_BOOTSTRAP_FILE_PATH.
+    fs.writeFileSync(
+      valuesFile,
+      yaml.stringify({
+        blockNode: {
+          config: {
+            APP_STATE_RSA_BOOTSTRAP_FILE_PATH: constants.BLOCK_NODE_RSA_BOOTSTRAP_FILE_PATH,
+          },
+          initContainers: [
+            this.buildDefaultBlockNodeInitStorageDirsContainer(),
+            this.buildRsaBootstrapRosterInitContainer(rosterBase64),
+          ],
+        },
+      }),
+    );
+
+    return valuesFile;
+  }
+
+  private buildDefaultBlockNodeInitStorageDirsContainer(): object {
+    // The block-node chart exposes blockNode.initContainers as a replacement list.
+    // Keep the chart's default init-storage-dirs container when adding the RSA bootstrap writer.
+    return {
+      name: 'init-storage-dirs',
+      image: 'busybox',
+      command: [
+        'sh',
+        '-c',
+        [
+          'mkdir -p /live-pvc/live-data && \\',
+          'chown 2000:2000 /live-pvc/live-data && \\',
+          'chmod 700 /live-pvc/live-data && \\',
+          'mkdir -p /archive-pvc/archive-data && \\',
+          'chown 2000:2000 /archive-pvc/archive-data && \\',
+          'chmod 700 /archive-pvc/archive-data && \\',
+          'chown 2000:2000 /verification-pvc && \\',
+          'chmod 700 /verification-pvc',
+        ].join('\n'),
+      ],
+      volumeMounts: [
+        {
+          name: 'live-storage',
+          mountPath: '/live-pvc',
+        },
+        {
+          name: 'archive-storage',
+          mountPath: '/archive-pvc',
+        },
+        {
+          name: 'verification-storage',
+          mountPath: '/verification-pvc',
+        },
+      ],
+    };
+  }
+
+  private buildRsaBootstrapRosterInitContainer(rosterBase64: string): object {
+    return {
+      name: 'write-rsa-bootstrap-roster',
+      image: 'busybox',
+      command: [
+        'sh',
+        '-c',
+        [
+          `mkdir -p ${constants.BLOCK_NODE_RSA_BOOTSTRAP_VERIFICATION_MOUNT_PATH} && \\`,
+          `printf "%s" "$RSA_BOOTSTRAP_ROSTER_BASE64" | base64 -d > ${constants.BLOCK_NODE_RSA_BOOTSTRAP_FILE_PATH} && \\`,
+          `chown 2000:2000 ${constants.BLOCK_NODE_RSA_BOOTSTRAP_FILE_PATH} && \\`,
+          `chmod 0444 ${constants.BLOCK_NODE_RSA_BOOTSTRAP_FILE_PATH}`,
+        ].join('\n'),
+      ],
+      env: [
+        {
+          name: 'RSA_BOOTSTRAP_ROSTER_BASE64',
+          value: rosterBase64,
+        },
+      ],
+      volumeMounts: [
+        {
+          name: 'verification-storage',
+          mountPath: constants.BLOCK_NODE_RSA_BOOTSTRAP_VERIFICATION_MOUNT_PATH,
+        },
+      ],
     };
   }
 

--- a/src/commands/file.ts
+++ b/src/commands/file.ts
@@ -314,7 +314,7 @@ Troubleshooting:
       isSystemFile?: boolean;
     }
 
-    const tasks = new Listr<Context>(
+    const tasks: SoloListr<Context> = new Listr(
       [
         {
           title: 'Initialize configuration',

--- a/src/commands/flags.ts
+++ b/src/commands/flags.ts
@@ -3122,6 +3122,7 @@ export class Flags {
     Flags.blockNodeChartVersion,
     Flags.blockNodeTssOverlay,
     Flags.priorityMapping,
+    Flags.blockNodeRsaBootstrapFile,
     Flags.externalBlockNodeAddress,
     Flags.realm,
     Flags.shard,

--- a/src/commands/flags.ts
+++ b/src/commands/flags.ts
@@ -1237,6 +1237,19 @@ export class Flags {
     prompt: undefined,
   };
 
+  public static readonly blockNodeRsaBootstrapFile: CommandFlag = {
+    constName: 'blockNodeRsaBootstrapFile',
+    name: 'block-node-rsa-bootstrap-file',
+    definition: {
+      describe:
+        'Path to an RSA bootstrap roster JSON file to use for the block node. ' +
+        'When omitted, Solo attempts to generate one from consensus node gossip signing keys.',
+      type: 'string',
+      defaultValue: '',
+    },
+    prompt: undefined,
+  };
+
   public static readonly wrapsEnabled: CommandFlag = {
     constName: 'wrapsEnabled',
     name: 'wraps',

--- a/src/core/block-node-rsa-bootstrap-roster.ts
+++ b/src/core/block-node-rsa-bootstrap-roster.ts
@@ -1,0 +1,92 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {X509Certificate} from 'node:crypto';
+import fs from 'node:fs';
+import {type ConsensusNode} from './model/consensus-node.js';
+import {Templates} from './templates.js';
+import {type K8Factory} from '../integration/kube/k8-factory.js';
+import {type NamespaceName} from '../types/namespace/namespace-name.js';
+import {type SoloLogger} from './logging/solo-logger.js';
+import {type NodeAlias} from '../types/aliases.js';
+import {type Secret} from '../integration/kube/resources/secret/secret.js';
+
+export interface BlockNodeRsaRosterNodeAddress {
+  RSAPubKey: string;
+  nodeId: number;
+}
+
+export interface BlockNodeRsaBootstrapRosterStructure {
+  nodeAddress: BlockNodeRsaRosterNodeAddress[];
+}
+
+export class BlockNodeRsaBootstrapRoster {
+  public static readBlockNodeRsaBootstrapRosterJsonFromFile(filePath: string): string {
+    return fs.readFileSync(filePath, 'utf8');
+  }
+
+  public static async buildBlockNodeRsaBootstrapRosterJsonFromSecrets(
+    consensusNodes: ConsensusNode[],
+    namespace: NamespaceName,
+    context: string,
+    k8Factory: K8Factory,
+    logger: SoloLogger,
+  ): Promise<string | undefined> {
+    const nodeAddresses: BlockNodeRsaRosterNodeAddress[] = [];
+
+    for (const consensusNode of consensusNodes) {
+      const nodeAlias: NodeAlias = consensusNode.name as NodeAlias;
+      const secretName: string = Templates.renderGossipKeySecretName(nodeAlias);
+      const publicKeyFileName: string = Templates.renderGossipPemPublicKeyFile(nodeAlias);
+
+      try {
+        const secret: Secret = await k8Factory.getK8(context).secrets().read(namespace, secretName);
+        const encodedPemCertificate: string | undefined = secret.data[publicKeyFileName];
+
+        if (!encodedPemCertificate) {
+          logger.warn(
+            `Skipping RSA bootstrap roster entry for ${nodeAlias}: secret '${secretName}' does not contain '${publicKeyFileName}'.`,
+          );
+          continue;
+        }
+
+        const pemCertificate: string = Buffer.from(encodedPemCertificate, 'base64').toString('utf8');
+
+        nodeAddresses.push({
+          nodeId: consensusNode.nodeId,
+          RSAPubKey: BlockNodeRsaBootstrapRoster.extractRsaPublicKeyHexFromPemCertificate(pemCertificate),
+        });
+      } catch (error) {
+        logger.warn(
+          `Skipping RSA bootstrap roster entry for ${nodeAlias}: failed to read gossip signing key secret '${secretName}': ${(error as Error).message}`,
+        );
+      }
+    }
+
+    if (nodeAddresses.length === 0) {
+      logger.warn(
+        'Skipping block node RSA bootstrap roster creation because no consensus node gossip signing keys were available. Mirror Node fallback applies.',
+      );
+      return undefined;
+    }
+
+    return BlockNodeRsaBootstrapRoster.buildBlockNodeRsaBootstrapRosterJson(nodeAddresses);
+  }
+
+  private static extractRsaPublicKeyHexFromPemCertificate(pemCertificate: string): string {
+    const cert: X509Certificate = new X509Certificate(pemCertificate);
+    const publicKeyDer: Buffer = cert.publicKey.export({type: 'spki', format: 'der'}) as Buffer;
+
+    return publicKeyDer.toString('hex');
+  }
+
+  private static buildBlockNodeRsaBootstrapRosterJson(nodeAddresses: BlockNodeRsaRosterNodeAddress[]): string {
+    return JSON.stringify(
+      {
+        // eslint-disable-next-line unicorn/no-array-sort
+        nodeAddress: nodeAddresses.sort((left, right): number => left.nodeId - right.nodeId),
+      } as BlockNodeRsaBootstrapRosterStructure,
+      undefined,
+      2,
+    );
+  }
+}

--- a/src/core/block-node-rsa-bootstrap-roster.ts
+++ b/src/core/block-node-rsa-bootstrap-roster.ts
@@ -72,14 +72,14 @@ export class BlockNodeRsaBootstrapRoster {
     return BlockNodeRsaBootstrapRoster.buildBlockNodeRsaBootstrapRosterJson(nodeAddresses);
   }
 
-  private static extractRsaPublicKeyHexFromPemCertificate(pemCertificate: string): string {
+  public static extractRsaPublicKeyHexFromPemCertificate(pemCertificate: string): string {
     const cert: X509Certificate = new X509Certificate(pemCertificate);
     const publicKeyDer: Buffer = cert.publicKey.export({type: 'spki', format: 'der'}) as Buffer;
 
     return publicKeyDer.toString('hex');
   }
 
-  private static buildBlockNodeRsaBootstrapRosterJson(nodeAddresses: BlockNodeRsaRosterNodeAddress[]): string {
+  public static buildBlockNodeRsaBootstrapRosterJson(nodeAddresses: BlockNodeRsaRosterNodeAddress[]): string {
     return JSON.stringify(
       {
         // eslint-disable-next-line unicorn/no-array-sort

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -451,10 +451,7 @@ export const BLOCK_NODE_PORT: number = +getEnvironmentVariable('BLOCK_NODE_PORT'
 export const BLOCK_NODE_PORT_LEGACY: number = +getEnvironmentVariable('BLOCK_NODE_PORT_LEGACY') || 8080;
 
 // Block Node RSA Bootstrap
-export const BLOCK_NODE_RSA_BOOTSTRAP_FILE_NAME: string = 'rsa-bootstrap-roster.json';
-export const BLOCK_NODE_RSA_BOOTSTRAP_FILE_PATH: string =
-  '/opt/hiero/block-node/verification/rsa-bootstrap-roster.json';
-export const BLOCK_NODE_RSA_BOOTSTRAP_VERIFICATION_MOUNT_PATH: string = '/opt/hiero/block-node/verification';
+export const BLOCK_NODE_RSA_BOOTSTRAP_FILE_PATH: string = '/opt/hiero/block-node/node/rsa-bootstrap-roster.json';
 
 export const BLOCK_ITEM_BATCH_SIZE: number = +getEnvironmentVariable('BLOCK_ITEM_BATCH_SIZE') || 256;
 

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -450,6 +450,12 @@ export const BLOCK_NODE_ACTIVE_TIMEOUT: number = +getEnvironmentVariable('BLOCK_
 export const BLOCK_NODE_PORT: number = +getEnvironmentVariable('BLOCK_NODE_PORT') || 40_840;
 export const BLOCK_NODE_PORT_LEGACY: number = +getEnvironmentVariable('BLOCK_NODE_PORT_LEGACY') || 8080;
 
+// Block Node RSA Bootstrap
+export const BLOCK_NODE_RSA_BOOTSTRAP_FILE_NAME: string = 'rsa-bootstrap-roster.json';
+export const BLOCK_NODE_RSA_BOOTSTRAP_FILE_PATH: string =
+  '/opt/hiero/block-node/verification/rsa-bootstrap-roster.json';
+export const BLOCK_NODE_RSA_BOOTSTRAP_VERIFICATION_MOUNT_PATH: string = '/opt/hiero/block-node/verification';
+
 export const BLOCK_ITEM_BATCH_SIZE: number = +getEnvironmentVariable('BLOCK_ITEM_BATCH_SIZE') || 256;
 
 // Filename suffix used for log/config archive files

--- a/test/e2e/commands/block-node.test.ts
+++ b/test/e2e/commands/block-node.test.ts
@@ -88,6 +88,7 @@ const endToEndTestSuite: EndToEndTestSuite = new EndToEndTestSuiteBuilder()
         BlockNodeTest.testBlockNode(options, 1);
 
         BlockNodeTest.add(options, ['node2']);
+        BlockNodeTest.verifyRsaBootstrapRoster(options, 2);
         DeploymentTest.info(options);
         DeploymentTest.verifyDeploymentConfigInfo(options);
 

--- a/test/e2e/commands/tests/block-node-test.ts
+++ b/test/e2e/commands/tests/block-node-test.ts
@@ -291,4 +291,45 @@ export class BlockNodeTest extends BaseCommandTest {
       }
     });
   }
+
+  public static verifyRsaBootstrapRoster(options: BaseTestOptions, blockNodeId: number): void {
+    const {namespace, contexts, testName} = options;
+
+    it(`${testName}: verify RSA bootstrap roster for block node ${blockNodeId}`, async (): Promise<void> => {
+      const blockNodeContainer: Container = await new K8Helper(contexts[0]).getBlockNodeContainer(
+        namespace,
+        blockNodeId,
+      );
+
+      expect(blockNodeContainer).to.not.be.undefined;
+
+      const rsaBootstrapFilePath: string = await blockNodeContainer.execContainer([
+        'bash',
+        '-c',
+        'printenv APP_STATE_RSA_BOOTSTRAP_FILE_PATH',
+      ]);
+
+      expect(rsaBootstrapFilePath.trim()).to.equal(constants.BLOCK_NODE_RSA_BOOTSTRAP_FILE_PATH);
+
+      const rosterJson: string = await blockNodeContainer.execContainer([
+        'bash',
+        '-c',
+        `cat ${constants.BLOCK_NODE_RSA_BOOTSTRAP_FILE_PATH}`,
+      ]);
+
+      const roster: {
+        nodeAddress: Array<{
+          nodeId: number;
+          RSAPubKey: string;
+        }>;
+      } = JSON.parse(rosterJson);
+
+      expect(roster.nodeAddress).to.not.be.empty;
+
+      for (const nodeAddress of roster.nodeAddress) {
+        expect(nodeAddress.nodeId).to.be.a('number');
+        expect(nodeAddress.RSAPubKey).to.match(/^[\da-f]+$/);
+      }
+    }).timeout(Duration.ofMinutes(2).toMillis());
+  }
 }

--- a/test/unit/core/block-node-rsa-bootstrap-roster.test.ts
+++ b/test/unit/core/block-node-rsa-bootstrap-roster.test.ts
@@ -1,0 +1,58 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {expect} from 'chai';
+import {describe, it} from 'mocha';
+import * as crypto from 'node:crypto';
+import * as x509 from '@peculiar/x509';
+
+import {BlockNodeRsaBootstrapRoster} from '../../../src/core/block-node-rsa-bootstrap-roster.js';
+
+describe('BlockNodeRsaBootstrapRoster', (): void => {
+  describe('buildBlockNodeRsaBootstrapRosterJson()', (): void => {
+    it('builds roster JSON sorted by node id', (): void => {
+      // @ts-expect-error - to access private method
+      const rosterJson: string = BlockNodeRsaBootstrapRoster.buildBlockNodeRsaBootstrapRosterJson([
+        {nodeId: 5, RSAPubKey: 'bb'},
+        {nodeId: 4, RSAPubKey: 'aa'},
+      ]);
+
+      expect(JSON.parse(rosterJson)).to.deep.equal({
+        nodeAddress: [
+          {nodeId: 4, RSAPubKey: 'aa'},
+          {nodeId: 5, RSAPubKey: 'bb'},
+        ],
+      });
+    });
+  });
+
+  describe('extractRsaPublicKeyHexFromPemCertificate()', (): void => {
+    it('extracts the hex-encoded DER SPKI public key from a PEM certificate', async (): Promise<void> => {
+      const keyPair: CryptoKeyPair = (await crypto.webcrypto.subtle.generateKey(
+        {
+          name: 'RSASSA-PKCS1-v1_5',
+          hash: 'SHA-384',
+          modulusLength: 3072,
+          publicExponent: new Uint8Array([1, 0, 1]),
+        },
+        true,
+        ['sign', 'verify'],
+      )) as CryptoKeyPair;
+
+      const certificate: x509.X509Certificate = await x509.X509CertificateGenerator.createSelfSigned({
+        name: 'CN=node1',
+        keys: keyPair,
+        signingAlgorithm: {name: 'RSASSA-PKCS1-v1_5', hash: 'SHA-384'},
+        notBefore: new Date(),
+        notAfter: new Date(Date.now() + 86_400_000),
+      });
+
+      const expectedPublicKeyDer: ArrayBuffer = await crypto.webcrypto.subtle.exportKey('spki', keyPair.publicKey);
+      const expectedPublicKeyHex: string = Buffer.from(expectedPublicKeyDer).toString('hex');
+
+      expect(
+        // @ts-expect-error - to access private method
+        BlockNodeRsaBootstrapRoster.extractRsaPublicKeyHexFromPemCertificate(certificate.toString('pem')),
+      ).to.equal(expectedPublicKeyHex);
+    });
+  });
+});

--- a/test/unit/core/block-node-rsa-bootstrap-roster.test.ts
+++ b/test/unit/core/block-node-rsa-bootstrap-roster.test.ts
@@ -10,7 +10,6 @@ import {BlockNodeRsaBootstrapRoster} from '../../../src/core/block-node-rsa-boot
 describe('BlockNodeRsaBootstrapRoster', (): void => {
   describe('buildBlockNodeRsaBootstrapRosterJson()', (): void => {
     it('builds roster JSON sorted by node id', (): void => {
-      // @ts-expect-error - to access private method
       const rosterJson: string = BlockNodeRsaBootstrapRoster.buildBlockNodeRsaBootstrapRosterJson([
         {nodeId: 5, RSAPubKey: 'bb'},
         {nodeId: 4, RSAPubKey: 'aa'},
@@ -50,7 +49,6 @@ describe('BlockNodeRsaBootstrapRoster', (): void => {
       const expectedPublicKeyHex: string = Buffer.from(expectedPublicKeyDer).toString('hex');
 
       expect(
-        // @ts-expect-error - to access private method
         BlockNodeRsaBootstrapRoster.extractRsaPublicKeyHexFromPemCertificate(certificate.toString('pem')),
       ).to.equal(expectedPublicKeyHex);
     });


### PR DESCRIPTION
## Description

Adds RSA bootstrap roster support for block node deployments.

Solo now attempts to build an RSA bootstrap roster from consensus node gossip signing certificates when running `block node add`. If the roster can be generated, Solo passes it to the block-node Helm chart through the new chart-native `blockNode.rsaBootstrap` values. The chart then writes the roster file into the block-node pod before the JVM starts and exposes the configured file path through block-node config.

This also adds support for `--block-node-rsa-bootstrap-file`, allowing users to provide a roster JSON file directly instead of generating one from consensus node secrets.

If consensus node gossip signing certificates are not available yet, Solo skips RSA bootstrap roster generation and continues with the existing behavior.

### Related Issues

* Closes # https://github.com/hiero-ledger/solo/issues/4426
* Depends on # https://github.com/hiero-ledger/hiero-block-node/pull/2863
