### PR TITLE
fix: prevent cache image pull hangs and surface failures

### DIFF
--- a/src/core/shell-runner.ts
+++ b/src/core/shell-runner.ts
@@ -82,6 +82,9 @@ export class ShellRunner {
         for (const item of items) {
           if (item) {
             output.push(item);
+            if (verbose) {
+              this.logger.showUser(item);
+            }
           }
         }
       });
@@ -91,7 +94,11 @@ export class ShellRunner {
         const items: string[] = data.toString().split(/\r?\n/);
         for (const item of items) {
           if (item) {
-            errorOutput.push(item.trim());
+            const errorMessage: string = item.trim();
+            errorOutput.push(errorMessage);
+            if (verbose) {
+              this.logger.showUser(errorMessage);
+            }
           }
         }
       });

--- a/src/core/shell-runner.ts
+++ b/src/core/shell-runner.ts
@@ -37,6 +37,7 @@ export class ShellRunner {
     environmentVariablesToAppend: Record<string, string> = {},
     timeoutMs?: number,
     useShell: boolean = true,
+    idleTimeoutMs?: number,
   ): Promise<string[]> {
     const redactedArguments: string[] = ShellRunner.redactArguments(arguments_);
     const message: string = `Executing command${OperatingSystem.isWin32() ? ' (Windows)' : ''}: ${cmd} ${redactedArguments.join(' ')}`;
@@ -65,6 +66,7 @@ export class ShellRunner {
 
       let timedOut: boolean = false;
       let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+      let idleTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
 
       if (timeoutMs !== undefined) {
         timeoutHandle = setTimeout((): void => {
@@ -76,8 +78,29 @@ export class ShellRunner {
         }, timeoutMs);
       }
 
+      const resetIdleTimeout: () => void = (): void => {
+        if (idleTimeoutMs === undefined) {
+          return;
+        }
+
+        if (idleTimeoutHandle) {
+          clearTimeout(idleTimeoutHandle);
+        }
+
+        idleTimeoutHandle = setTimeout((): void => {
+          timedOut = true;
+          child.kill();
+          const error: Error = new Error(`Command produced no output for ${idleTimeoutMs}ms: '${cmd}'`);
+          error.stack = callStack;
+          reject(error);
+        }, idleTimeoutMs);
+      };
+
+      resetIdleTimeout();
+
       const output: string[] = [];
       child.stdout.on('data', (data): void => {
+        resetIdleTimeout();
         const items: string[] = data.toString().split(/\r?\n/);
         for (const item of items) {
           if (item) {
@@ -91,6 +114,7 @@ export class ShellRunner {
 
       const errorOutput: string[] = [];
       child.stderr.on('data', (data): void => {
+        resetIdleTimeout();
         const items: string[] = data.toString().split(/\r?\n/);
         for (const item of items) {
           if (item) {
@@ -106,6 +130,10 @@ export class ShellRunner {
       child.on('exit', (code, signal): void => {
         if (timeoutHandle) {
           clearTimeout(timeoutHandle);
+        }
+
+        if (idleTimeoutHandle) {
+          clearTimeout(idleTimeoutHandle);
         }
 
         if (timedOut) {

--- a/src/core/shell-runner.ts
+++ b/src/core/shell-runner.ts
@@ -68,13 +68,20 @@ export class ShellRunner {
       let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
       let idleTimeoutHandle: ReturnType<typeof setTimeout> | undefined;
 
+      const failOnTimeout: (error: Error) => void = (error: Error): void => {
+        if (timedOut) {
+          return;
+        }
+
+        timedOut = true;
+        child.kill();
+        error.stack = callStack;
+        reject(error);
+      };
+
       if (timeoutMs !== undefined) {
         timeoutHandle = setTimeout((): void => {
-          timedOut = true;
-          child.kill();
-          const error: Error = new Error(`Command timed out after ${timeoutMs}ms: '${cmd}'`);
-          error.stack = callStack;
-          reject(error);
+          failOnTimeout(new Error(`Command timed out after ${timeoutMs}ms: '${cmd}'`));
         }, timeoutMs);
       }
 
@@ -88,11 +95,7 @@ export class ShellRunner {
         }
 
         idleTimeoutHandle = setTimeout((): void => {
-          timedOut = true;
-          child.kill();
-          const error: Error = new Error(`Command produced no output for ${idleTimeoutMs}ms: '${cmd}'`);
-          error.stack = callStack;
-          reject(error);
+          failOnTimeout(new Error(`Command produced no output for ${idleTimeoutMs}ms: '${cmd}'`));
         }, idleTimeoutMs);
       };
 

--- a/src/integration/cache/impl/image-cache-handler.ts
+++ b/src/integration/cache/impl/image-cache-handler.ts
@@ -71,7 +71,7 @@ export class ImageCacheHandler implements CacheOperationHandler {
               task.title += ' - ' + chalk.red(`failed to SAVE image: ${image}`);
               this.logger.showUser(`Failed to save image archive: ${image}. ${message}`);
               this.logger.error('Failed to save image archive:', error);
-              throw error;
+              return;
             }
           }
 

--- a/src/integration/cache/impl/image-cache-handler.ts
+++ b/src/integration/cache/impl/image-cache-handler.ts
@@ -67,9 +67,11 @@ export class ImageCacheHandler implements CacheOperationHandler {
             try {
               await this.engine.saveImage(image, archivePath);
             } catch (error) {
+              const message: string = error instanceof Error ? error.message : String(error);
               task.title += ' - ' + chalk.red(`failed to SAVE image: ${image}`);
+              this.logger.showUser(`Failed to save image archive: ${image}. ${message}`);
               this.logger.error('Failed to save image archive:', error);
-              return;
+              throw error;
             }
           }
 

--- a/src/integration/container-engine/docker-client.ts
+++ b/src/integration/container-engine/docker-client.ts
@@ -18,6 +18,7 @@ import {Architecture} from '../../business/utils/architecture.js';
 
 @injectable()
 export class DockerClient implements ContainerEngineClient {
+  private static readonly IMAGE_PULL_TIMEOUT_MS: number = 15 * 60 * 1000;
   private readonly shellRunner: ShellRunner;
 
   public constructor(
@@ -34,7 +35,14 @@ export class DockerClient implements ContainerEngineClient {
   public async pullImage(image: string): Promise<void> {
     const platform: string = Architecture.getLinuxPlatform();
 
-    await this.shellRunner.run('docker', ['pull', '--platform', platform, image]);
+    await this.shellRunner.run(
+      'docker',
+      ['pull', '--platform', platform, image],
+      true,
+      false,
+      {},
+      DockerClient.IMAGE_PULL_TIMEOUT_MS,
+    );
   }
 
   public async saveImage(image: string, archivePath: string): Promise<void> {
@@ -43,7 +51,14 @@ export class DockerClient implements ContainerEngineClient {
     const platform: string = Architecture.getLinuxPlatform();
     const craneExecutable: string = await this.dependencyManager.getExecutable(constants.CRANE);
 
-    await this.shellRunner.run(craneExecutable, ['pull', '--platform', platform, image, archivePath]);
+    await this.shellRunner.run(
+      craneExecutable,
+      ['pull', '--platform', platform, image, archivePath],
+      true,
+      false,
+      {},
+      DockerClient.IMAGE_PULL_TIMEOUT_MS,
+    );
   }
 
   public async loadImage(archivePath: string): Promise<void> {

--- a/src/integration/container-engine/docker-client.ts
+++ b/src/integration/container-engine/docker-client.ts
@@ -19,6 +19,7 @@ import {Architecture} from '../../business/utils/architecture.js';
 @injectable()
 export class DockerClient implements ContainerEngineClient {
   private static readonly IMAGE_PULL_TIMEOUT_MS: number = 15 * 60 * 1000;
+  private static readonly IMAGE_PULL_IDLE_TIMEOUT_MS: number = 45 * 1000;
   private readonly shellRunner: ShellRunner;
 
   public constructor(
@@ -42,6 +43,8 @@ export class DockerClient implements ContainerEngineClient {
       false,
       {},
       DockerClient.IMAGE_PULL_TIMEOUT_MS,
+      true,
+      DockerClient.IMAGE_PULL_IDLE_TIMEOUT_MS,
     );
   }
 
@@ -58,6 +61,8 @@ export class DockerClient implements ContainerEngineClient {
       false,
       {},
       DockerClient.IMAGE_PULL_TIMEOUT_MS,
+      true,
+      DockerClient.IMAGE_PULL_IDLE_TIMEOUT_MS,
     );
   }
 

--- a/src/integration/container-engine/docker-client.ts
+++ b/src/integration/container-engine/docker-client.ts
@@ -18,8 +18,8 @@ import {Architecture} from '../../business/utils/architecture.js';
 
 @injectable()
 export class DockerClient implements ContainerEngineClient {
-  private static readonly IMAGE_PULL_TIMEOUT_MS: number = 15 * 60 * 1000;
-  private static readonly IMAGE_PULL_IDLE_TIMEOUT_MS: number = 45 * 1000;
+  private static readonly IMAGE_PULL_TIMEOUT_MS: number = 10 * 60 * 1000;
+  private static readonly IMAGE_PULL_IDLE_TIMEOUT_MS: number = 10 * 60 * 1000;
   private readonly shellRunner: ShellRunner;
 
   public constructor(

--- a/test/unit/core/shell-runner.test.ts
+++ b/test/unit/core/shell-runner.test.ts
@@ -70,6 +70,15 @@ describe('ShellRunner', (): void => {
     expect(loggerShowUserStub).to.have.been.calledWith('verbose-output');
   }).timeout(Duration.ofSeconds(10).toMillis());
 
+  it('should reject when command is idle with no output', async (): Promise<void> => {
+    const commandToRun: string = 'node -e "setTimeout(()=>{}, 10000)"';
+    const idleTimeoutMs: number = 500;
+
+    await expect(shellRunner.run(commandToRun, [], false, false, {}, 10_000, true, idleTimeoutMs)).to.be.rejectedWith(
+      `Command produced no output for ${idleTimeoutMs}ms`,
+    );
+  }).timeout(Duration.ofSeconds(10).toMillis());
+
   describe('redactArguments', (): void => {
     it('should redact --password and its value', (): void => {
       const arguments_: string[] = ['--password', 'mySecret'];

--- a/test/unit/core/shell-runner.test.ts
+++ b/test/unit/core/shell-runner.test.ts
@@ -17,6 +17,7 @@ describe('ShellRunner', (): void => {
   let shellRunner: ShellRunner,
     loggerDebugStub: SinonStub,
     loggerInfoStub: SinonStub,
+    loggerShowUserStub: SinonStub,
     childProcessSpy: SinonSpy,
     readableSpy: SinonSpy;
 
@@ -26,6 +27,7 @@ describe('ShellRunner', (): void => {
     // Spy on methods
     loggerDebugStub = sinon.stub(SoloPinoLogger.prototype, 'debug');
     loggerInfoStub = sinon.stub(SoloPinoLogger.prototype, 'info');
+    loggerShowUserStub = sinon.stub(SoloPinoLogger.prototype, 'showUser');
     childProcessSpy = sinon.spy(ChildProcess.prototype, 'on');
     readableSpy = sinon.spy(Readable.prototype, 'on');
   });
@@ -60,6 +62,12 @@ describe('ShellRunner', (): void => {
     await expect(shellRunner.run(commandToRun, [], false, false, {}, timeoutMs)).to.be.rejectedWith(
       `Command timed out after ${timeoutMs}ms`,
     );
+  }).timeout(Duration.ofSeconds(10).toMillis());
+
+  it('should stream output when verbose mode is enabled', async (): Promise<void> => {
+    await shellRunner.run('node -e "console.log(\'verbose-output\')"', [], true);
+
+    expect(loggerShowUserStub).to.have.been.calledWith('verbose-output');
   }).timeout(Duration.ofSeconds(10).toMillis());
 
   describe('redactArguments', (): void => {

--- a/test/unit/integration/cache/image-cache-handler.test.ts
+++ b/test/unit/integration/cache/image-cache-handler.test.ts
@@ -67,7 +67,7 @@ describe('ImageCacheHandler pull', (): void => {
     flush: (callback: (error?: Error) => void): void => callback(),
   };
 
-  it('should throw when saveImage fails', async (): Promise<void> => {
+  it('should continue without registering cached result when saveImage fails', async (): Promise<void> => {
     const saveImageStub: SinonStub = sinon.stub().rejects(new Error('rate limited'));
     const engine: ContainerEngineClient = {
       pullImage: async (): Promise<void> => undefined,
@@ -84,7 +84,9 @@ describe('ImageCacheHandler pull', (): void => {
     const subtasks: readonly SoloListrTask<AnyListrContext>[] = await handler.pull();
     const context: {config: {results: unknown[]}} = {config: {results: []}};
 
-    await expect(subtasks[0].task(context as never, {title: 'task'} as never)).to.be.rejectedWith('rate limited');
+    await subtasks[0].task(context as never, {title: 'task'} as never);
+
+    expect(saveImageStub).to.have.been.calledOnce;
     expect(context.config.results).to.have.lengthOf(0);
   });
 

--- a/test/unit/integration/cache/image-cache-handler.test.ts
+++ b/test/unit/integration/cache/image-cache-handler.test.ts
@@ -1,0 +1,104 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import 'sinon-chai';
+
+import {expect} from 'chai';
+import sinon, {type SinonStub} from 'sinon';
+import {describe, it} from 'mocha';
+import {ImageCacheHandler} from '../../../../src/integration/cache/impl/image-cache-handler.js';
+import {StaticCacheTargetProvider} from '../../../../src/integration/cache/target-providers/static-cache-target-provider.js';
+import {CacheArtifactEnum} from '../../../../src/integration/cache/enums/cache-artifact-enum.js';
+import {type CacheCatalogStore} from '../../../../src/integration/cache/api/cache-catalog-store.js';
+import {type CacheHealthInspector} from '../../../../src/integration/cache/api/cache-health-inspector.js';
+import {type SoloLogger} from '../../../../src/core/logging/solo-logger.js';
+import {type ContainerEngineClient} from '../../../../src/integration/container-engine/container-engine-client.js';
+
+describe('ImageCacheHandler pull', (): void => {
+  const target = {
+    type: CacheArtifactEnum.IMAGE,
+    name: 'docker.io/library/busybox',
+    version: '1.36.1',
+    source: undefined,
+  };
+
+  const store: CacheCatalogStore = {
+    save: async (): Promise<void> => undefined,
+    load: async (): Promise<never> => ({items: []}) as never,
+    exists: async (): Promise<boolean> => true,
+    clear: async (): Promise<void> => undefined,
+    resolvePath: (): string => '/tmp/busybox.tar',
+  };
+
+  const inspector: CacheHealthInspector = {
+    exists: async (): Promise<boolean> => false,
+    getSize: async (): Promise<number> => 0,
+    filterExisting: async (paths: readonly string[]): Promise<readonly string[]> => paths,
+  };
+
+  const logger: SoloLogger = {
+    setDevMode: (): void => undefined,
+    isDevMode: (): boolean => false,
+    nextTraceId: (): void => undefined,
+    setLogBinding: (): void => undefined,
+    addLogBindings: (): void => undefined,
+    clearLogBindings: (): void => undefined,
+    prepMeta: (meta?: object): object => meta ?? {},
+    showUser: (): void => undefined,
+    showUserError: (): void => undefined,
+    error: (): void => undefined,
+    warn: (): void => undefined,
+    info: (): void => undefined,
+    debug: (): void => undefined,
+    showList: (): void => undefined,
+    showJSON: (): void => undefined,
+    addMessageGroup: (): void => undefined,
+    getMessageGroup: (): string[] => [],
+    addMessageGroupMessage: (): void => undefined,
+    showMessageGroup: (): void => undefined,
+    getMessageGroupKeys: (): string[] => [],
+    showAllMessageGroups: (): void => undefined,
+    flush: (callback: (error?: Error) => void): void => callback(),
+  };
+
+  it('should throw when saveImage fails', async (): Promise<void> => {
+    const saveImageStub: SinonStub = sinon.stub().rejects(new Error('rate limited'));
+    const engine: ContainerEngineClient = {
+      pullImage: async (): Promise<void> => undefined,
+      saveImage: saveImageStub,
+      loadImage: async (): Promise<void> => undefined,
+      loadImageArchiveIntoCluster: async (): Promise<void> => undefined,
+      removeImage: async (): Promise<void> => undefined,
+      listLoadedImagesInCluster: async (): Promise<readonly string[]> => [],
+    };
+
+    const provider: StaticCacheTargetProvider = new StaticCacheTargetProvider([target]);
+    const handler: ImageCacheHandler = new ImageCacheHandler(engine, provider, store, inspector, logger);
+
+    const subtasks = await handler.pull();
+    const context: {config: {results: unknown[]}} = {config: {results: []}};
+
+    await expect(subtasks[0].task(context as never, {title: 'task'} as never)).to.be.rejectedWith('rate limited');
+    expect(context.config.results).to.have.lengthOf(0);
+  });
+
+  it('should register cached result when saveImage succeeds', async (): Promise<void> => {
+    const engine: ContainerEngineClient = {
+      pullImage: async (): Promise<void> => undefined,
+      saveImage: async (): Promise<void> => undefined,
+      loadImage: async (): Promise<void> => undefined,
+      loadImageArchiveIntoCluster: async (): Promise<void> => undefined,
+      removeImage: async (): Promise<void> => undefined,
+      listLoadedImagesInCluster: async (): Promise<readonly string[]> => [],
+    };
+
+    const provider: StaticCacheTargetProvider = new StaticCacheTargetProvider([target]);
+    const handler: ImageCacheHandler = new ImageCacheHandler(engine, provider, store, inspector, logger);
+
+    const subtasks = await handler.pull();
+    const context: {config: {results: unknown[]}} = {config: {results: []}};
+
+    await subtasks[0].task(context as never, {title: 'task'} as never);
+
+    expect(context.config.results).to.have.lengthOf(1);
+  });
+});

--- a/test/unit/integration/cache/image-cache-handler.test.ts
+++ b/test/unit/integration/cache/image-cache-handler.test.ts
@@ -12,9 +12,16 @@ import {type CacheCatalogStore} from '../../../../src/integration/cache/api/cach
 import {type CacheHealthInspector} from '../../../../src/integration/cache/api/cache-health-inspector.js';
 import {type SoloLogger} from '../../../../src/core/logging/solo-logger.js';
 import {type ContainerEngineClient} from '../../../../src/integration/container-engine/container-engine-client.js';
+import {type SoloListrTask} from '../../../../src/types/index.js';
+import {type AnyListrContext} from '../../../../src/types/aliases.js';
 
 describe('ImageCacheHandler pull', (): void => {
-  const target = {
+  const target: {
+    type: CacheArtifactEnum;
+    name: string;
+    version: string;
+    source: string | undefined;
+  } = {
     type: CacheArtifactEnum.IMAGE,
     name: 'docker.io/library/busybox',
     version: '1.36.1',
@@ -74,7 +81,7 @@ describe('ImageCacheHandler pull', (): void => {
     const provider: StaticCacheTargetProvider = new StaticCacheTargetProvider([target]);
     const handler: ImageCacheHandler = new ImageCacheHandler(engine, provider, store, inspector, logger);
 
-    const subtasks = await handler.pull();
+    const subtasks: readonly SoloListrTask<AnyListrContext>[] = await handler.pull();
     const context: {config: {results: unknown[]}} = {config: {results: []}};
 
     await expect(subtasks[0].task(context as never, {title: 'task'} as never)).to.be.rejectedWith('rate limited');
@@ -94,7 +101,7 @@ describe('ImageCacheHandler pull', (): void => {
     const provider: StaticCacheTargetProvider = new StaticCacheTargetProvider([target]);
     const handler: ImageCacheHandler = new ImageCacheHandler(engine, provider, store, inspector, logger);
 
-    const subtasks = await handler.pull();
+    const subtasks: readonly SoloListrTask<AnyListrContext>[] = await handler.pull();
     const context: {config: {results: unknown[]}} = {config: {results: []}};
 
     await subtasks[0].task(context as never, {title: 'task'} as never);


### PR DESCRIPTION
## Description

This pull request changes the following:

* Streams `stdout` and `stderr` output to users in real time when `ShellRunner.run()` is invoked in verbose mode.
* Adds a 10-minute per-command timeout for `docker pull` and `crane pull`, with the same 10-minute idle window for commands that stop producing output.
* Applies those timeout protections to both Docker image pulls and Crane image archive saves in `DockerClient`.
* Continues remaining cache image pulls when an individual image save fails, while logging and showing the failed image message.
* Avoids registering a failed image as cached when its archive save fails.
* Adds unit tests for verbose shell output streaming, command idle timeout rejection, and image cache handler failure continuation/success handling.

### Related Issues

* Related to hiero-ledger/homebrew-tools#74

### Pull request (PR) checklist

* [x] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [x] Any technical debt has been documented as a separate issue and linked to this PR
* [x] Any `infra` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [x] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [x] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* Ran focused unit tests for `ShellRunner` and `ImageCacheHandler`; result: `12 passing`.
* Ran project validation commands: `task build`, `task format`, and `task check`.
* Ran `cache image pull` manually and verified image caching progresses with visible task output and completes successfully under normal registry/network behavior.

The following was not tested:

* End-to-end run under Homebrew install path with induced registry/network failures.