### PR TITLE
fix: propagate shared resource scheduling values

### DIFF
--- a/src/commands/mirror-node.ts
+++ b/src/commands/mirror-node.ts
@@ -761,6 +761,7 @@ export class MirrorNodeCommand extends BaseCommand {
               }
 
               this.sharedResourceManager.enableRedis();
+              this.sharedResourceManager.setSchedulingChartValues(context_.config.chartValues);
               context_.config.installSharedResources = await this.sharedResourceManager.installChart(
                 context_.config.namespace,
                 context_.config.chartDirectory,

--- a/src/core/shared-resources/shared-resource-manager.ts
+++ b/src/core/shared-resources/shared-resource-manager.ts
@@ -9,6 +9,19 @@ import {type ChartManager} from '../chart-manager.js';
 import {type NamespaceName} from '../../types/namespace/namespace-name.js';
 import * as constants from '../../core/constants.js';
 import {HelmChartValues, type HelmChartValue} from '../../integration/helm/model/values.js';
+import * as fs from 'node:fs';
+import yaml from 'yaml';
+
+type HelmValuesObject = Record<string, unknown>;
+type HelmMapValue = Record<string, HelmChartValue>;
+type HelmToleration = HelmMapValue;
+
+interface SharedResourceSchedulingValues {
+  postgresNodeSelector: HelmMapValue;
+  postgresTolerations: HelmToleration[];
+  redisNodeSelector: HelmMapValue;
+  redisTolerations: HelmToleration[];
+}
 
 @injectable()
 export class SharedResourceManager {
@@ -28,6 +41,10 @@ export class SharedResourceManager {
 
   public setAdditionalChartValues(additionalChartValues: HelmChartValues): void {
     this.additionalChartValues = additionalChartValues.clone();
+  }
+
+  public setSchedulingChartValues(sourceChartValues: HelmChartValues): void {
+    this.additionalChartValues.add(buildSchedulingChartValues(sourceChartValues));
   }
 
   public enablePostgres(): void {
@@ -106,4 +123,155 @@ export class SharedResourceManager {
 
     return true;
   }
+}
+
+function buildSchedulingChartValues(sourceChartValues: HelmChartValues): HelmChartValues {
+  const schedulingValues: SharedResourceSchedulingValues = {
+    postgresNodeSelector: {},
+    postgresTolerations: [],
+    redisNodeSelector: {},
+    redisTolerations: [],
+  };
+
+  for (const valuesFilePath of getValuesFilePaths(sourceChartValues)) {
+    const values: unknown = yaml.parse(fs.readFileSync(valuesFilePath, 'utf8'));
+    if (!isHelmValuesObject(values)) {
+      continue;
+    }
+
+    mergeSchedulingValues(schedulingValues, values);
+  }
+
+  return toChartValues(schedulingValues);
+}
+
+function getValuesFilePaths(chartValues: HelmChartValues): string[] {
+  const arguments_: string[] = chartValues.toArguments();
+  const valuesFilePaths: string[] = [];
+
+  for (let index: number = 0; index < arguments_.length - 1; index++) {
+    if (arguments_[index] === '--values') {
+      valuesFilePaths.push(arguments_[index + 1]);
+    }
+  }
+
+  return valuesFilePaths;
+}
+
+function mergeSchedulingValues(target: SharedResourceSchedulingValues, values: HelmValuesObject): void {
+  const topLevelNodeSelector: HelmMapValue = getMapValue(values, 'nodeSelector');
+  const topLevelTolerations: HelmToleration[] = getTolerations(values, 'tolerations');
+
+  Object.assign(target.postgresNodeSelector, topLevelNodeSelector);
+  addTolerations(target.postgresTolerations, topLevelTolerations);
+  Object.assign(target.redisNodeSelector, topLevelNodeSelector);
+  addTolerations(target.redisTolerations, topLevelTolerations);
+
+  for (const path of ['postgresql.postgresql', 'postgresql.primary']) {
+    Object.assign(target.postgresNodeSelector, getMapValue(values, `${path}.nodeSelector`));
+    addTolerations(target.postgresTolerations, getTolerations(values, `${path}.tolerations`));
+  }
+
+  for (const path of ['redis', 'redis.master', 'redis.replica']) {
+    Object.assign(target.redisNodeSelector, getMapValue(values, `${path}.nodeSelector`));
+    addTolerations(target.redisTolerations, getTolerations(values, `${path}.tolerations`));
+  }
+}
+
+function getMapValue(values: HelmValuesObject, path: string): HelmMapValue {
+  const value: unknown = getValueAtPath(values, path);
+  if (!isHelmValuesObject(value)) {
+    return {};
+  }
+
+  return Object.fromEntries(
+    Object.entries(value).filter((entry: [string, unknown]): entry is [string, HelmChartValue] =>
+      isHelmChartValue(entry[1]),
+    ),
+  );
+}
+
+function getTolerations(values: HelmValuesObject, path: string): HelmToleration[] {
+  const value: unknown = getValueAtPath(values, path);
+  if (!Array.isArray(value)) {
+    return [];
+  }
+
+  return value
+    .filter(isHelmValuesObject)
+    .map(
+      (toleration: HelmValuesObject): HelmToleration =>
+        Object.fromEntries(
+          Object.entries(toleration).filter((entry: [string, unknown]): entry is [string, HelmChartValue] =>
+            isHelmChartValue(entry[1]),
+          ),
+        ),
+    )
+    .filter((toleration: HelmToleration): boolean => Object.keys(toleration).length > 0);
+}
+
+function getValueAtPath(values: HelmValuesObject, path: string): unknown {
+  let currentValue: unknown = values;
+
+  for (const segment of path.split('.')) {
+    if (!isHelmValuesObject(currentValue)) {
+      return undefined;
+    }
+
+    currentValue = currentValue[segment];
+  }
+
+  return currentValue;
+}
+
+function addTolerations(target: HelmToleration[], tolerations: HelmToleration[]): void {
+  const existing: Set<string> = new Set(target.map((toleration: HelmToleration): string => JSON.stringify(toleration)));
+
+  for (const toleration of tolerations) {
+    const serialized: string = JSON.stringify(toleration);
+    if (!existing.has(serialized)) {
+      target.push(toleration);
+      existing.add(serialized);
+    }
+  }
+}
+
+function toChartValues(schedulingValues: SharedResourceSchedulingValues): HelmChartValues {
+  const chartValues: HelmChartValues = new HelmChartValues();
+
+  addNodeSelectorChartValues(chartValues, 'postgresql.primary.nodeSelector', schedulingValues.postgresNodeSelector);
+  addTolerationChartValues(chartValues, 'postgresql.primary.tolerations', schedulingValues.postgresTolerations);
+
+  for (const redisPath of ['redis.master', 'redis.replica']) {
+    addNodeSelectorChartValues(chartValues, `${redisPath}.nodeSelector`, schedulingValues.redisNodeSelector);
+    addTolerationChartValues(chartValues, `${redisPath}.tolerations`, schedulingValues.redisTolerations);
+  }
+
+  return chartValues;
+}
+
+function addNodeSelectorChartValues(chartValues: HelmChartValues, path: string, nodeSelector: HelmMapValue): void {
+  for (const [key, value] of Object.entries(nodeSelector)) {
+    chartValues.setLiteral(`${path}.${escapeHelmPathSegment(key)}`, value);
+  }
+}
+
+function addTolerationChartValues(chartValues: HelmChartValues, path: string, tolerations: HelmToleration[]): void {
+  for (const [index, toleration] of tolerations.entries()) {
+    for (const [key, value] of Object.entries(toleration)) {
+      chartValues.setLiteral(`${path}[${index}].${key}`, value);
+    }
+  }
+}
+
+function escapeHelmPathSegment(segment: string): string {
+  return segment.replaceAll('.', String.raw`\.`);
+}
+
+function isHelmValuesObject(value: unknown): value is HelmValuesObject {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isHelmChartValue(value: unknown): value is HelmChartValue {
+  return typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean';
 }

--- a/test/unit/core/shared-resources/shared-resource-manager.test.ts
+++ b/test/unit/core/shared-resources/shared-resource-manager.test.ts
@@ -3,6 +3,8 @@
 import {expect} from 'chai';
 import {afterEach, beforeEach, describe, it} from 'mocha';
 import sinon from 'sinon';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
 
 import {SharedResourceManager} from '../../../../src/core/shared-resources/shared-resource-manager.js';
 import {type ChartManager} from '../../../../src/core/chart-manager.js';
@@ -11,7 +13,8 @@ import {type HelmClient} from '../../../../src/integration/helm/helm-client.js';
 import {NamespaceName} from '../../../../src/types/namespace/namespace-name.js';
 import * as constants from '../../../../src/core/constants.js';
 import {type AnyObject} from '../../../../src/types/aliases.js';
-import {type HelmChartValues} from '../../../../src/integration/helm/model/values.js';
+import {HelmChartValues} from '../../../../src/integration/helm/model/values.js';
+import {PathEx} from '../../../../src/business/utils/path-ex.js';
 
 describe('SharedResourceManager', (): void => {
   const namespace: NamespaceName = NamespaceName.of('test-namespace');
@@ -22,6 +25,7 @@ describe('SharedResourceManager', (): void => {
   let helmStub: HelmClient;
   let chartManagerStub: ChartManager;
   let manager: SharedResourceManager;
+  let temporaryDirectory: string;
 
   const chartValueArguments: () => string[] = (): string[] => {
     const chartValues: HelmChartValues = (chartManagerStub.install as sinon.SinonStub).firstCall.args[5];
@@ -41,10 +45,12 @@ describe('SharedResourceManager', (): void => {
     chartManagerStub.uninstall = sinon.stub().resolves(true);
 
     manager = new SharedResourceManager(loggerStub, helmStub, chartManagerStub);
+    temporaryDirectory = fs.mkdtempSync(PathEx.join(os.tmpdir(), 'solo-shared-resource-manager-'));
   });
 
   afterEach((): void => {
     sinon.restore();
+    fs.rmSync(temporaryDirectory, {force: true, recursive: true});
   });
 
   describe('installChart()', (): void => {
@@ -116,6 +122,85 @@ describe('SharedResourceManager', (): void => {
       expect(valueArguments).to.include('--set');
       expect(valueArguments).to.include('redis.image.registry=gcr.io');
       expect(valueArguments).to.include('redis.sentinel.masterSet=mirror');
+    });
+
+    it('maps mirror-node scheduling values into shared-resource chart paths', async (): Promise<void> => {
+      const valuesFilePath: string = PathEx.join(temporaryDirectory, 'mirror-node-values.yaml');
+      fs.writeFileSync(
+        valuesFilePath,
+        [
+          'tolerations:',
+          '  - key: "solo.hashgraph.io/owner"',
+          '    operator: "Equal"',
+          '    value: "adhoc-performance-test"',
+          '    effect: "NoSchedule"',
+          'postgresql:',
+          '  postgresql:',
+          '    tolerations:',
+          '      - key: "solo-scheduling.io/os"',
+          '        operator: "Equal"',
+          '        value: "linux"',
+          '        effect: "NoSchedule"',
+          'redis:',
+          '  tolerations:',
+          '    - key: "solo.hashgraph.io/role"',
+          '      operator: "Equal"',
+          '      value: "consensus-node"',
+          '      effect: "NoSchedule"',
+          '',
+        ].join('\n'),
+      );
+
+      manager.setSchedulingChartValues(new HelmChartValues().file(valuesFilePath));
+
+      await manager.installChart(namespace, '', chartVersion, context);
+
+      const valueArguments: string[] = chartValueArguments();
+
+      expect(valueArguments).to.include('--set-literal');
+      expect(valueArguments).to.include('postgresql.primary.tolerations[0].key=solo.hashgraph.io/owner');
+      expect(valueArguments).to.include('postgresql.primary.tolerations[0].value=adhoc-performance-test');
+      expect(valueArguments).to.include('postgresql.primary.tolerations[1].key=solo-scheduling.io/os');
+      expect(valueArguments).to.include('redis.replica.tolerations[0].key=solo.hashgraph.io/owner');
+      expect(valueArguments).to.include('redis.replica.tolerations[0].value=adhoc-performance-test');
+      expect(valueArguments).to.include('redis.replica.tolerations[1].key=solo.hashgraph.io/role');
+      expect(valueArguments).to.include('redis.master.tolerations[1].key=solo.hashgraph.io/role');
+    });
+
+    it('maps direct shared-resource scheduling values from values files', async (): Promise<void> => {
+      const valuesFilePath: string = PathEx.join(temporaryDirectory, 'shared-resource-values.yaml');
+      fs.writeFileSync(
+        valuesFilePath,
+        [
+          'postgresql:',
+          '  primary:',
+          '    nodeSelector:',
+          '      solo.hashgraph.io/role: "database"',
+          '    tolerations:',
+          '      - key: "solo.hashgraph.io/owner"',
+          '        operator: "Equal"',
+          '        value: "adhoc-single-day-test"',
+          '        effect: "NoSchedule"',
+          'redis:',
+          '  replica:',
+          '    tolerations:',
+          '      - key: "solo.hashgraph.io/owner"',
+          '        operator: "Equal"',
+          '        value: "adhoc-performance-test"',
+          '        effect: "NoSchedule"',
+          '',
+        ].join('\n'),
+      );
+
+      manager.setSchedulingChartValues(new HelmChartValues().file(valuesFilePath));
+
+      await manager.installChart(namespace, '', chartVersion, context);
+
+      const valueArguments: string[] = chartValueArguments();
+
+      expect(valueArguments).to.include(String.raw`postgresql.primary.nodeSelector.solo\.hashgraph\.io/role=database`);
+      expect(valueArguments).to.include('postgresql.primary.tolerations[0].value=adhoc-single-day-test');
+      expect(valueArguments).to.include('redis.replica.tolerations[0].value=adhoc-performance-test');
     });
 
     it('installs chart with the correct release name and chart name', async (): Promise<void> => {


### PR DESCRIPTION
## Summary

- Propagates mirror-node scheduling values into the `solo-shared-resources` Helm install before Postgres and Redis are created.
- Maps shared and mirror-node value-file `nodeSelector` and `tolerations` settings to the Postgres primary and Redis master/replica chart paths.
- Adds unit coverage for tainted-cluster toleration propagation.

Fixes #4625

## Root Cause

Mirror-node installs the `solo-shared-resources` chart before installing mirror-node itself. That release only received Solo-generated enablement values, so Postgres and Redis did not inherit scheduling values from the mirror-node values file. On tainted performance clusters, the pods had no matching `solo.hashgraph.io/owner` tolerations and remained unschedulable.

## Validation

- `MOCHA_SUITE_NAME="SharedResourceManager" npx mocha 'test/unit/core/shared-resources/shared-resource-manager.test.ts'`
- `npx tsc --noEmit --pretty false`
- `npx eslint src/core/shared-resources/shared-resource-manager.ts src/commands/mirror-node.ts test/unit/core/shared-resources/shared-resource-manager.test.ts`
- `task build`
- `task format`
- `task check`

Notes: the repo-wide lint tasks completed with warnings already present across the repository; no errors were reported.
