### PR TITLE
docs(one-shot): correct --rollback describe text and document resume workflow

### DIFF
--- a/src/commands/flags.ts
+++ b/src/commands/flags.ts
@@ -1998,7 +1998,8 @@ export class Flags {
     name: 'rollback',
     definition: {
       describe:
-        'Automatically clean up resources when deploy fails. Use --no-rollback to skip cleanup and keep partial resources for inspection.',
+        'Opt in to automatic cleanup when deploy fails. By default, ' +
+        'failed one-shot deploys keep partial resources so you can inspect the failure and re-run the same command.',
       defaultValue: false,
       type: 'boolean',
       disablePrompt: true,


### PR DESCRIPTION
## Description

update the description of the `--rollback` flag to better reflect the usage of the flag

### Related Issues

* Closes # https://github.com/hiero-ledger/solo/issues/4565
