### PR TITLE
feat(one-shot): add idempotency guards for consensus deploy/setup/start and block, mirror, explorer, relay add steps

### DIFF
--- a/src/business/runtime-state/config/remote/remote-config-runtime-state.ts
+++ b/src/business/runtime-state/config/remote/remote-config-runtime-state.ts
@@ -31,7 +31,7 @@ import {
 import {NamespaceName} from '../../../../types/namespace/namespace-name.js';
 import {ComponentStateMetadataSchema} from '../../../../data/schema/model/remote/state/component-state-metadata-schema.js';
 import {Templates} from '../../../../core/templates.js';
-import {DeploymentPhase} from '../../../../data/schema/model/remote/deployment-phase.js';
+import {DeploymentPhase, DEPLOYMENT_PHASE_ORDER} from '../../../../data/schema/model/remote/deployment-phase.js';
 import {getSoloVersion} from '../../../../../version.js';
 import * as constants from '../../../../core/constants.js';
 import {Flags as flags} from '../../../../commands/flags.js';
@@ -745,15 +745,6 @@ export class RemoteConfigRuntimeState implements RemoteConfigRuntimeStateApi {
     ComponentTypes.RelayNodes,
   ];
 
-  private static readonly PHASE_ORDER: Readonly<Record<DeploymentPhase, number>> = {
-    [DeploymentPhase.REQUESTED]: 0,
-    [DeploymentPhase.DEPLOYED]: 1,
-    [DeploymentPhase.CONFIGURED]: 2,
-    [DeploymentPhase.STARTED]: 3,
-    [DeploymentPhase.STOPPED]: 4,
-    [DeploymentPhase.FROZEN]: 5,
-  };
-
   public getComponentPhasesMap(): Map<ComponentTypes, DeploymentPhase> {
     if (!this.isLoaded()) {
       return new Map();
@@ -773,7 +764,7 @@ export class RemoteConfigRuntimeState implements RemoteConfigRuntimeStateApi {
       }
       let minimumPhase: DeploymentPhase = phases[0];
       for (const phase of phases) {
-        if (RemoteConfigRuntimeState.PHASE_ORDER[phase] < RemoteConfigRuntimeState.PHASE_ORDER[minimumPhase]) {
+        if (DEPLOYMENT_PHASE_ORDER[phase] < DEPLOYMENT_PHASE_ORDER[minimumPhase]) {
           minimumPhase = phase;
         }
       }

--- a/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
+++ b/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
@@ -76,7 +76,7 @@ import {BlockNodeStateSchema} from '../../../../data/schema/model/remote/state/b
 import {MirrorNodeStateSchema} from '../../../../data/schema/model/remote/state/mirror-node-state-schema.js';
 import {ExplorerStateSchema} from '../../../../data/schema/model/remote/state/explorer-state-schema.js';
 import {RelayNodeStateSchema} from '../../../../data/schema/model/remote/state/relay-node-state-schema.js';
-import {DeploymentPhase} from '../../../../data/schema/model/remote/deployment-phase.js';
+import {DeploymentPhase, isDeploymentPhaseAtLeast} from '../../../../data/schema/model/remote/deployment-phase.js';
 import {ComponentTypes} from '../../../../core/config/remote/enumerations/component-types.js';
 import {ConfigMap} from '../../../../integration/kube/resources/config-map/config-map.js';
 import chalk from 'chalk';
@@ -129,6 +129,8 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
   ): OrchestratorPipeline<OneShotSingleDeployContext> {
     let config: OneShotSingleDeployConfigClass;
     const getConfigGlobal: () => OneShotSingleDeployConfigClass = (): OneShotSingleDeployConfigClass => config;
+
+    let deploymentStateSnapshot: DeploymentStateSnapshot | undefined;
 
     const phases: Array<OrchestratorPipelinePhase<OneShotSingleDeployConfigClass, OneShotSingleDeployContext>> = [
       new OrchestratorPipelinePhase('Initialize', {
@@ -328,6 +330,7 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
           exitOnError: false,
           task: async (context_: OneShotSingleDeployContext): Promise<void> => {
             context_.deploymentStateSnapshot = await this.buildDeploymentStateSnapshot(getConfig());
+            deploymentStateSnapshot = context_.deploymentStateSnapshot;
           },
         }),
       }),
@@ -538,7 +541,13 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
                 BlockCommandDefinition.ADD_COMMAND,
                 (): string[] => DeployArgvBuilders.buildBlockNodeArgv(getConfig()),
                 this.taskList,
-                (): boolean => constants.ONE_SHOT_WITH_BLOCK_NODE.toLowerCase() !== 'true',
+                (): boolean =>
+                  constants.ONE_SHOT_WITH_BLOCK_NODE.toLowerCase() !== 'true' ||
+                  this.isComponentInPhaseAtLeast(
+                    deploymentStateSnapshot,
+                    ComponentTypes.BlockNode,
+                    DeploymentPhase.DEPLOYED,
+                  ),
               ),
           }),
           OrchestratorPipelinePhase.composite('Deploy network node', [
@@ -551,6 +560,8 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
                   ConsensusCommandDefinition.DEPLOY_COMMAND,
                   (): string[] => DeployArgvBuilders.buildConsensusDeployArgv(getConfig()),
                   this.taskList,
+                  // Idempotency guard: skip if the consensus node is already deployed or the network Helm release exists.
+                  (): boolean => this.isConsensusDeployStepComplete(deploymentStateSnapshot),
                 ),
             }),
             OrchestratorPipelinePhase.composite('Setup and start consensus node', [
@@ -563,6 +574,13 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
                     ConsensusCommandDefinition.SETUP_COMMAND,
                     (): string[] => DeployArgvBuilders.buildConsensusSetupArgv(getConfig()),
                     this.taskList,
+                    // Idempotency guard: skip if the consensus node is already configured (setup already ran).
+                    (): boolean =>
+                      this.isComponentInPhaseAtLeast(
+                        deploymentStateSnapshot,
+                        ComponentTypes.ConsensusNode,
+                        DeploymentPhase.CONFIGURED,
+                      ),
                   ),
               }),
               new OrchestratorPipelinePhase('Start consensus node', {
@@ -574,6 +592,13 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
                     ConsensusCommandDefinition.START_COMMAND,
                     (): string[] => DeployArgvBuilders.buildConsensusStartArgv(getConfig()),
                     this.taskList,
+                    // Idempotency guard: skip if the consensus node is already started.
+                    (): boolean =>
+                      this.isComponentInPhaseAtLeast(
+                        deploymentStateSnapshot,
+                        ComponentTypes.ConsensusNode,
+                        DeploymentPhase.STARTED,
+                      ),
                   ),
               }),
               new OrchestratorPipelinePhase('Create accounts', {
@@ -590,7 +615,14 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
                 MirrorCommandDefinition.ADD_COMMAND,
                 (): string[] => DeployArgvBuilders.buildMirrorNodeArgv(getConfig()),
                 this.taskList,
-                (): boolean => !getConfig().deployMirrorNode,
+                // Feature-flag short-circuit takes precedence; otherwise skip if already deployed (idempotency guard).
+                (): boolean =>
+                  !getConfig().deployMirrorNode ||
+                  this.isComponentInPhaseAtLeast(
+                    deploymentStateSnapshot,
+                    ComponentTypes.MirrorNode,
+                    DeploymentPhase.DEPLOYED,
+                  ),
               ),
           }),
           new OrchestratorPipelinePhase('Deploy explorer', {
@@ -600,7 +632,14 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
                 ExplorerCommandDefinition.ADD_COMMAND,
                 (): string[] => DeployArgvBuilders.buildExplorerArgv(getConfig()),
                 this.taskList,
-                (): boolean => !getConfig().deployExplorer && !getConfig().minimalSetup,
+                // Feature-flag short-circuit takes precedence; otherwise skip if already deployed (idempotency guard).
+                (): boolean =>
+                  (!getConfig().deployExplorer && !getConfig().minimalSetup) ||
+                  this.isComponentInPhaseAtLeast(
+                    deploymentStateSnapshot,
+                    ComponentTypes.Explorer,
+                    DeploymentPhase.DEPLOYED,
+                  ),
               ),
           }).withWaitCondition(SoloEventType.MirrorNodeDeployed, Duration.ofMinutes(10)),
           new OrchestratorPipelinePhase('Deploy JSON-RPC Relay', {
@@ -610,7 +649,14 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
                 RelayCommandDefinition.ADD_COMMAND,
                 (): string[] => DeployArgvBuilders.buildRelayArgv(getConfig()),
                 this.taskList,
-                (): boolean => !getConfig().deployRelay && !getConfig().minimalSetup,
+                // Feature-flag short-circuit takes precedence; otherwise skip if already deployed (idempotency guard).
+                (): boolean =>
+                  (!getConfig().deployRelay && !getConfig().minimalSetup) ||
+                  this.isComponentInPhaseAtLeast(
+                    deploymentStateSnapshot,
+                    ComponentTypes.RelayNodes,
+                    DeploymentPhase.DEPLOYED,
+                  ),
               ),
           })
             .withWaitCondition(SoloEventType.MirrorNodeDeployed, Duration.ofMinutes(10))
