### PR TITLE
fix(remote-config): make component creation idempotent on existing component

### DIFF
--- a/src/business/runtime-state/config/remote/remote-config-runtime-state.ts
+++ b/src/business/runtime-state/config/remote/remote-config-runtime-state.ts
@@ -270,15 +270,23 @@ export class RemoteConfigRuntimeState implements RemoteConfigRuntimeStateApi {
 
     //* add the new nodes to components
     for (const nodeAlias of nodeAliases) {
-      this.configuration.components.addNewComponent(
-        componentFactory.createNewConsensusNodeComponent(
-          Templates.renderComponentIdFromNodeAlias(nodeAlias),
-          clusterReference,
-          namespace,
-          DeploymentPhase.REQUESTED,
-        ),
+      const consensusNodeComponent: ConsensusNodeStateSchema = componentFactory.createNewConsensusNodeComponent(
+        Templates.renderComponentIdFromNodeAlias(nodeAlias),
+        clusterReference,
+        namespace,
+        DeploymentPhase.REQUESTED,
+      );
+
+      const consensusNodeAdded: boolean = this.configuration.components.addNewComponent(
+        consensusNodeComponent,
         ComponentTypes.ConsensusNode,
       );
+
+      if (!consensusNodeAdded) {
+        this.logger.info(
+          `Consensus node with id: ${consensusNodeComponent.metadata.id} already exists, skipping creation`,
+        );
+      }
     }
 
     await this.persist();

--- a/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
+++ b/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
@@ -410,12 +410,17 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
                 deployConfig.namespace,
               );
               blockNode.metadata.phase = DeploymentPhase.REQUESTED;
-              this.remoteConfig.configuration.components.addNewComponent(
+
+              const blockNodeAdded: boolean = this.remoteConfig.configuration.components.addNewComponent(
                 blockNode,
                 ComponentTypes.BlockNode,
                 false,
                 true,
               );
+
+              if (!blockNodeAdded) {
+                this.logger.info(`Block node with id: ${blockNode.metadata.id} already exists, skipping creation`);
+              }
             }
 
             if (deployConfig.deployExplorer) {
@@ -424,12 +429,17 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
                 deployConfig.namespace,
               );
               explorer.metadata.phase = DeploymentPhase.REQUESTED;
-              this.remoteConfig.configuration.components.addNewComponent(
+
+              const explorerAdded: boolean = this.remoteConfig.configuration.components.addNewComponent(
                 explorer,
                 ComponentTypes.Explorer,
                 false,
                 true,
               );
+
+              if (!explorerAdded) {
+                this.logger.info(`Explorer with id: ${explorer.metadata.id} already exists, skipping creation`);
+              }
             }
 
             if (deployConfig.deployMirrorNode) {
@@ -438,12 +448,17 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
                 deployConfig.namespace,
               );
               mirrorNode.metadata.phase = DeploymentPhase.REQUESTED;
-              this.remoteConfig.configuration.components.addNewComponent(
+
+              const mirrorNodeAdded: boolean = this.remoteConfig.configuration.components.addNewComponent(
                 mirrorNode,
                 ComponentTypes.MirrorNode,
                 false,
                 true,
               );
+
+              if (!mirrorNodeAdded) {
+                this.logger.info(`Mirror node with id ${mirrorNode.metadata.id} already exists, skipping creation`);
+              }
             }
 
             if (deployConfig.deployRelay) {
@@ -457,7 +472,16 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
                 nodeIds,
               );
               relay.metadata.phase = DeploymentPhase.REQUESTED;
-              this.remoteConfig.configuration.components.addNewComponent(relay, ComponentTypes.RelayNodes, false, true);
+              const relayAdded: boolean = this.remoteConfig.configuration.components.addNewComponent(
+                relay,
+                ComponentTypes.RelayNodes,
+                false,
+                true,
+              );
+
+              if (!relayAdded) {
+                this.logger.info(`Relay node with id: ${relay.metadata.id} already exists, skipping creation`);
+              }
             }
 
             await this.remoteConfig.persist();

