### PR TITLE
fix: address feedback for cache feature

### DIFF
--- a/resources/config/solo-cache-images-target.yaml
+++ b/resources/config/solo-cache-images-target.yaml
@@ -4,7 +4,6 @@ templates:
   - RELAY_VERSION
   - EXPLORER_VERSION
   - MINIO_OPERATOR_VERSION
-  - CONSENSUS_NODE_VERSION
 
 images:
   # --- Mirror Node ---

--- a/src/commands/cache.ts
+++ b/src/commands/cache.ts
@@ -52,6 +52,14 @@ interface CacheClearContext {
   config: CacheClearConfigClass;
 }
 
+interface CachePruneConfigClass {
+  imageCacheHandler: ImageCacheHandler;
+}
+
+interface CachePruneContext {
+  config: CachePruneConfigClass;
+}
+
 interface CacheStatusConfigClass {
   imageCacheHandler: ImageCacheHandler;
   clusterReference: ClusterReferenceName;
@@ -94,7 +102,18 @@ export class CacheCommand extends BaseCommand {
 
   public static readonly PULL_FLAGS_LIST: CommandFlags = {
     required: [],
-    optional: [flags.quiet, flags.cacheDir, flags.devMode, flags.edgeEnabled],
+    optional: [
+      flags.quiet,
+      flags.cacheDir,
+      flags.devMode,
+      flags.edgeEnabled,
+
+      // Versions
+      flags.mirrorNodeVersion,
+      flags.blockNodeVersion,
+      flags.relayVersion,
+      flags.explorerVersion,
+    ],
   };
 
   public static readonly LOAD_FLAGS_LIST: CommandFlags = {
@@ -108,6 +127,11 @@ export class CacheCommand extends BaseCommand {
   };
 
   public static readonly CLEAR_FLAGS_LIST: CommandFlags = {
+    required: [],
+    optional: [flags.quiet, flags.cacheDir, flags.devMode],
+  };
+
+  public static readonly PRUNE_FLAGS_LIST: CommandFlags = {
     required: [],
     optional: [flags.quiet, flags.cacheDir, flags.devMode],
   };
@@ -138,7 +162,13 @@ export class CacheCommand extends BaseCommand {
 
             const edgeEnabled: boolean = this.configManager.getFlag(flags.edgeEnabled);
 
-            const renderedYamlPath: string = await this.renderImageTargetsFile(edgeEnabled);
+            const renderedYamlPath: string = await this.renderImageTargetsFile(
+              edgeEnabled,
+              this.configManager.getFlag(flags.mirrorNodeVersion),
+              this.configManager.getFlag(flags.blockNodeVersion),
+              this.configManager.getFlag(flags.relayVersion),
+              this.configManager.getFlag(flags.explorerVersion),
+            );
 
             context_.config = {
               imageCacheHandler: await this.buildImageCacheHandlerFromYaml(renderedYamlPath),
@@ -289,6 +319,33 @@ export class CacheCommand extends BaseCommand {
       constants.LISTR_DEFAULT_OPTIONS.DEFAULT,
       undefined,
       'cache image clear',
+    );
+
+    await tasks.run();
+    return true;
+  }
+
+  public async prune(): Promise<boolean> {
+    const tasks: SoloListr<CachePruneContext> = this.taskList.newTaskList(
+      [
+        {
+          title: 'Prune image cache',
+          task: async (context_): Promise<void> => {
+            const cacheDirectory: string = this.configManager.getFlag(flags.cacheDir);
+
+            const config: CachePruneConfigClass = {
+              imageCacheHandler: await this.buildImageCacheHandlerFromRenderedFile(cacheDirectory),
+            };
+
+            context_.config = config;
+
+            await config.imageCacheHandler.prune();
+          },
+        },
+      ],
+      constants.LISTR_DEFAULT_OPTIONS.DEFAULT,
+      undefined,
+      'cache image prune',
     );
 
     await tasks.run();
@@ -467,19 +524,27 @@ export class CacheCommand extends BaseCommand {
     return PathEx.join(cacheDirectory, 'config', CacheImageTargetTemplateRenderer.RENDERED_FILE_NAME);
   }
 
-  private async renderImageTargetsFile(edgeEnabled: boolean): Promise<string> {
+  private async renderImageTargetsFile(
+    edgeEnabled: boolean,
+    mirrorNodeVersion?: string,
+    blockNodeVersion?: string,
+    relayVersion?: string,
+    explorerVersion?: string,
+  ): Promise<string> {
     const cacheDirectory: string = this.configManager.getFlag(flags.cacheDir);
     const renderedConfigDirectory: string = PathEx.join(cacheDirectory, 'config');
 
     return new CacheImageTargetTemplateRenderer(
       new DefaultCacheImageTemplateResolver(
         new CacheImageTemplateValues(
-          edgeEnabled ? version.MIRROR_NODE_EDGE_VERSION : version.MIRROR_NODE_VERSION,
-          edgeEnabled ? version.BLOCK_NODE_EDGE_VERSION : version.BLOCK_NODE_VERSION,
-          edgeEnabled ? version.HEDERA_JSON_RPC_RELAY_EDGE_VERSION : version.HEDERA_JSON_RPC_RELAY_VERSION,
-          edgeEnabled ? version.EXPLORER_EDGE_VERSION : version.EXPLORER_VERSION,
+          mirrorNodeVersion || (edgeEnabled ? version.MIRROR_NODE_EDGE_VERSION : version.MIRROR_NODE_VERSION),
+          blockNodeVersion || (edgeEnabled ? version.BLOCK_NODE_EDGE_VERSION : version.BLOCK_NODE_VERSION),
+          relayVersion ||
+            (edgeEnabled ? version.HEDERA_JSON_RPC_RELAY_EDGE_VERSION : version.HEDERA_JSON_RPC_RELAY_VERSION),
+          explorerVersion || (edgeEnabled ? version.EXPLORER_EDGE_VERSION : version.EXPLORER_VERSION),
+
+          // MinIO is an external dependency and currently has no Solo edge variant.
           version.MINIO_OPERATOR_VERSION,
-          edgeEnabled ? version.HEDERA_PLATFORM_EDGE_VERSION : version.HEDERA_PLATFORM_VERSION,
         ),
       ),
     ).renderToFile(constants.SOLO_CACHE_IMAGES_TARGET_FILE, renderedConfigDirectory);

--- a/src/commands/command-definitions/cache-command-definition.ts
+++ b/src/commands/command-definitions/cache-command-definition.ts
@@ -31,6 +31,7 @@ export class CacheCommandDefinition extends BaseCommandDefinition {
   public static readonly IMAGE_LIST: string = 'list';
   public static readonly IMAGE_CLEAR: string = 'clear';
   public static readonly IMAGE_STATUS: string = 'status';
+  public static readonly IMAGE_PRUNE: string = 'prune';
 
   public static readonly IMAGE_PULL_COMMAND: string = `${CacheCommandDefinition.COMMAND_NAME} ${CacheCommandDefinition.IMAGE_SUBCOMMAND_NAME} ${CacheCommandDefinition.IMAGE_PULL}`;
 
@@ -77,6 +78,16 @@ export class CacheCommandDefinition extends BaseCommandDefinition {
               this.cacheCommand,
               this.cacheCommand.clear,
               CacheCommand.CLEAR_FLAGS_LIST,
+              [],
+            ),
+          )
+          .addSubcommand(
+            new Subcommand(
+              CacheCommandDefinition.IMAGE_PRUNE,
+              'Prune the image archives.',
+              this.cacheCommand,
+              this.cacheCommand.prune,
+              CacheCommand.PRUNE_FLAGS_LIST,
               [],
             ),
           )

--- a/src/commands/one-shot/orchestrator/deploy/deploy-argv-builders.ts
+++ b/src/commands/one-shot/orchestrator/deploy/deploy-argv-builders.ts
@@ -268,6 +268,18 @@ export class DeployArgvBuilders {
       ...CacheCommandDefinition.IMAGE_PULL_COMMAND.split(' '),
       optionFromFlag(Flags.edgeEnabled),
       (!!config.edgeEnabled).toString(),
+
+      optionFromFlag(Flags.mirrorNodeVersion),
+      config.versions.mirror,
+
+      optionFromFlag(Flags.blockNodeVersion),
+      config.versions.blockNode,
+
+      optionFromFlag(Flags.relayVersion),
+      config.versions.relay,
+
+      optionFromFlag(Flags.explorerVersion),
+      config.versions.explorer,
     );
     return argvPushGlobalFlags(argv);
   }

--- a/src/integration/cache/api/cache-operation-handler.ts
+++ b/src/integration/cache/api/cache-operation-handler.ts
@@ -16,7 +16,7 @@ import {type CachedItemStructure} from '../models/cached-item-structure.js';
  *
  * This keeps domain-specific behavior out of the coordinator.
  */
-  export interface CacheOperationHandler {
+export interface CacheOperationHandler {
   /**
    * Returns the artifact type handled by this strategy.
    */

--- a/src/integration/cache/api/cache-operation-handler.ts
+++ b/src/integration/cache/api/cache-operation-handler.ts
@@ -16,7 +16,7 @@ import {type CachedItemStructure} from '../models/cached-item-structure.js';
  *
  * This keeps domain-specific behavior out of the coordinator.
  */
-export interface CacheOperationHandler {
+  export interface CacheOperationHandler {
   /**
    * Returns the artifact type handled by this strategy.
    */
@@ -65,4 +65,9 @@ export interface CacheOperationHandler {
    * It may be used by callers to inspect or report cache contents.
    */
   list(): Promise<readonly CachedItemStructure[]>;
+
+  /**
+   * Deletes all cached artifacts and cache metadata for this domain.
+   */
+  prune(): Promise<void>;
 }

--- a/src/integration/cache/impl/image-cache-handler.ts
+++ b/src/integration/cache/impl/image-cache-handler.ts
@@ -119,6 +119,10 @@ export class ImageCacheHandler implements CacheOperationHandler {
     }
   }
 
+  public async prune(): Promise<void> {
+    await this.store.clear();
+  }
+
   public async healthcheck(): Promise<readonly ArtifactHealthResult[]> {
     const results: ArtifactHealthResult[] = [];
 

--- a/src/integration/cache/models/cache-image-template-values-structure.ts
+++ b/src/integration/cache/models/cache-image-template-values-structure.ts
@@ -6,5 +6,4 @@ export interface CacheImageTemplateValuesStructure {
   readonly RELAY_VERSION: string;
   readonly EXPLORER_VERSION: string;
   readonly MINIO_OPERATOR_VERSION: string;
-  readonly CONSENSUS_NODE_VERSION: string;
 }

--- a/src/integration/cache/models/impl/cache-image-template-values.ts
+++ b/src/integration/cache/models/impl/cache-image-template-values.ts
@@ -8,7 +8,6 @@ export class CacheImageTemplateValues implements CacheImageTemplateValuesStructu
   public readonly RELAY_VERSION: string;
   public readonly EXPLORER_VERSION: string;
   public readonly MINIO_OPERATOR_VERSION: string;
-  public readonly CONSENSUS_NODE_VERSION: string;
 
   public constructor(
     mirrorNodeVersion: string,
@@ -16,14 +15,12 @@ export class CacheImageTemplateValues implements CacheImageTemplateValuesStructu
     relayVersion: string,
     explorerVersion: string,
     minioOperatorVersion: string,
-    consensusNodeVersion: string,
   ) {
     this.MIRROR_NODE_VERSION = this.removeVPrefix(mirrorNodeVersion);
     this.BLOCK_NODE_VERSION = this.removeVPrefix(blockNodeVersion);
     this.RELAY_VERSION = this.removeVPrefix(relayVersion);
     this.EXPLORER_VERSION = this.removeVPrefix(explorerVersion);
     this.MINIO_OPERATOR_VERSION = this.ensureVPrefix(minioOperatorVersion);
-    this.CONSENSUS_NODE_VERSION = this.removeVPrefix(consensusNodeVersion);
   }
 
   /**


### PR DESCRIPTION
## Description

1. Image cache disabled by default
Fixed `ENABLE_IMAGE_CACHE` so cache is enabled by default and only disabled with `ENABLE_IMAGE_CACHE=false`.

2. One-shot cache pull ignores resolved versions
Passed one-shot resolved component versions into `cache image pull`.

3. Cache rendering falls back to defaults
Updated image target rendering to use provided version flags instead of only `--edge`.

4. Unused consensus cache template value
Removed unused `CONSENSUS_NODE_VERSION` from cache template values.

5. Old cached archives are left behind
Added `cache image prune` to remove all cached image artifacts and metadata.

6. Edge MinIO version behavior unclear
Kept `MinIO` on the default version and documented that it has no Solo edge variant.

7. Homebrew cache success message issue
Not part of this Solo PR; should be fixed in the Homebrew formula by checking the cache pull command result.

### Related Issues

* Closes # https://github.com/hiero-ledger/solo/issues/4580
