### PR TITLE
feat(one-shot): add idempotency guard for account creation via accounts.json

### DIFF
--- a/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
+++ b/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
@@ -653,7 +653,11 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
   private buildCreateAccountsTask(config: OneShotSingleDeployConfigClass): SoloListrTask<OneShotSingleDeployContext> {
     return {
       title: 'Create Accounts',
-      skip: (): boolean => config.predefinedAccounts === false,
+      // Skip when predefined accounts are disabled, or (idempotency guard) when accounts.json
+      // already exists from a prior successful run. The file is written only on full success of
+      // this step (in the Finish phase), so its presence is an all-or-nothing completion signal.
+      skip: (context_: OneShotSingleDeployContext): boolean =>
+        config.predefinedAccounts === false || context_.deploymentStateSnapshot?.accounts.accountsFileExists === true,
       task: async (
         _: OneShotSingleDeployContext,
         task: SoloListrTaskWrapper<OneShotSingleDeployContext>,

--- a/test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts
+++ b/test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts
@@ -350,3 +350,43 @@ describe('DefaultOneShotDeployOrchestrator buildDeploymentStateSnapshot', (): vo
     expect(snapshot.helm.installedReleases.has('solo-cluster-setup')).to.be.true;
   });
 });
+
+function makeAccountsSnapshot(accountsFileExists: boolean): DeploymentStateSnapshot {
+  return {
+    localConfig: {deploymentExists: false, clusterRefs: new Set<string>()},
+    remoteConfig: {configMapExists: false, componentPhases: new Map()},
+    helm: {installedReleases: new Set<string>()},
+    keys: {consensusKeysOnDisk: false},
+    accounts: {accountsFileExists},
+  };
+}
+
+function createAccountsSkip(
+  config: OneShotSingleDeployConfigClass,
+  snapshot: DeploymentStateSnapshot | undefined,
+): boolean {
+  const orchestrator: DefaultOneShotDeployOrchestrator = makeOrchestrator();
+  // @ts-expect-error - to access private method
+  const task: {skip: (context_: MockType) => boolean} = orchestrator.buildCreateAccountsTask(config);
+  return task.skip({deploymentStateSnapshot: snapshot} as MockType);
+}
+
+describe('DefaultOneShotDeployOrchestrator Create Accounts skip guard', (): void => {
+  it('skips when predefined accounts are disabled, regardless of accounts.json', (): void => {
+    expect(createAccountsSkip(makeConfig({predefinedAccounts: false}), makeAccountsSnapshot(false))).to.be.true;
+    expect(createAccountsSkip(makeConfig({predefinedAccounts: false}), makeAccountsSnapshot(true))).to.be.true;
+  });
+
+  it('skips when accounts.json already exists from a prior successful run', (): void => {
+    expect(createAccountsSkip(makeConfig({predefinedAccounts: true}), makeAccountsSnapshot(true))).to.be.true;
+  });
+
+  it('runs when accounts.json is absent', (): void => {
+    expect(createAccountsSkip(makeConfig({predefinedAccounts: true}), makeAccountsSnapshot(false))).to.be.false;
+  });
+
+  it('runs when the snapshot is unavailable', (): void => {
+    const noSnapshot: DeploymentStateSnapshot | undefined = undefined;
+    expect(createAccountsSkip(makeConfig({predefinedAccounts: true}), noSnapshot)).to.be.false;
+  });
+});


### PR DESCRIPTION
## Description

Add an all-or-nothing guard on the account-creation step using the accounts.json file the step already writes on success. Faster and more reliable than a ledger round-trip; matches Phase 1's local-only snapshot model.

### Related Issues

* Closes # https://github.com/hiero-ledger/solo/issues/4564

