### PR TITLE
fix: guard solo-command-output/cli-help downloads behind attach-docs-enabled

### DIFF
--- a/.github/workflows/flow-deploy-release-artifact.yaml
+++ b/.github/workflows/flow-deploy-release-artifact.yaml
@@ -679,6 +679,7 @@ jobs:
     needs:
       - prepare-release
       - hugo-docs-build-main
+      - docs-automation
     uses: ./.github/workflows/zxc-hugo-publish.yaml
     with:
       docs-build-label: 'v${{ needs.prepare-release.outputs.version }}'

--- a/.github/workflows/flow-hugo-publish.yaml
+++ b/.github/workflows/flow-hugo-publish.yaml
@@ -134,6 +134,16 @@ jobs:
 
   # ------- Hugo Build and Publish for Version Tag and Main Branch -------
 
+  # Generate CLI help and command output docs artifacts for versioned releases
+  docs-automation:
+    name: Docs Automation
+    if: ${{ needs.setup.outputs.versioned-release == 'true' && !cancelled() && !failure() }}
+    uses: ./.github/workflows/zxc-docs-automation.yaml
+    needs:
+      - setup
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}
+
   # Do a Hugo build for the docs site for a version tag
   hugo-docs-build:
     name: Hugo Docs Build
@@ -170,6 +180,7 @@ jobs:
     needs:
       - setup
       - hugo-docs-build-main
+      - docs-automation
     with:
       docs-build-label: ${{ needs.setup.outputs.docs-build-label }}
       attach-docs-enabled: true

--- a/.github/workflows/zxc-hugo-publish.yaml
+++ b/.github/workflows/zxc-hugo-publish.yaml
@@ -82,12 +82,14 @@ jobs:
           path: docs/site
 
       - name: Download Solo Command Output Artifacts
+        if: ${{ inputs.attach-docs-enabled }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: solo-command-output
           path: docs/site/build
 
       - name: Download Solo CLI Help Artifacts
+        if: ${{ inputs.attach-docs-enabled }}
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: solo-cli-help


### PR DESCRIPTION
## Description

This pull request changes the following:

* Guards the `Download Solo Command Output Artifacts` and `Download Solo CLI Help Artifacts` steps in `zxc-hugo-publish.yaml` with `if: ${{ inputs.attach-docs-enabled }}`. These artifacts are only needed when attaching files to a release — skipping them on routine GitHub Pages publishes stops the recurring workflow failure.
* Adds a `docs-automation` job to `flow-hugo-publish.yaml` (versioned-release path) and wires it into `hugo-docs-publish`'s `needs` so the CLI-help and command-output artifacts are ready before the release-attach publish step runs.
* Fixes a race condition in `flow-deploy-release-artifact.yaml` where `hugo-docs-publish` had no dependency on `docs-automation`, allowing it to start before the artifacts were available.

### Related Issues

* Closes #4606

### Root Cause

`zxc-hugo-publish.yaml` unconditionally downloaded `solo-command-output` and `solo-cli-help` artifacts on every invocation. Those artifacts are only produced by `zxc-docs-automation.yaml`, which was never called during push-to-main runs of `flow-hugo-publish.yaml`. Result: every push to `main` failed with `Artifact not found for name: solo-command-output`, blocking GitHub Pages deploys.

### Pull request (PR) checklist

* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description

### Testing

* [ ] These changes required manual testing that is documented below

The following manual testing was done:

* Verified the last 5 push-to-main runs of `flow-hugo-publish.yaml` all failed with `Artifact not found for name: solo-command-output` in the `Hugo Docs Publish - Main Only / Deploy` job.
* The fix gates those download steps on `attach-docs-enabled`, which is `false` (default) for push-to-main runs, so they will be skipped and the Pages deploy will proceed.

The following was not tested:

* End-to-end versioned release flow (requires a real release trigger); the logic mirrors the existing pattern in `flow-deploy-release-artifact.yaml`.