### PR TITLE
fix: use deployed block-node id for image-tag configmap update

### DIFF
--- a/src/commands/block-node.ts
+++ b/src/commands/block-node.ts
@@ -540,7 +540,6 @@ export class BlockNodeCommand extends BaseCommand {
               releaseName,
               chartVersion,
               valuesArg,
-              clusterRef,
               imageTag,
               blockNodeChartDirectory,
               newBlockNodeComponent,
@@ -567,11 +566,7 @@ export class BlockNodeCommand extends BaseCommand {
             if (imageTag) {
               // update config map with new VERSION info since
               // it will be used as a critical environment variable by block node
-              const blockNodeStateSchema: BlockNodeStateSchema = this.componentFactory.createNewBlockNodeComponent(
-                clusterRef,
-                namespace,
-              );
-              const blockNodeId: ComponentId = blockNodeStateSchema.metadata.id;
+              const blockNodeId: ComponentId = newBlockNodeComponent.metadata.id;
 
               const name: string = `block-node-${blockNodeId}-config`;
               const data: Record<string, string> = {VERSION: imageTag};


### PR DESCRIPTION
## Description

This pull request changes the following:

* Fixes the `block node add --image-tag` config map update path to use the deployed block-node component ID.
* Removes unused `clusterRef` destructuring in the same flow.

### Related Issues

* Closes #4513
* Related to #4513

### Pull request (PR) checklist

* [ ] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [x] Any technical debt has been documented as a separate issue and linked to this PR
* [ ] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [ ] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [x] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* Ran local validation flow with `./test_update.sh` after the code fix.
* Verified block node add with local image deployment now targets the expected `block-node-<id>-config` and completes successfully.

The following was not tested:

* Dedicated unit/integration test coverage for this exact image-tag config-map ID path has not yet been added.

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
