### PR TITLE
fix: hugo docs build empty then branch in github:download:solo:assets

### DIFF
--- a/docs/site/Taskfile.github.yaml
+++ b/docs/site/Taskfile.github.yaml
@@ -62,17 +62,17 @@ tasks:
             url=$(echo "$asset" | jq -r '.url')
             dest="build/$tag/$name"
 
-            # skip if dest doesn't exist or if the artifact name starts with example- or if the filename is 
+            # skip if dest doesn't exist or if the artifact name starts with example- or if the filename is
             #  docs-latest.tar.gz and npmjsLatest is false
             if [[ -f "$dest" || "$name" == example-* || ( "$name" == "docs-latest.tar.gz" && "$npmjsLatest" == "false" ) ]]; then
               # echo "✔ Skipping condition met for $name, not writing $dest, npmjsLatest: $npmjsLatest"
-            else
-              echo "⬇ Downloading $name, $dest doesn't exist yet"
-              curl -sSL --retry 3 --fail -o "$dest" "$url" || {
-                echo "❌ Failed to download $url" >&2
-                rm -f "$dest"
-              }
+              continue
             fi
+            echo "⬇ Downloading $name, $dest doesn't exist yet"
+            curl -sSL --retry 3 --fail -o "$dest" "$url" || {
+              echo "❌ Failed to download $url" >&2
+              rm -f "$dest"
+            }
           done
         done
 


### PR DESCRIPTION
## Description

This pull request changes the following:

* Fixes the Hugo docs build failure in the `github:download:solo:assets` Taskfile task.

The task failed under Task's [`mvdan/sh`](https://github.com/mvdan/sh) shell interpreter with `30:118: then must be followed by a statement list`, because the `then` branch of the asset skip-condition contained only a commented-out `echo`. Unlike bash, `mvdan/sh` does not treat a lone comment as a valid statement, so the branch was effectively empty.

The condition is now inverted to use `continue`, and the download runs unconditionally afterward, removing the empty branch.

### Related Issues

* Closes #4527

### Pull request (PR) checklist

* [ ] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [x] Any technical debt has been documented as a separate issue and linked to this PR
* [x] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [ ] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [x] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* Ran `task --list` in `docs/site` and confirmed the Taskfile now parses successfully (it previously failed during parse with the same syntax error).

The following was not tested:

* The full end-to-end docs build / asset download was not run locally (requires GitHub release assets and `GH_TOKEN`); it is exercised by the docs CI workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)