--- a/src/core/config/remote/api/components-data-wrapper-api.ts
+++ b/src/core/config/remote/api/components-data-wrapper-api.ts
@@ -21,7 +21,12 @@ export interface ComponentsDataWrapperApi {
    * @param isReplace
    * @param skipIncrement
    */
-  addNewComponent(component: BaseStateSchema, type: ComponentTypes, isReplace?: boolean, skipIncrement?: boolean): void;
+  addNewComponent(
+    component: BaseStateSchema,
+    type: ComponentTypes,
+    isReplace?: boolean,
+    skipIncrement?: boolean,
+  ): boolean;
 
   changeNodePhase(componentId: ComponentId, phase: DeploymentPhase): void;
 

--- a/src/core/config/remote/components-data-wrapper.ts
+++ b/src/core/config/remote/components-data-wrapper.ts
@@ -31,7 +31,7 @@ export class ComponentsDataWrapper implements ComponentsDataWrapperApi {
     type: ComponentTypes,
     isReplace?: boolean,
     skipIncrement: boolean = false,
-  ): void {
+  ): boolean {
     const componentId: ComponentId = component.metadata.id;
 
     if (typeof componentId !== 'number') {
@@ -42,19 +42,32 @@ export class ComponentsDataWrapper implements ComponentsDataWrapperApi {
       throw new SoloErrors.internal.dataValidation('component type', 'BaseState', 'unknown');
     }
 
+    let componentAdded: boolean = false;
+
     const addComponentCallback: (components: BaseStateSchema[]) => void = (components): void => {
-      if (this.checkComponentExists(components, component) && !isReplace) {
-        throw new SoloErrors.validation.componentAlreadyExists(String(componentId));
+      const existingComponentIndex: number = components.findIndex(
+        (existingComponent): boolean => existingComponent.metadata.id === componentId,
+      );
+
+      if (existingComponentIndex !== -1) {
+        if (isReplace) {
+          components[existingComponentIndex] = component;
+        }
+
+        return;
       }
+
       components.push(component);
+      componentAdded = true;
     };
 
     this.applyCallbackToComponentGroup(type, addComponentCallback, componentId);
 
-    if (!skipIncrement) {
-      // Increment the component id counter for the specified type when adding
+    if (componentAdded && !skipIncrement) {
       this.componentIds[type] += 1;
     }
+
+    return componentAdded;
   }
 
   // TODO: Remove once unified method is fully utilized
@@ -230,11 +243,6 @@ export class ComponentsDataWrapper implements ComponentsDataWrapperApi {
         throw new SoloErrors.validation.unknownComponentType(componentType, String(componentId));
       }
     }
-  }
-
-  /** checks if component exists in the respective group */
-  private checkComponentExists(components: BaseStateSchema[], newComponent: BaseStateSchema): boolean {
-    return components.some((component): boolean => component.metadata.id === newComponent.metadata.id);
   }
 
   public getNewComponentId(componentType: ComponentTypes): number {

--- a/test/unit/core/config/remote/components-data-wrapper.test.ts
+++ b/test/unit/core/config/remote/components-data-wrapper.test.ts
@@ -6,7 +6,7 @@ import {describe, it} from 'mocha';
 import {ComponentsDataWrapper} from '../../../../../src/core/config/remote/components-data-wrapper.js';
 import {SoloError} from '../../../../../src/core/errors/solo-error.js';
 import {ComponentTypes} from '../../../../../src/core/config/remote/enumerations/component-types.js';
-import {type NodeId} from '../../../../../src/types/aliases.js';
+import {type AnyObject, type NodeId} from '../../../../../src/types/aliases.js';
 import {
   type ClusterReferenceName,
   type ComponentId,
@@ -94,10 +94,10 @@ export function createComponentsDataWrapper(): {
   };
 }
 
-describe('ComponentsDataWrapper', () => {
-  it('should be able to create a instance', () => createComponentsDataWrapper());
+describe('ComponentsDataWrapper', (): void => {
+  it('should be able to create a instance', (): AnyObject => createComponentsDataWrapper());
 
-  it('should not be able to add new component with the .addNewComponent() method if it already exist', () => {
+  it('should skip adding a component with the .addNewComponent() method if it already exists', (): void => {
     const {
       wrapper: {componentsDataWrapper},
       components: {consensusNodes},
@@ -105,13 +105,16 @@ describe('ComponentsDataWrapper', () => {
 
     const existingComponent: ConsensusNodeStateSchema = consensusNodes[0];
 
-    expect(() => componentsDataWrapper.addNewComponent(existingComponent, ComponentTypes.ConsensusNode)).to.throw(
-      SoloError,
-      'already exists',
+    const componentAdded: boolean = componentsDataWrapper.addNewComponent(
+      existingComponent,
+      ComponentTypes.ConsensusNode,
     );
+
+    expect(componentAdded).to.be.false;
+    expect(componentsDataWrapper.state.consensusNodes).to.have.lengthOf(1);
   });
 
-  it('should be able to add new component with the .addNewComponent() method', () => {
+  it('should be able to add new component with the .addNewComponent() method', (): void => {
     const {
       wrapper: {componentsDataWrapper},
     } = createComponentsDataWrapper();
@@ -127,12 +130,34 @@ describe('ComponentsDataWrapper', () => {
     const metadata: ComponentStateMetadataSchema = new ComponentStateMetadataSchema(id, namespace, cluster, phase);
     const newComponent: EnvoyProxyStateSchema = new EnvoyProxyStateSchema(metadata);
 
-    componentsDataWrapper.addNewComponent(newComponent, ComponentTypes.EnvoyProxy);
+    const componentAdded: boolean = componentsDataWrapper.addNewComponent(newComponent, ComponentTypes.EnvoyProxy);
 
+    expect(componentAdded).to.be.true;
     expect(componentsDataWrapper.state.envoyProxies).to.have.lengthOf(2);
   });
 
-  it('should be able to change node state with the .changeNodeState(()', () => {
+  it('should not increment component id counter when existing component is skipped', (): void => {
+    const {
+      wrapper: {componentsDataWrapper},
+      components: {consensusNodes},
+    } = createComponentsDataWrapper();
+
+    const existingComponent: ConsensusNodeStateSchema = consensusNodes[0];
+    const originalComponentIdCounter: number = componentsDataWrapper.componentIds[ComponentTypes.ConsensusNode];
+
+    const componentAdded: boolean = componentsDataWrapper.addNewComponent(
+      existingComponent,
+      ComponentTypes.ConsensusNode,
+      false,
+      true,
+    );
+
+    expect(componentAdded).to.be.false;
+    expect(componentsDataWrapper.state.consensusNodes).to.have.lengthOf(1);
+    expect(componentsDataWrapper.componentIds[ComponentTypes.ConsensusNode]).to.equal(originalComponentIdCounter);
+  });
+
+  it('should be able to change node state with the .changeNodeState(()', (): void => {
     const {
       wrapper: {componentsDataWrapper},
       componentId,
@@ -145,19 +170,19 @@ describe('ComponentsDataWrapper', () => {
     expect(componentsDataWrapper.state.consensusNodes[0].metadata.phase).to.equal(newNodeState);
   });
 
-  it("should not be able to edit component with the .editComponent() if it doesn't exist ", () => {
+  it("should not be able to edit component with the .editComponent() if it doesn't exist ", (): void => {
     const {
       wrapper: {componentsDataWrapper},
     } = createComponentsDataWrapper();
     const notFoundComponentId: ComponentId = 9;
 
-    expect(() => componentsDataWrapper.changeNodePhase(notFoundComponentId, DeploymentPhase.FROZEN)).to.throw(
+    expect((): void => componentsDataWrapper.changeNodePhase(notFoundComponentId, DeploymentPhase.FROZEN)).to.throw(
       SoloError,
       'not found',
     );
   });
 
-  it('should be able to remove component with the .removeComponent()', () => {
+  it('should be able to remove component with the .removeComponent()', (): void => {
     const {
       wrapper: {componentsDataWrapper},
       components: {relays},
@@ -169,20 +194,20 @@ describe('ComponentsDataWrapper', () => {
     expect(relays).to.not.have.own.property(componentId.toString());
   });
 
-  it("should not be able to remove component with the .removeComponent() if it doesn't exist ", () => {
+  it("should not be able to remove component with the .removeComponent() if it doesn't exist ", (): void => {
     const {
       wrapper: {componentsDataWrapper},
     } = createComponentsDataWrapper();
 
     const notFoundComponentId: ComponentId = 9;
 
-    expect(() => componentsDataWrapper.removeComponent(notFoundComponentId, ComponentTypes.RelayNodes)).to.throw(
+    expect((): void => componentsDataWrapper.removeComponent(notFoundComponentId, ComponentTypes.RelayNodes)).to.throw(
       SoloError,
       'not found',
     );
   });
 
-  it('should be able to get components with .getComponent()', () => {
+  it('should be able to get components with .getComponent()', (): void => {
     const {
       wrapper: {componentsDataWrapper},
       componentId,
@@ -199,7 +224,7 @@ describe('ComponentsDataWrapper', () => {
     );
   });
 
-  it("should fail if trying to get component that doesn't exist with .getComponent()", () => {
+  it("should fail if trying to get component that doesn't exist with .getComponent()", (): void => {
     const {
       wrapper: {componentsDataWrapper},
     } = createComponentsDataWrapper();
@@ -207,8 +232,8 @@ describe('ComponentsDataWrapper', () => {
     const notFoundComponentId: ComponentId = 9;
     const type: ComponentTypes = ComponentTypes.MirrorNode;
 
-    expect(() => componentsDataWrapper.getComponent<MirrorNodeStateSchema>(type, notFoundComponentId)).to.throw(
-      'not found',
-    );
+    expect(
+      (): MirrorNodeStateSchema => componentsDataWrapper.getComponent<MirrorNodeStateSchema>(type, notFoundComponentId),
+    ).to.throw('not found');
   });
 });


### PR DESCRIPTION
## Description

- Updated remote config component creation to be idempotent.
- The component wrapper now skips existing components instead of throwing, returns whether a component was actually added, and avoids incrementing component counters when nothing was added. - Callers can now log and continue safely on reruns, while malformed input validation remains unchanged.

### Related Issues

* Closes # https://github.com/hiero-ledger/solo/issues/4560