@@ -755,6 +801,38 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
 
   private getOneShotOutputDirectory(deploymentName: string): string {
     return PathEx.join(constants.SOLO_HOME_DIR, `one-shot-${deploymentName}`);
+  }
+
+  /**
+   * Idempotency guard shared by the optional-component `add` steps and the consensus-node steps.
+   * Returns true when the component's recorded phase is at or beyond {@link minimumPhase},
+   * indicating the corresponding step already completed in a prior run and should be skipped on
+   * re-run. Returns false when the snapshot is unavailable or the component has no recorded phase
+   * (treat as not yet at that phase).
+   */
+  private isComponentInPhaseAtLeast(
+    snapshot: DeploymentStateSnapshot | undefined,
+    componentType: ComponentTypes,
+    minimumPhase: DeploymentPhase,
+  ): boolean {
+    const phase: DeploymentPhase | undefined = snapshot?.remoteConfig.componentPhases.get(componentType);
+    if (phase === undefined) {
+      return false;
+    }
+    return isDeploymentPhaseAtLeast(phase, minimumPhase);
+  }
+
+  /**
+   * Idempotency guard for the `consensus deploy` step. Returns true when the consensus node is
+   * already at or beyond {@link DeploymentPhase.DEPLOYED}, or when the network Helm release
+   * ({@link constants.SOLO_DEPLOYMENT_CHART}) is already installed — either signal means the
+   * deploy step ran in a prior attempt and should be skipped on re-run.
+   */
+  private isConsensusDeployStepComplete(snapshot: DeploymentStateSnapshot | undefined): boolean {
+    if (this.isComponentInPhaseAtLeast(snapshot, ComponentTypes.ConsensusNode, DeploymentPhase.DEPLOYED)) {
+      return true;
+    }
+    return snapshot?.helm.installedReleases.has(constants.SOLO_DEPLOYMENT_CHART) ?? false;
   }
 
   private async buildDeploymentStateSnapshot(

--- a/src/data/schema/model/remote/deployment-phase.ts
+++ b/src/data/schema/model/remote/deployment-phase.ts
@@ -40,3 +40,25 @@ export enum DeploymentPhase {
    */
   FROZEN = 'frozen',
 }
+
+/**
+ * Ordinal ranking of {@link DeploymentPhase} values, ordered by deployment progression.
+ * Use this (via {@link isDeploymentPhaseAtLeast}) for any "phase >= X" comparison so the
+ * ordering lives in exactly one place.
+ */
+export const DEPLOYMENT_PHASE_ORDER: Readonly<Record<DeploymentPhase, number>> = {
+  [DeploymentPhase.REQUESTED]: 0,
+  [DeploymentPhase.DEPLOYED]: 1,
+  [DeploymentPhase.CONFIGURED]: 2,
+  [DeploymentPhase.STARTED]: 3,
+  [DeploymentPhase.STOPPED]: 4,
+  [DeploymentPhase.FROZEN]: 5,
+};
+
+/**
+ * Returns true when {@link phase} is at or beyond {@link minimumPhase} in the deployment
+ * progression defined by {@link DEPLOYMENT_PHASE_ORDER}.
+ */
+export function isDeploymentPhaseAtLeast(phase: DeploymentPhase, minimumPhase: DeploymentPhase): boolean {
+  return DEPLOYMENT_PHASE_ORDER[phase] >= DEPLOYMENT_PHASE_ORDER[minimumPhase];
+}

--- a/test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts
+++ b/test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts
@@ -8,6 +8,9 @@ import {NamespaceName} from '../../../../../../src/types/namespace/namespace-nam
 import {SoloError} from '../../../../../../src/core/errors/solo-error.js';
 import {type OneShotSingleDeployConfigClass} from '../../../../../../src/commands/one-shot/one-shot-single-deploy-config-class.js';
 import {type DeploymentStateSnapshot} from '../../../../../../src/commands/one-shot/deployment-state-snapshot.js';
+import {ComponentTypes} from '../../../../../../src/core/config/remote/enumerations/component-types.js';
+import {DeploymentPhase} from '../../../../../../src/data/schema/model/remote/deployment-phase.js';
+import * as constants from '../../../../../../src/core/constants.js';
 
 type MockType = any;
 type MockListr = MockType;
@@ -348,5 +351,178 @@ describe('DefaultOneShotDeployOrchestrator buildDeploymentStateSnapshot', (): vo
 
     expect(snapshot.helm.installedReleases.has('solo-deployment')).to.be.true;
     expect(snapshot.helm.installedReleases.has('solo-cluster-setup')).to.be.true;
+  });
+});
+
+function makeSnapshot(
+  componentPhases: Map<ComponentTypes, DeploymentPhase>,
+  installedReleases: Set<string> = new Set<string>(),
+): DeploymentStateSnapshot {
+  return {
+    localConfig: {deploymentExists: false, clusterRefs: new Set<string>()},
+    remoteConfig: {configMapExists: true, componentPhases},
+    helm: {installedReleases},
+    keys: {consensusKeysOnDisk: false},
+    accounts: {accountsFileExists: false},
+  };
+}
+
+describe('DefaultOneShotDeployOrchestrator isComponentInPhaseAtLeast', (): void => {
+  it('returns false when the snapshot is undefined', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeOrchestrator();
+
+    // @ts-expect-error - to access private method
+    expect(orchestrator.isComponentInPhaseAtLeast(undefined, ComponentTypes.MirrorNode, DeploymentPhase.DEPLOYED)).to.be
+      .false;
+  });
+
+  it('returns false when the component has no recorded phase', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeOrchestrator();
+    const snapshot: DeploymentStateSnapshot = makeSnapshot(new Map());
+
+    // @ts-expect-error - to access private method
+    expect(orchestrator.isComponentInPhaseAtLeast(snapshot, ComponentTypes.MirrorNode, DeploymentPhase.DEPLOYED)).to.be
+      .false;
+  });
+
+  it('returns false when the component is only REQUESTED (below DEPLOYED)', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeOrchestrator();
+    const snapshot: DeploymentStateSnapshot = makeSnapshot(
+      new Map([[ComponentTypes.MirrorNode, DeploymentPhase.REQUESTED]]),
+    );
+
+    // @ts-expect-error - to access private method
+    expect(orchestrator.isComponentInPhaseAtLeast(snapshot, ComponentTypes.MirrorNode, DeploymentPhase.DEPLOYED)).to.be
+      .false;
+  });
+
+  it('returns true when the component is exactly at the minimum phase', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeOrchestrator();
+    const snapshot: DeploymentStateSnapshot = makeSnapshot(
+      new Map([[ComponentTypes.BlockNode, DeploymentPhase.DEPLOYED]]),
+    );
+
+    // @ts-expect-error - to access private method
+    expect(orchestrator.isComponentInPhaseAtLeast(snapshot, ComponentTypes.BlockNode, DeploymentPhase.DEPLOYED)).to.be
+      .true;
+  });
+
+  it('returns true when the component is beyond the minimum phase (e.g. STARTED >= DEPLOYED)', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeOrchestrator();
+    const snapshot: DeploymentStateSnapshot = makeSnapshot(
+      new Map([[ComponentTypes.RelayNodes, DeploymentPhase.STARTED]]),
+    );
+
+    // @ts-expect-error - to access private method
+    expect(orchestrator.isComponentInPhaseAtLeast(snapshot, ComponentTypes.RelayNodes, DeploymentPhase.DEPLOYED)).to.be
+      .true;
+  });
+
+  it('honours the requested minimum phase (CONFIGURED for consensus setup)', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeOrchestrator();
+    const deployedOnly: DeploymentStateSnapshot = makeSnapshot(
+      new Map([[ComponentTypes.ConsensusNode, DeploymentPhase.DEPLOYED]]),
+    );
+    const configured: DeploymentStateSnapshot = makeSnapshot(
+      new Map([[ComponentTypes.ConsensusNode, DeploymentPhase.CONFIGURED]]),
+    );
+
+    // DEPLOYED is below CONFIGURED, so the consensus setup step must NOT be skipped.
+    // @ts-expect-error - to access private method
+    const deployedSkipsSetup: boolean = orchestrator.isComponentInPhaseAtLeast(
+      deployedOnly,
+      ComponentTypes.ConsensusNode,
+      DeploymentPhase.CONFIGURED,
+    );
+    // @ts-expect-error - to access private method
+    const configuredSkipsSetup: boolean = orchestrator.isComponentInPhaseAtLeast(
+      configured,
+      ComponentTypes.ConsensusNode,
+      DeploymentPhase.CONFIGURED,
+    );
+    expect(deployedSkipsSetup).to.be.false;
+    expect(configuredSkipsSetup).to.be.true;
+  });
+
+  it('honours the requested minimum phase (STARTED for consensus start)', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeOrchestrator();
+    const configured: DeploymentStateSnapshot = makeSnapshot(
+      new Map([[ComponentTypes.ConsensusNode, DeploymentPhase.CONFIGURED]]),
+    );
+    const started: DeploymentStateSnapshot = makeSnapshot(
+      new Map([[ComponentTypes.ConsensusNode, DeploymentPhase.STARTED]]),
+    );
+
+    // CONFIGURED is below STARTED, so the consensus start step must NOT be skipped.
+    // @ts-expect-error - to access private method
+    const configuredSkipsStart: boolean = orchestrator.isComponentInPhaseAtLeast(
+      configured,
+      ComponentTypes.ConsensusNode,
+      DeploymentPhase.STARTED,
+    );
+    // @ts-expect-error - to access private method
+    const startedSkipsStart: boolean = orchestrator.isComponentInPhaseAtLeast(
+      started,
+      ComponentTypes.ConsensusNode,
+      DeploymentPhase.STARTED,
+    );
+    expect(configuredSkipsStart).to.be.false;
+    expect(startedSkipsStart).to.be.true;
+  });
+
+  it('evaluates each component independently', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeOrchestrator();
+    const snapshot: DeploymentStateSnapshot = makeSnapshot(
+      new Map([
+        [ComponentTypes.MirrorNode, DeploymentPhase.DEPLOYED],
+        [ComponentTypes.Explorer, DeploymentPhase.REQUESTED],
+      ]),
+    );
+
+    // @ts-expect-error - to access private method
+    expect(orchestrator.isComponentInPhaseAtLeast(snapshot, ComponentTypes.MirrorNode, DeploymentPhase.DEPLOYED)).to.be
+      .true;
+    // @ts-expect-error - to access private method
+    expect(orchestrator.isComponentInPhaseAtLeast(snapshot, ComponentTypes.Explorer, DeploymentPhase.DEPLOYED)).to.be
+      .false;
+  });
+});
+
+describe('DefaultOneShotDeployOrchestrator isConsensusDeployStepComplete', (): void => {
+  it('returns false when the snapshot is undefined', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeOrchestrator();
+    const noSnapshot: DeploymentStateSnapshot | undefined = undefined;
+
+    // @ts-expect-error - to access private method
+    expect(orchestrator.isConsensusDeployStepComplete(noSnapshot)).to.be.false;
+  });
+
+  it('returns false on a fresh deploy (no phase, no Helm release)', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeOrchestrator();
+    const snapshot: DeploymentStateSnapshot = makeSnapshot(new Map());
+
+    // @ts-expect-error - to access private method
+    expect(orchestrator.isConsensusDeployStepComplete(snapshot)).to.be.false;
+  });
+
+  it('returns true when the consensus node phase is at or beyond DEPLOYED', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeOrchestrator();
+    const snapshot: DeploymentStateSnapshot = makeSnapshot(
+      new Map([[ComponentTypes.ConsensusNode, DeploymentPhase.DEPLOYED]]),
+    );
+
+    // @ts-expect-error - to access private method
+    expect(orchestrator.isConsensusDeployStepComplete(snapshot)).to.be.true;
+  });
+
+  it('returns true when the network Helm release already exists (phase not yet recorded)', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeOrchestrator();
+    const snapshot: DeploymentStateSnapshot = makeSnapshot(
+      new Map([[ComponentTypes.ConsensusNode, DeploymentPhase.REQUESTED]]),
+      new Set<string>([constants.SOLO_DEPLOYMENT_CHART]),
+    );
+
+    // @ts-expect-error - to access private method
+    expect(orchestrator.isConsensusDeployStepComplete(snapshot)).to.be.true;
   });
 });

