### PR TITLE
fix: retry address book query on INVALID_NODE_ACCOUNT in dual-cluster

### DIFF
--- a/src/core/account-manager.ts
+++ b/src/core/account-manager.ts
@@ -21,6 +21,7 @@ import {
   Logger,
   LogLevel,
   Long,
+  PrecheckStatusError,
   PrivateKey,
   Status,
   TransactionReceipt,
@@ -1074,10 +1075,36 @@ export class AccountManager {
 
     const realm: Realm = this.localConfig.configuration.realmForDeployment(deployment);
     const shard: Shard = this.localConfig.configuration.shardForDeployment(deployment);
-    const query: FileContentsQuery = new FileContentsQuery().setFileId(
-      new FileId(shard, realm, FileId.ADDRESS_BOOK.num),
-    );
-    return Buffer.from(await query.execute(client)).toString('base64');
+    const fileId: FileId = new FileId(shard, realm, FileId.ADDRESS_BOOK.num);
+
+    // The SDK does not retry INVALID_NODE_ACCOUNT for queries (only for transactions), so we
+    // retry here to handle the race where a node's gRPC endpoint is up but its Hedera state
+    // has not finished initializing yet.
+    const maxAttempts: number = 5;
+    const retryDelayMs: number = 5000;
+    let lastError: PrecheckStatusError | undefined;
+
+    for (let attempt: number = 0; attempt < maxAttempts; attempt++) {
+      try {
+        return Buffer.from(await new FileContentsQuery().setFileId(fileId).execute(client)).toString('base64');
+      } catch (error) {
+        if (
+          error instanceof PrecheckStatusError &&
+          error.status === Status.InvalidNodeAccount &&
+          attempt < maxAttempts - 1
+        ) {
+          this.logger.warn(
+            `Address book query returned INVALID_NODE_ACCOUNT (attempt ${attempt + 1}/${maxAttempts}), retrying in ${retryDelayMs}ms`,
+          );
+          lastError = error;
+          await sleep(Duration.ofMillis(retryDelayMs));
+        } else {
+          throw error;
+        }
+      }
+    }
+
+    throw lastError!;
   }
 
   public async getFileContents(


### PR DESCRIPTION
## Description

This pull request changes the following:

* In `prepareAddressBookBase64`, wrap the `FileContentsQuery.execute()` call in a retry loop (up to 5 attempts, 5 s delay) that catches `PrecheckStatusError` with `INVALID_NODE_ACCOUNT` and retries.

### Root cause

In a dual-cluster deployment, consensus nodes from the second cluster pass the gRPC-level ping health check (TCP connection is established) but may not have finished initializing their Hedera state when the mirror node deployment calls `prepareAddressBookBase64`. The Hedera JS SDK's `Query._getStatusAndExecutionState()` returns `ExecutionState.Error` for `INVALID_NODE_ACCOUNT` — unlike transactions, which get `ExecutionState.Retry` and rotate to the next node. So `FileContentsQuery` throws `PrecheckStatusError` immediately with no SDK-level retry.

The retry loop creates a fresh `FileContentsQuery` instance on each attempt so the SDK re-selects from the node pool, and allows the initializing node(s) time to become ready before giving up.

### Related Issues

* Closes #4578

### Pull request (PR) checklist

* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description

### Testing

* [ ] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [x] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* The fix targets the intermittent race condition in the dual-cluster E2E test. The retry logic has been code-reviewed against the SDK source to confirm `INVALID_NODE_ACCOUNT` is non-retriable for queries.

The following was not tested:

* Full dual-cluster E2E test run (requires CI environment with two Kind clusters).