### PR TITLE
fix: allow local build upgrades without upgrade version

### DIFF
--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -1467,11 +1467,12 @@ export class NodeCommandTasks {
         }
 
         if ('upgradeVersion' in context_.config) {
-          if (!context_.config.upgradeVersion) {
+          if (context_.config.upgradeVersion) {
+            releaseTag = context_.config.upgradeVersion;
+          } else if (!localBuildPath) {
             this.logger.info('Skip, no need to update the platform software');
             return;
           }
-          releaseTag = context_.config.upgradeVersion;
         }
 
         context_.config.releaseTag = releaseTag;

--- a/test/unit/commands/node/local-build-path-pvc-validation.test.ts
+++ b/test/unit/commands/node/local-build-path-pvc-validation.test.ts
@@ -67,6 +67,44 @@ describe('NodeCommandTasks local build path PVC validation', (): void => {
   });
 });
 
+describe('NodeCommandTasks platform software fetch routing', (): void => {
+  it('uploads local build software when upgrade version is empty', async (): Promise<void> => {
+    const nodeCommandTasks: NodeCommandTasks = Object.create(NodeCommandTasks.prototype) as NodeCommandTasks;
+    const uploadResult: object = {};
+    const validateNodePvcsStub: sinon.SinonStub = sinon
+      .stub(nodeCommandTasks as unknown as Record<string, unknown>, 'validateNodePvcsForLocalBuildPath')
+      .resolves();
+    const uploadPlatformSoftwareStub: sinon.SinonStub = sinon
+      .stub(nodeCommandTasks as unknown as Record<string, unknown>, '_uploadPlatformSoftware')
+      .returns(uploadResult);
+
+    try {
+      const fetchPlatformSoftwareTask = nodeCommandTasks.fetchPlatformSoftware('nodeAliases');
+      const result: unknown = await fetchPlatformSoftwareTask.task(
+        {
+          config: {
+            consensusNodes: [{name: 'node1', context: 'kind-solo'}],
+            localBuildPath: '/tmp/local-build/data',
+            namespace: NamespaceName.of('solo'),
+            nodeAliases: ['node1'],
+            podRefs: {},
+            releaseTag: 'v0.74.0',
+            stagingDir: '/tmp/staging',
+            upgradeVersion: '',
+          },
+        } as never,
+        {} as never,
+      );
+
+      expect(result).to.equal(uploadResult);
+      expect(validateNodePvcsStub.calledOnceWith(NamespaceName.of('solo'), ['kind-solo'])).to.equal(true);
+      expect(uploadPlatformSoftwareStub.calledOnce).to.equal(true);
+    } finally {
+      sinon.restore();
+    }
+  });
+});
+
 describe('NodeCommandTasks gossipFqdnRestricted resolution', (): void => {
   const configMapFalseData: {data: Record<string, string>} = {
     data: {[constants.APPLICATION_PROPERTIES]: 'nodes.gossipFqdnRestricted=false\n'},

--- a/test/unit/commands/node/local-build-path-pvc-validation.test.ts
+++ b/test/unit/commands/node/local-build-path-pvc-validation.test.ts
@@ -79,7 +79,8 @@ describe('NodeCommandTasks platform software fetch routing', (): void => {
       .returns(uploadResult);
 
     try {
-      const fetchPlatformSoftwareTask = nodeCommandTasks.fetchPlatformSoftware('nodeAliases');
+      const fetchPlatformSoftwareTask: ReturnType<NodeCommandTasks['fetchPlatformSoftware']> =
+        nodeCommandTasks.fetchPlatformSoftware('nodeAliases');
       const result: unknown = await fetchPlatformSoftwareTask.task(
         {
           config: {


### PR DESCRIPTION
## Description

This pull request changes the following:

* Allows `solo consensus network upgrade --local-build-path <path>` to upload local build software even when `--upgrade-version` is omitted or empty.
* Keeps the existing skip behavior when neither `--upgrade-version` nor `--local-build-path` is provided.
* Adds a unit regression test for the local-build upgrade routing path.

Root cause: `fetchPlatformSoftware()` returned early whenever `upgradeVersion` existed on the config but was empty, before the `localBuildPath` upload branch could run.

### Related Issues

* Closes #3846

### Pull request (PR) checklist

* [x] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [ ] Any technical debt has been documented as a separate issue and linked to this PR
* [ ] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [x] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [ ] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* `npx mocha 'test/unit/commands/node/local-build-path-pvc-validation.test.ts'`
* `task build`
* `task format`
* `task check`

The following was not tested:

* A live Kubernetes consensus network upgrade with `--local-build-path` and no `--upgrade-version` was not run locally.

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | Yes                       |
| docs:     | changes to documentation                            | none                    | Yes                       |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