--- a/test/unit/data/schema/model/remote/deployment-phase.test.ts
+++ b/test/unit/data/schema/model/remote/deployment-phase.test.ts
@@ -1,0 +1,40 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {describe, it} from 'mocha';
+import {expect} from 'chai';
+import {
+  DeploymentPhase,
+  DEPLOYMENT_PHASE_ORDER,
+  isDeploymentPhaseAtLeast,
+} from '../../../../../../src/data/schema/model/remote/deployment-phase.js';
+
+describe('deployment-phase', (): void => {
+  describe('DEPLOYMENT_PHASE_ORDER', (): void => {
+    it('ranks every DeploymentPhase value', (): void => {
+      for (const phase of Object.values(DeploymentPhase)) {
+        expect(DEPLOYMENT_PHASE_ORDER[phase]).to.be.a('number');
+      }
+    });
+
+    it('orders REQUESTED below DEPLOYED', (): void => {
+      expect(DEPLOYMENT_PHASE_ORDER[DeploymentPhase.REQUESTED]).to.be.lessThan(
+        DEPLOYMENT_PHASE_ORDER[DeploymentPhase.DEPLOYED],
+      );
+    });
+  });
+
+  describe('isDeploymentPhaseAtLeast', (): void => {
+    it('returns false when the phase is below the minimum', (): void => {
+      expect(isDeploymentPhaseAtLeast(DeploymentPhase.REQUESTED, DeploymentPhase.DEPLOYED)).to.be.false;
+    });
+
+    it('returns true when the phase equals the minimum', (): void => {
+      expect(isDeploymentPhaseAtLeast(DeploymentPhase.DEPLOYED, DeploymentPhase.DEPLOYED)).to.be.true;
+    });
+
+    it('returns true when the phase is beyond the minimum', (): void => {
+      expect(isDeploymentPhaseAtLeast(DeploymentPhase.STARTED, DeploymentPhase.DEPLOYED)).to.be.true;
+      expect(isDeploymentPhaseAtLeast(DeploymentPhase.FROZEN, DeploymentPhase.DEPLOYED)).to.be.true;
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds re-run protection to the one-shot deploy flow.

Consensus-node steps (closes #4562):
- consensus deploy — skips if the consensus node is already deployed, or the network Helm release already exists
- consensus setup — skips if the consensus node is already configured
- consensus start — skips if the consensus node is already started

Optional component steps (closes #4563):
- block / mirror / explorer / relay add — each skips if that component is already deployed

Existing feature-flag skips are preserved and take precedence over the new phase guards.

### Related Issues

* Closes # https://github.com/hiero-ledger/solo/issues/4562
* Closes # https://github.com/hiero-ledger/solo/issues/4563
