### PR TITLE
feat: add idempotency guards for cluster-ref and key commands

### DIFF
--- a/.github/workflows/flow-migration-test.yaml
+++ b/.github/workflows/flow-migration-test.yaml
@@ -43,6 +43,7 @@ on:
       - opened
       - reopened
       - synchronize
+      - ready_for_review
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true

--- a/src/commands/cache.ts
+++ b/src/commands/cache.ts
@@ -484,7 +484,10 @@ export class CacheCommand extends BaseCommand {
     return {
       title: 'Pull and cache container images',
       task: async ({config: {imageCacheHandler}}, task): Promise<SoloListr<AnyListrContext>> => {
-        return task.newListr(await imageCacheHandler.pull(), constants.LISTR_DEFAULT_OPTIONS.WITH_CONCURRENCY);
+        return task.newListr(
+          await imageCacheHandler.pull(),
+          constants.LISTR_DEFAULT_OPTIONS.WITH_CONCURRENCY_COLLAPSABLE,
+        );
       },
     };
   }
@@ -500,7 +503,7 @@ export class CacheCommand extends BaseCommand {
         );
         subTasks.push(...newTasks);
 
-        return task.newListr(subTasks, constants.LISTR_DEFAULT_OPTIONS.WITH_CONCURRENCY);
+        return task.newListr(subTasks, constants.LISTR_DEFAULT_OPTIONS.WITH_CONCURRENCY_COLLAPSABLE);
       },
     };
   }

--- a/src/commands/cluster/tasks.ts
+++ b/src/commands/cluster/tasks.ts
@@ -346,38 +346,44 @@ export class ClusterCommandTasks {
       task: async (context_: ClusterReferenceSetupContext): Promise<void> => {
         const k8: K8 = this.k8Factory.getK8(context_.config.context);
 
+        // Check if ClusterRole already exists using Kubernetes JavaScript API
+        let podMonitorRoleExists: boolean = false;
         try {
-          // Check if ClusterRole already exists using Kubernetes JavaScript API
-          await k8.rbac().clusterRoleExists(constants.POD_MONITOR_ROLE);
+          podMonitorRoleExists = await k8.rbac().clusterRoleExists(constants.POD_MONITOR_ROLE);
+        } catch (error) {
+          throw new SoloErrors.system.clusterRoleCheckFailed(constants.POD_MONITOR_ROLE, error as Error);
+        }
+        if (podMonitorRoleExists) {
           this.logger.showUser(
             `⏭️  ClusterRole pod-monitor-role already exists in context ${context_.config.context}, skipping`,
           );
-        } catch {
-          // ClusterRole doesn't exist, create it
-          try {
-            await k8.rbac().createClusterRole(
-              constants.POD_MONITOR_ROLE,
-              [
-                {
-                  apiGroups: [''],
-                  resources: ['pods', 'services', 'clusterroles', 'pods/log', 'secrets'],
-                  verbs: ['get', 'list'],
-                },
-                {
-                  apiGroups: [''],
-                  resources: ['pods/exec'],
-                  verbs: ['create'],
-                },
-              ],
-              {'solo.hedera.com/type': 'cluster-role'},
-            );
-            this.logger.showUser(
-              `✅ ClusterRole pod-monitor-role installed successfully in context ${context_.config.context}`,
-            );
-          } catch (installError) {
-            this.logger.debug('Error installing pod-monitor-role ClusterRole', installError);
-            throw new SoloErrors.deployment.clusterRoleInstallFailed(installError);
-          }
+          return;
+        }
+
+        // ClusterRole doesn't exist, create it
+        try {
+          await k8.rbac().createClusterRole(
+            constants.POD_MONITOR_ROLE,
+            [
+              {
+                apiGroups: [''],
+                resources: ['pods', 'services', 'clusterroles', 'pods/log', 'secrets'],
+                verbs: ['get', 'list'],
+              },
+              {
+                apiGroups: [''],
+                resources: ['pods/exec'],
+                verbs: ['create'],
+              },
+            ],
+            {'solo.hedera.com/type': 'cluster-role'},
+          );
+          this.logger.showUser(
+            `✅ ClusterRole pod-monitor-role installed successfully in context ${context_.config.context}`,
+          );
+        } catch (installError) {
+          this.logger.debug('Error installing pod-monitor-role ClusterRole', installError);
+          throw new SoloErrors.deployment.clusterRoleInstallFailed(installError);
         }
       },
     };

--- a/src/commands/cluster/tasks.ts
+++ b/src/commands/cluster/tasks.ts
@@ -174,7 +174,7 @@ export class ClusterCommandTasks {
   public getClusterInfo(): SoloListrTask<AnyListrContext> {
     return {
       title: 'Get cluster info',
-      task: async (context_, task) => {
+      task: async (context_, task): Promise<void> => {
         const clusterReference: string = context_.config.clusterRef;
         const clusterReferences: FacadeMap<string, StringFacade, string> = this.localConfig.configuration.clusterRefs;
         const deployments: MutableFacadeArray<Deployment, DeploymentSchema> =

--- a/src/commands/command-helpers.ts
+++ b/src/commands/command-helpers.ts
@@ -75,6 +75,15 @@ export function argvPushGlobalFlags(argv: string[], cacheDirectory: string = '')
   return argv;
 }
 
+export type InvokedSoloCommand = {
+  title: string;
+  skip: () => boolean;
+  task: (
+    _context: ListrContext,
+    taskListWrapper: TaskListWrapper,
+  ) => Promise<Listr<ListrContext, ListrRendererValue, ListrRendererValue>>;
+};
+
 /**
  * Helper function to invoke a Solo command with proper task integration
  * @param title - Task title to display
@@ -90,14 +99,7 @@ export function invokeSoloCommand(
   callback: () => Promise<string[]> | string[],
   taskList: TaskList<ListrContext, ListrRendererValue, ListrRendererValue>,
   skipCallback?: () => boolean,
-): {
-  title: string;
-  skip: () => boolean;
-  task: (
-    _context: ListrContext,
-    taskListWrapper: TaskListWrapper,
-  ) => Promise<Listr<ListrContext, ListrRendererValue, ListrRendererValue>>;
-} {
+): InvokedSoloCommand {
   return {
     title,
     skip: skipCallback || ((): boolean => false),

--- a/src/commands/command-helpers.ts
+++ b/src/commands/command-helpers.ts
@@ -34,7 +34,7 @@ export function negatedOptionFromFlag(flag: CommandFlag): string {
 /**
  * Helper function to format a command path as a full CLI invocation string
  * @param commandPath - The command path (e.g., 'one-shot falcon deploy')
- * @param args - Optional additional arguments (flags, values, placeholders)
+ * @param arguments_ - Optional additional arguments (flags, values, placeholders)
  * @returns Full CLI string (e.g., 'solo one-shot falcon deploy --values-file ./file.yaml')
  */
 export function soloCommand(commandPath: string, ...arguments_: string[]): string {

--- a/src/commands/one-shot/deployment-state-snapshot.ts
+++ b/src/commands/one-shot/deployment-state-snapshot.ts
@@ -21,4 +21,7 @@ export interface DeploymentStateSnapshot {
   accounts: {
     accountsFileExists: boolean;
   };
+  cluster: {
+    podMonitorRoleExists: boolean;
+  };
 }

--- a/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
+++ b/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
@@ -405,6 +405,7 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
           return {
             ...baseTask,
             skip: (context_: OneShotSingleDeployContext): boolean => {
+              // Idempotency guard: skip if cluster ref already exists in local config
               if (context_.deploymentStateSnapshot?.localConfig.clusterRefs.has(context_.config.clusterRef)) {
                 this.logger.info(
                   `Step '${ClusterReferenceCommandDefinition.CONNECT_COMMAND}' skipped: cluster ref already in local config`,
@@ -445,6 +446,7 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
           return {
             ...baseTask,
             skip: (context_: OneShotSingleDeployContext): boolean => {
+              // Idempotency guard: skip if pod-monitor-role exists in cluster
               if (context_.deploymentStateSnapshot?.cluster.podMonitorRoleExists) {
                 this.logger.info(
                   `Step '${ClusterReferenceCommandDefinition.SETUP_COMMAND}' skipped: pod-monitor-role already installed`,
@@ -467,6 +469,7 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
           return {
             ...baseTask,
             skip: (context_: OneShotSingleDeployContext): boolean => {
+              // Idempotency guard: skip if keys already exist in the SOLO_HOME directory
               if (context_.deploymentStateSnapshot?.keys.consensusKeysOnDisk) {
                 this.logger.info(
                   `Step '${KeysCommandDefinition.KEYS_COMMAND}' skipped: consensus keys already on disk`,

--- a/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
+++ b/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
@@ -57,7 +57,7 @@ import {ConsensusCommandDefinition} from '../../../command-definitions/consensus
 import {ClusterReferenceCommandDefinition} from '../../../command-definitions/cluster-reference-command-definition.js';
 import {DeploymentCommandDefinition} from '../../../command-definitions/deployment-command-definition.js';
 import {KeysCommandDefinition} from '../../../command-definitions/keys-command-definition.js';
-import {invokeSoloCommand} from '../../../command-helpers.js';
+import {InvokedSoloCommand, invokeSoloCommand} from '../../../command-helpers.js';
 import {Flags as flags} from '../../../flags.js';
 import * as constants from '../../../../core/constants.js';
 import * as helpers from '../../../../core/helpers.js';
@@ -399,7 +399,7 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
       }),
       new OrchestratorPipelinePhase('Cluster connect', {
         asListrTask: (getConfig: () => OneShotSingleDeployConfigClass): SoloListrTask<OneShotSingleDeployContext> => {
-          const baseTask = invokeSoloCommand(
+          const baseTask: InvokedSoloCommand = invokeSoloCommand(
             `solo ${ClusterReferenceCommandDefinition.CONNECT_COMMAND}`,
             ClusterReferenceCommandDefinition.CONNECT_COMMAND,
             (): string[] => DeployArgvBuilders.buildClusterConnectArgv(getConfig()),
@@ -422,7 +422,7 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
       }),
       new OrchestratorPipelinePhase('Deployment create', {
         asListrTask: (getConfig: () => OneShotSingleDeployConfigClass): SoloListrTask<OneShotSingleDeployContext> => {
-          const baseTask = invokeSoloCommand(
+          const baseTask: InvokedSoloCommand = invokeSoloCommand(
             `solo ${DeploymentCommandDefinition.CREATE_COMMAND}`,
             DeploymentCommandDefinition.CREATE_COMMAND,
             (): string[] => DeployArgvBuilders.buildDeploymentCreateArgv(getConfig()),
@@ -445,7 +445,7 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
       }),
       new OrchestratorPipelinePhase('Deployment attach', {
         asListrTask: (getConfig: () => OneShotSingleDeployConfigClass): SoloListrTask<OneShotSingleDeployContext> => {
-          const baseTask = invokeSoloCommand(
+          const baseTask: InvokedSoloCommand = invokeSoloCommand(
             `solo ${DeploymentCommandDefinition.ATTACH_COMMAND}`,
             DeploymentCommandDefinition.ATTACH_COMMAND,
             (): string[] => DeployArgvBuilders.buildDeploymentAttachArgv(getConfig()),
@@ -468,7 +468,7 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
       }),
       new OrchestratorPipelinePhase('Cluster setup', {
         asListrTask: (getConfig: () => OneShotSingleDeployConfigClass): SoloListrTask<OneShotSingleDeployContext> => {
-          const baseTask = invokeSoloCommand(
+          const baseTask: InvokedSoloCommand = invokeSoloCommand(
             `solo ${ClusterReferenceCommandDefinition.SETUP_COMMAND}`,
             ClusterReferenceCommandDefinition.SETUP_COMMAND,
             (): string[] => DeployArgvBuilders.buildClusterSetupArgv(getConfig()),
@@ -491,7 +491,7 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
       }),
       new OrchestratorPipelinePhase('Keys generate', {
         asListrTask: (getConfig: () => OneShotSingleDeployConfigClass): SoloListrTask<OneShotSingleDeployContext> => {
-          const baseTask = invokeSoloCommand(
+          const baseTask: InvokedSoloCommand = invokeSoloCommand(
             `solo ${KeysCommandDefinition.KEYS_COMMAND}`,
             KeysCommandDefinition.KEYS_COMMAND,
             (): string[] => DeployArgvBuilders.buildKeysGenerateArgv(getConfig()),

--- a/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
+++ b/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
@@ -418,22 +418,50 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
         },
       }),
       new OrchestratorPipelinePhase('Deployment create', {
-        asListrTask: (getConfig: () => OneShotSingleDeployConfigClass): SoloListrTask<OneShotSingleDeployContext> =>
-          invokeSoloCommand(
+        asListrTask: (getConfig: () => OneShotSingleDeployConfigClass): SoloListrTask<OneShotSingleDeployContext> => {
+          const baseTask = invokeSoloCommand(
             `solo ${DeploymentCommandDefinition.CREATE_COMMAND}`,
             DeploymentCommandDefinition.CREATE_COMMAND,
             (): string[] => DeployArgvBuilders.buildDeploymentCreateArgv(getConfig()),
             this.taskList,
-          ),
+          );
+          return {
+            ...baseTask,
+            skip: (context_: OneShotSingleDeployContext): boolean => {
+              // Idempotency guard: skip if deployment already exists in local config
+              if (context_.deploymentStateSnapshot?.localConfig.deploymentExists) {
+                this.logger.info(
+                  `Step '${DeploymentCommandDefinition.CREATE_COMMAND}' skipped: deployment already exists in local config`,
+                );
+                return true;
+              }
+              return false;
+            },
+          };
+        },
       }),
       new OrchestratorPipelinePhase('Deployment attach', {
-        asListrTask: (getConfig: () => OneShotSingleDeployConfigClass): SoloListrTask<OneShotSingleDeployContext> =>
-          invokeSoloCommand(
+        asListrTask: (getConfig: () => OneShotSingleDeployConfigClass): SoloListrTask<OneShotSingleDeployContext> => {
+          const baseTask = invokeSoloCommand(
             `solo ${DeploymentCommandDefinition.ATTACH_COMMAND}`,
             DeploymentCommandDefinition.ATTACH_COMMAND,
             (): string[] => DeployArgvBuilders.buildDeploymentAttachArgv(getConfig()),
             this.taskList,
-          ),
+          );
+          return {
+            ...baseTask,
+            skip: (context_: OneShotSingleDeployContext): boolean => {
+              // Idempotency guard: skip if remote config already exists in cluster
+              if (context_.deploymentStateSnapshot?.remoteConfig.configMapExists) {
+                this.logger.info(
+                  `Step '${DeploymentCommandDefinition.ATTACH_COMMAND}' skipped: remote config already exists`,
+                );
+                return true;
+              }
+              return false;
+            },
+          };
+        },
       }),
       new OrchestratorPipelinePhase('Cluster setup', {
         asListrTask: (getConfig: () => OneShotSingleDeployConfigClass): SoloListrTask<OneShotSingleDeployContext> => {

--- a/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
+++ b/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
@@ -395,13 +395,26 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
           ),
       }),
       new OrchestratorPipelinePhase('Cluster connect', {
-        asListrTask: (getConfig: () => OneShotSingleDeployConfigClass): SoloListrTask<OneShotSingleDeployContext> =>
-          invokeSoloCommand(
+        asListrTask: (getConfig: () => OneShotSingleDeployConfigClass): SoloListrTask<OneShotSingleDeployContext> => {
+          const baseTask = invokeSoloCommand(
             `solo ${ClusterReferenceCommandDefinition.CONNECT_COMMAND}`,
             ClusterReferenceCommandDefinition.CONNECT_COMMAND,
             (): string[] => DeployArgvBuilders.buildClusterConnectArgv(getConfig()),
             this.taskList,
-          ),
+          );
+          return {
+            ...baseTask,
+            skip: (context_: OneShotSingleDeployContext): boolean => {
+              if (context_.deploymentStateSnapshot?.localConfig.clusterRefs.has(context_.config.clusterRef)) {
+                this.logger.info(
+                  `Step '${ClusterReferenceCommandDefinition.CONNECT_COMMAND}' skipped: cluster ref already in local config`,
+                );
+                return true;
+              }
+              return false;
+            },
+          };
+        },
       }),
       new OrchestratorPipelinePhase('Deployment create', {
         asListrTask: (getConfig: () => OneShotSingleDeployConfigClass): SoloListrTask<OneShotSingleDeployContext> =>
@@ -422,22 +435,48 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
           ),
       }),
       new OrchestratorPipelinePhase('Cluster setup', {
-        asListrTask: (getConfig: () => OneShotSingleDeployConfigClass): SoloListrTask<OneShotSingleDeployContext> =>
-          invokeSoloCommand(
+        asListrTask: (getConfig: () => OneShotSingleDeployConfigClass): SoloListrTask<OneShotSingleDeployContext> => {
+          const baseTask = invokeSoloCommand(
             `solo ${ClusterReferenceCommandDefinition.SETUP_COMMAND}`,
             ClusterReferenceCommandDefinition.SETUP_COMMAND,
             (): string[] => DeployArgvBuilders.buildClusterSetupArgv(getConfig()),
             this.taskList,
-          ),
+          );
+          return {
+            ...baseTask,
+            skip: (context_: OneShotSingleDeployContext): boolean => {
+              if (context_.deploymentStateSnapshot?.cluster.podMonitorRoleExists) {
+                this.logger.info(
+                  `Step '${ClusterReferenceCommandDefinition.SETUP_COMMAND}' skipped: pod-monitor-role already installed`,
+                );
+                return true;
+              }
+              return false;
+            },
+          };
+        },
       }),
       new OrchestratorPipelinePhase('Keys generate', {
-        asListrTask: (getConfig: () => OneShotSingleDeployConfigClass): SoloListrTask<OneShotSingleDeployContext> =>
-          invokeSoloCommand(
+        asListrTask: (getConfig: () => OneShotSingleDeployConfigClass): SoloListrTask<OneShotSingleDeployContext> => {
+          const baseTask = invokeSoloCommand(
             `solo ${KeysCommandDefinition.KEYS_COMMAND}`,
             KeysCommandDefinition.KEYS_COMMAND,
             (): string[] => DeployArgvBuilders.buildKeysGenerateArgv(getConfig()),
             this.taskList,
-          ),
+          );
+          return {
+            ...baseTask,
+            skip: (context_: OneShotSingleDeployContext): boolean => {
+              if (context_.deploymentStateSnapshot?.keys.consensusKeysOnDisk) {
+                this.logger.info(
+                  `Step '${KeysCommandDefinition.KEYS_COMMAND}' skipped: consensus keys already on disk`,
+                );
+                return true;
+              }
+              return false;
+            },
+          };
+        },
       }),
       new OrchestratorPipelinePhase('Create remote config components', {
         asListrTask: (getConfig: () => OneShotSingleDeployConfigClass): SoloListrTask<OneShotSingleDeployContext> => ({
@@ -802,12 +841,23 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
       PathEx.join(this.getOneShotOutputDirectory(deployConfig.deployment), 'accounts.json'),
     );
 
+    let podMonitorRoleExists: boolean = false;
+    try {
+      podMonitorRoleExists = await this.k8Factory
+        .getK8(deployConfig.context)
+        .rbac()
+        .clusterRoleExists(constants.POD_MONITOR_ROLE);
+    } catch {
+      this.logger.info('ClusterRole check unavailable during snapshot, treating as fresh deploy');
+    }
+
     return {
       localConfig: {deploymentExists, clusterRefs: clusterReferences},
       remoteConfig: {configMapExists, componentPhases},
       helm: {installedReleases},
       keys: {consensusKeysOnDisk},
       accounts: {accountsFileExists},
+      cluster: {podMonitorRoleExists},
     };
   }
 

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -365,9 +365,20 @@ export const LISTR_DEFAULT_RENDERER_OPTION: {
   formatOutput: 'wrap',
 };
 
+export const LISTR_DEFAULT_RENDERER_COLLAPSABLE_OPTIONS: typeof LISTR_DEFAULT_RENDERER_OPTION = {
+  collapseSubtasks: true,
+  timer: LISTR_DEFAULT_RENDERER_TIMER_OPTION,
+  persistentOutput: true,
+  clearOutput: false,
+  collapseErrors: false,
+  showErrorMessage: false,
+  formatOutput: 'wrap',
+};
+
 export const LISTR_DEFAULT_OPTIONS: {
   DEFAULT: ListrBaseClassOptions<AnyListrContext, ListrRendererValue>;
   WITH_CONCURRENCY: ListrBaseClassOptions<AnyListrContext, ListrRendererValue>;
+  WITH_CONCURRENCY_COLLAPSABLE: ListrBaseClassOptions<AnyListrContext, ListrRendererValue>;
 } = {
   DEFAULT: {
     renderer: SOLO_SILENT_MODE ? 'silent' : 'default',
@@ -381,6 +392,14 @@ export const LISTR_DEFAULT_OPTIONS: {
     renderer: SOLO_SILENT_MODE ? 'silent' : 'default',
     concurrent: true,
     rendererOptions: LISTR_DEFAULT_RENDERER_OPTION,
+    fallbackRendererOptions: {
+      timer: LISTR_DEFAULT_RENDERER_TIMER_OPTION,
+    },
+  },
+  WITH_CONCURRENCY_COLLAPSABLE: {
+    renderer: SOLO_SILENT_MODE ? 'silent' : 'default',
+    concurrent: true,
+    rendererOptions: LISTR_DEFAULT_RENDERER_COLLAPSABLE_OPTIONS,
     fallbackRendererOptions: {
       timer: LISTR_DEFAULT_RENDERER_TIMER_OPTION,
     },

--- a/src/core/errors/classes/system/cluster-role-check-failed-solo-error.ts
+++ b/src/core/errors/classes/system/cluster-role-check-failed-solo-error.ts
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {SoloError} from '../../solo-error.js';
+import {ErrorOwnership} from '../../error-ownership.js';
+import {ErrorCodeRegistry} from '../../error-code-registry.js';
+
+export class ClusterRoleCheckFailedSoloError extends SoloError {
+  protected override readonly retryable: boolean = false;
+  protected override readonly ownership: ErrorOwnership = ErrorOwnership.Infrastructure;
+
+  public constructor(clusterRoleName: string, cause: Error) {
+    super(
+      {
+        message: `Failed to check if ClusterRole exists: ${clusterRoleName}: ${cause.message}`,
+        code: ErrorCodeRegistry.CLUSTER_ROLE_CHECK_FAILED,
+        troubleshootingSteps:
+          'Check solo logs: tail -n 100 ~/.solo/logs/solo.log\n' +
+          'Verify RBAC permissions: kubectl get clusterroles\n' +
+          'Inspect cluster state: kubectl get pods -A',
+      },
+      cause,
+    );
+  }
+}

--- a/src/core/errors/error-code-registry.ts
+++ b/src/core/errors/error-code-registry.ts
@@ -280,6 +280,7 @@ export const ErrorCodeRegistry: Record<string, string> = {
   INIT_SYSTEM_FILES_FAILED: 'SOLO-5070',
   CACHE_PROVIDER_NOT_CONFIGURED: 'SOLO-5071',
   POD_TERMINATION_TIMEOUT: 'SOLO-5072',
+  CLUSTER_ROLE_CHECK_FAILED: 'SOLO-5073',
 
   // 9xxx - Internal: Unexpected bugs, unimplemented paths
   TIMEOUT: 'SOLO-9001',

--- a/src/core/errors/solo-errors.ts
+++ b/src/core/errors/solo-errors.ts
@@ -274,6 +274,7 @@ import {InitSystemFilesFailedSoloError} from './classes/system/init-system-files
 import {CacheProviderNotConfiguredSoloError} from './classes/system/cache-provider-not-configured-solo-error.js';
 import {PodTerminationTimeoutSoloError} from './classes/system/pod-termination-timeout-solo-error.js';
 import {TimeoutSoloError} from './classes/system/timeout-solo-error.js';
+import {ClusterRoleCheckFailedSoloError} from './classes/system/cluster-role-check-failed-solo-error.js';
 import {LoggerMessageGroupNotFoundError} from './classes/internal/logger-message-group-not-found-error.js';
 import {CommandReturnedFalseError} from './classes/internal/command-returned-false-error.js';
 import {RemoteConfigUnsupportedComponentError} from './classes/internal/remote-config-unsupported-component-error.js';
@@ -781,6 +782,7 @@ export class SoloErrors {
     readonly cacheProviderNotConfigured: typeof CacheProviderNotConfiguredSoloError;
     readonly podTerminationTimeout: typeof PodTerminationTimeoutSoloError;
     readonly timeout: typeof TimeoutSoloError;
+    readonly clusterRoleCheckFailed: typeof ClusterRoleCheckFailedSoloError;
   } = Object.freeze({
     blockNodePodNotFound: BlockNodePodNotFoundSoloError,
     blockNodeNotReady: BlockNodeNotReadySoloError,
@@ -855,6 +857,7 @@ export class SoloErrors {
     cacheProviderNotConfigured: CacheProviderNotConfiguredSoloError,
     podTerminationTimeout: PodTerminationTimeoutSoloError,
     timeout: TimeoutSoloError,
+    clusterRoleCheckFailed: ClusterRoleCheckFailedSoloError,
   });
 
   // 9xxx — Internal: Unexpected bugs, unimplemented paths

--- a/src/integration/cache/impl/image-cache-handler.ts
+++ b/src/integration/cache/impl/image-cache-handler.ts
@@ -102,9 +102,7 @@ export class ImageCacheHandler implements CacheOperationHandler {
           try {
             await this.engine.loadImageArchiveIntoCluster(item.localPath, target);
           } catch (error) {
-            this.logger.showUser(`Failed to load image archive into cluster: ${name}`);
             this.logger.error(error);
-            console.error(error);
           }
         },
       });

--- a/src/integration/cache/impl/image-cache-handler.ts
+++ b/src/integration/cache/impl/image-cache-handler.ts
@@ -102,6 +102,7 @@ export class ImageCacheHandler implements CacheOperationHandler {
           try {
             await this.engine.loadImageArchiveIntoCluster(item.localPath, target);
           } catch (error) {
+            this.logger.showUser(`Failed to load image archive into cluster: ${name}`);
             this.logger.error(error);
           }
         },

--- a/src/integration/cache/impl/image-cache-handler.ts
+++ b/src/integration/cache/impl/image-cache-handler.ts
@@ -102,7 +102,6 @@ export class ImageCacheHandler implements CacheOperationHandler {
           try {
             await this.engine.loadImageArchiveIntoCluster(item.localPath, target);
           } catch (error) {
-            this.logger.showUser(`Failed to load image archive into cluster: ${name}`);
             this.logger.error(error);
           }
         },

--- a/test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts
+++ b/test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts
@@ -11,6 +11,10 @@ import {type DeploymentStateSnapshot} from '../../../../../../src/commands/one-s
 import {ComponentTypes} from '../../../../../../src/core/config/remote/enumerations/component-types.js';
 import {DeploymentPhase} from '../../../../../../src/data/schema/model/remote/deployment-phase.js';
 import * as constants from '../../../../../../src/core/constants.js';
+import {OrchestratorPipeline} from '../../../../../../src/commands/one-shot/orchestrator/orchestrator-pipeline.js';
+import type {
+  OneShotSingleDeployContext
+} from '../../../../../../src/commands/one-shot/one-shot-single-deploy-context.js';
 
 type MockType = any;
 type MockListr = MockType;
@@ -86,6 +90,33 @@ function makeTaskWrapper(promptResult: boolean): MockListr {
   return {
     prompt: promptAdapterStub,
   };
+}
+
+function makeMinimalOrchestrator(): DefaultOneShotDeployOrchestrator {
+  return new DefaultOneShotDeployOrchestrator(
+    {} as MockType,
+    {emit: sinon.stub(), waitFor: sinon.stub()} as MockType,
+    {} as MockType,
+    {} as MockType,
+    {} as MockType,
+    {info: sinon.stub()} as MockType,
+    {} as MockType,
+    {} as MockType,
+    {} as MockType,
+    {} as MockType,
+    {} as MockType,
+    {} as MockType,
+  );
+}
+
+function buildPipelineTasks(orchestrator: DefaultOneShotDeployOrchestrator): MockType[] {
+  const pipeline: OrchestratorPipeline<OneShotSingleDeployContext> = orchestrator.buildDeployPipeline(
+    {_: []} as MockType,
+    {required: [], optional: []} as MockType,
+    {} as MockType,
+    {} as MockType,
+  );
+  return pipeline.tasks as MockType[];
 }
 
 describe('DefaultOneShotDeployOrchestrator non-Kind context guard', (): void => {
@@ -486,23 +517,6 @@ describe('DefaultOneShotDeployOrchestrator idempotency skip guards', (): void =>
   const CLUSTER_SETUP_TASK_INDEX: number = 9;
   const KEYS_GENERATE_TASK_INDEX: number = 10;
 
-  function makeMinimalOrchestrator(): DefaultOneShotDeployOrchestrator {
-    return new DefaultOneShotDeployOrchestrator(
-      {} as MockType,
-      {emit: sinon.stub(), waitFor: sinon.stub()} as MockType,
-      {} as MockType,
-      {} as MockType,
-      {} as MockType,
-      {info: sinon.stub()} as MockType,
-      {} as MockType,
-      {} as MockType,
-      {} as MockType,
-      {} as MockType,
-      {} as MockType,
-      {} as MockType,
-    );
-  }
-
   function makeSnapshot(overrides: Partial<DeploymentStateSnapshot> = {}): DeploymentStateSnapshot {
     return {
       localConfig: {deploymentExists: false, clusterRefs: new Set()},
@@ -513,16 +527,6 @@ describe('DefaultOneShotDeployOrchestrator idempotency skip guards', (): void =>
       cluster: {podMonitorRoleExists: false},
       ...overrides,
     };
-  }
-
-  function buildPipelineTasks(orchestrator: DefaultOneShotDeployOrchestrator): MockType[] {
-    const pipeline = orchestrator.buildDeployPipeline(
-      {_: []} as MockType,
-      {required: [], optional: []} as MockType,
-      {} as MockType,
-      {} as MockType,
-    );
-    return pipeline.tasks as MockType[];
   }
 
   it('cluster connect: does not skip when snapshot is absent', (): void => {

--- a/test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts
+++ b/test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts
@@ -478,6 +478,8 @@ describe('DefaultOneShotDeployOrchestrator buildDeploymentStateSnapshot', (): vo
 
 describe('DefaultOneShotDeployOrchestrator idempotency skip guards', (): void => {
   const CLUSTER_CONNECT_TASK_INDEX: number = 6;
+  const DEPLOYMENT_CREATE_TASK_INDEX: number = 7;
+  const DEPLOYMENT_ATTACH_TASK_INDEX: number = 8;
   const CLUSTER_SETUP_TASK_INDEX: number = 9;
   const KEYS_GENERATE_TASK_INDEX: number = 10;
 
@@ -552,6 +554,74 @@ describe('DefaultOneShotDeployOrchestrator idempotency skip guards', (): void =>
     };
 
     expect(tasks[CLUSTER_CONNECT_TASK_INDEX].skip(context_)).to.be.false;
+  });
+
+  it('deployment create: does not skip when snapshot is absent', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeMinimalOrchestrator();
+    const tasks: MockType[] = buildPipelineTasks(orchestrator);
+    const context_: MockType = {config: makeConfig(), deploymentStateSnapshot: undefined};
+
+    expect(tasks[DEPLOYMENT_CREATE_TASK_INDEX].skip(context_)).to.be.false;
+  });
+
+  it('deployment create: skips when deployment already exists in local config', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeMinimalOrchestrator();
+    const tasks: MockType[] = buildPipelineTasks(orchestrator);
+    const context_: MockType = {
+      config: makeConfig(),
+      deploymentStateSnapshot: makeSnapshot({
+        localConfig: {deploymentExists: true, clusterRefs: new Set()},
+      }),
+    };
+
+    expect(tasks[DEPLOYMENT_CREATE_TASK_INDEX].skip(context_)).to.be.true;
+  });
+
+  it('deployment create: does not skip when deployment does not exist', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeMinimalOrchestrator();
+    const tasks: MockType[] = buildPipelineTasks(orchestrator);
+    const context_: MockType = {
+      config: makeConfig(),
+      deploymentStateSnapshot: makeSnapshot({
+        localConfig: {deploymentExists: false, clusterRefs: new Set()},
+      }),
+    };
+
+    expect(tasks[DEPLOYMENT_CREATE_TASK_INDEX].skip(context_)).to.be.false;
+  });
+
+  it('deployment attach: does not skip when snapshot is absent', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeMinimalOrchestrator();
+    const tasks: MockType[] = buildPipelineTasks(orchestrator);
+    const context_: MockType = {config: makeConfig(), deploymentStateSnapshot: undefined};
+
+    expect(tasks[DEPLOYMENT_ATTACH_TASK_INDEX].skip(context_)).to.be.false;
+  });
+
+  it('deployment attach: skips when remote config already exists', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeMinimalOrchestrator();
+    const tasks: MockType[] = buildPipelineTasks(orchestrator);
+    const context_: MockType = {
+      config: makeConfig(),
+      deploymentStateSnapshot: makeSnapshot({
+        remoteConfig: {configMapExists: true, componentPhases: new Map()},
+      }),
+    };
+
+    expect(tasks[DEPLOYMENT_ATTACH_TASK_INDEX].skip(context_)).to.be.true;
+  });
+
+  it('deployment attach: does not skip when remote config is absent', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeMinimalOrchestrator();
+    const tasks: MockType[] = buildPipelineTasks(orchestrator);
+    const context_: MockType = {
+      config: makeConfig(),
+      deploymentStateSnapshot: makeSnapshot({
+        remoteConfig: {configMapExists: false, componentPhases: new Map()},
+      }),
+    };
+
+    expect(tasks[DEPLOYMENT_ATTACH_TASK_INDEX].skip(context_)).to.be.false;
   });
 
   it('cluster setup: does not skip when snapshot is absent', (): void => {

--- a/test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts
+++ b/test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts
@@ -11,10 +11,8 @@ import {type DeploymentStateSnapshot} from '../../../../../../src/commands/one-s
 import {ComponentTypes} from '../../../../../../src/core/config/remote/enumerations/component-types.js';
 import {DeploymentPhase} from '../../../../../../src/data/schema/model/remote/deployment-phase.js';
 import * as constants from '../../../../../../src/core/constants.js';
-import {OrchestratorPipeline} from '../../../../../../src/commands/one-shot/orchestrator/orchestrator-pipeline.js';
-import type {
-  OneShotSingleDeployContext
-} from '../../../../../../src/commands/one-shot/one-shot-single-deploy-context.js';
+import {type OrchestratorPipeline} from '../../../../../../src/commands/one-shot/orchestrator/orchestrator-pipeline.js';
+import {type OneShotSingleDeployContext} from '../../../../../../src/commands/one-shot/one-shot-single-deploy-context.js';
 
 type MockType = any;
 type MockListr = MockType;

--- a/test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts
+++ b/test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts
@@ -698,6 +698,7 @@ function makeSnapshot(
     helm: {installedReleases},
     keys: {consensusKeysOnDisk: false},
     accounts: {accountsFileExists: false},
+    cluster: {podMonitorRoleExists: false},
   };
 }
 

--- a/test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts
+++ b/test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts
@@ -871,6 +871,7 @@ function makeAccountsSnapshot(accountsFileExists: boolean): DeploymentStateSnaps
     helm: {installedReleases: new Set<string>()},
     keys: {consensusKeysOnDisk: false},
     accounts: {accountsFileExists},
+    cluster: {podMonitorRoleExists: false},
   };
 }
 

--- a/test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts
+++ b/test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts
@@ -349,4 +349,268 @@ describe('DefaultOneShotDeployOrchestrator buildDeploymentStateSnapshot', (): vo
     expect(snapshot.helm.installedReleases.has('solo-deployment')).to.be.true;
     expect(snapshot.helm.installedReleases.has('solo-cluster-setup')).to.be.true;
   });
+
+  it('sets cluster.podMonitorRoleExists to true when the ClusterRole exists', async (): Promise<void> => {
+    const remoteConfigMock: MockType = {
+      load: sinon.stub().rejects(new Error('no config')),
+      isLoaded: sinon.stub().returns(false),
+      getComponentPhasesMap: sinon.stub().returns(new Map()),
+    };
+    const localConfigMock: MockType = {
+      isLoaded: false,
+    };
+    const helmMock: MockType = {
+      listReleases: sinon.stub().resolves([]),
+    };
+    const loggerMock: MockType = {
+      info: sinon.stub(),
+      debug: sinon.stub(),
+    };
+    const k8FactoryMock: MockType = {
+      getK8: sinon.stub().returns({
+        rbac: sinon.stub().returns({
+          clusterRoleExists: sinon.stub().resolves(true),
+        }),
+      }),
+    };
+    const orchestrator: DefaultOneShotDeployOrchestrator = new DefaultOneShotDeployOrchestrator(
+      {} as MockType,
+      {} as MockType,
+      {} as MockType,
+      localConfigMock,
+      remoteConfigMock,
+      loggerMock,
+      {} as MockType,
+      {} as MockType,
+      k8FactoryMock,
+      {} as MockType,
+      {} as MockType,
+      helmMock,
+    );
+
+    // @ts-expect-error - to access private method
+    const snapshot: DeploymentStateSnapshot = await orchestrator.buildDeploymentStateSnapshot(makeConfig());
+
+    expect(snapshot.cluster.podMonitorRoleExists).to.be.true;
+  });
+
+  it('sets cluster.podMonitorRoleExists to false when the ClusterRole does not exist', async (): Promise<void> => {
+    const remoteConfigMock: MockType = {
+      load: sinon.stub().rejects(new Error('no config')),
+      isLoaded: sinon.stub().returns(false),
+      getComponentPhasesMap: sinon.stub().returns(new Map()),
+    };
+    const localConfigMock: MockType = {
+      isLoaded: false,
+    };
+    const helmMock: MockType = {
+      listReleases: sinon.stub().resolves([]),
+    };
+    const loggerMock: MockType = {
+      info: sinon.stub(),
+      debug: sinon.stub(),
+    };
+    const k8FactoryMock: MockType = {
+      getK8: sinon.stub().returns({
+        rbac: sinon.stub().returns({
+          clusterRoleExists: sinon.stub().resolves(false),
+        }),
+      }),
+    };
+    const orchestrator: DefaultOneShotDeployOrchestrator = new DefaultOneShotDeployOrchestrator(
+      {} as MockType,
+      {} as MockType,
+      {} as MockType,
+      localConfigMock,
+      remoteConfigMock,
+      loggerMock,
+      {} as MockType,
+      {} as MockType,
+      k8FactoryMock,
+      {} as MockType,
+      {} as MockType,
+      helmMock,
+    );
+
+    // @ts-expect-error - to access private method
+    const snapshot: DeploymentStateSnapshot = await orchestrator.buildDeploymentStateSnapshot(makeConfig());
+
+    expect(snapshot.cluster.podMonitorRoleExists).to.be.false;
+  });
+
+  it('defaults cluster.podMonitorRoleExists to false when k8Factory is unavailable', async (): Promise<void> => {
+    const remoteConfigMock: MockType = {
+      load: sinon.stub().rejects(new Error('no config')),
+      isLoaded: sinon.stub().returns(false),
+      getComponentPhasesMap: sinon.stub().returns(new Map()),
+    };
+    const localConfigMock: MockType = {
+      isLoaded: false,
+    };
+    const helmMock: MockType = {
+      listReleases: sinon.stub().resolves([]),
+    };
+    const loggerMock: MockType = {
+      info: sinon.stub(),
+      debug: sinon.stub(),
+    };
+    const orchestrator: DefaultOneShotDeployOrchestrator = new DefaultOneShotDeployOrchestrator(
+      {} as MockType,
+      {} as MockType,
+      {} as MockType,
+      localConfigMock,
+      remoteConfigMock,
+      loggerMock,
+      {} as MockType,
+      {} as MockType,
+      {} as MockType,
+      {} as MockType,
+      {} as MockType,
+      helmMock,
+    );
+
+    // @ts-expect-error - to access private method
+    const snapshot: DeploymentStateSnapshot = await orchestrator.buildDeploymentStateSnapshot(makeConfig());
+
+    expect(snapshot.cluster.podMonitorRoleExists).to.be.false;
+  });
+});
+
+describe('DefaultOneShotDeployOrchestrator idempotency skip guards', (): void => {
+  const CLUSTER_CONNECT_TASK_INDEX: number = 6;
+  const CLUSTER_SETUP_TASK_INDEX: number = 9;
+  const KEYS_GENERATE_TASK_INDEX: number = 10;
+
+  function makeMinimalOrchestrator(): DefaultOneShotDeployOrchestrator {
+    return new DefaultOneShotDeployOrchestrator(
+      {} as MockType,
+      {emit: sinon.stub(), waitFor: sinon.stub()} as MockType,
+      {} as MockType,
+      {} as MockType,
+      {} as MockType,
+      {info: sinon.stub()} as MockType,
+      {} as MockType,
+      {} as MockType,
+      {} as MockType,
+      {} as MockType,
+      {} as MockType,
+      {} as MockType,
+    );
+  }
+
+  function makeSnapshot(overrides: Partial<DeploymentStateSnapshot> = {}): DeploymentStateSnapshot {
+    return {
+      localConfig: {deploymentExists: false, clusterRefs: new Set()},
+      remoteConfig: {configMapExists: false, componentPhases: new Map()},
+      helm: {installedReleases: new Set()},
+      keys: {consensusKeysOnDisk: false},
+      accounts: {accountsFileExists: false},
+      cluster: {podMonitorRoleExists: false},
+      ...overrides,
+    };
+  }
+
+  function buildPipelineTasks(orchestrator: DefaultOneShotDeployOrchestrator): MockType[] {
+    const pipeline = orchestrator.buildDeployPipeline(
+      {_: []} as MockType,
+      {required: [], optional: []} as MockType,
+      {} as MockType,
+      {} as MockType,
+    );
+    return pipeline.tasks as MockType[];
+  }
+
+  it('cluster connect: does not skip when snapshot is absent', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeMinimalOrchestrator();
+    const tasks: MockType[] = buildPipelineTasks(orchestrator);
+    const context_: MockType = {config: makeConfig(), deploymentStateSnapshot: undefined};
+
+    expect(tasks[CLUSTER_CONNECT_TASK_INDEX].skip(context_)).to.be.false;
+  });
+
+  it('cluster connect: skips when clusterRef is already in local config', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeMinimalOrchestrator();
+    const tasks: MockType[] = buildPipelineTasks(orchestrator);
+    const context_: MockType = {
+      config: makeConfig({clusterRef: 'one-shot'}),
+      deploymentStateSnapshot: makeSnapshot({
+        localConfig: {deploymentExists: true, clusterRefs: new Set(['one-shot'])},
+      }),
+    };
+
+    expect(tasks[CLUSTER_CONNECT_TASK_INDEX].skip(context_)).to.be.true;
+  });
+
+  it('cluster connect: does not skip when clusterRef is not in local config', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeMinimalOrchestrator();
+    const tasks: MockType[] = buildPipelineTasks(orchestrator);
+    const context_: MockType = {
+      config: makeConfig({clusterRef: 'one-shot'}),
+      deploymentStateSnapshot: makeSnapshot({
+        localConfig: {deploymentExists: false, clusterRefs: new Set()},
+      }),
+    };
+
+    expect(tasks[CLUSTER_CONNECT_TASK_INDEX].skip(context_)).to.be.false;
+  });
+
+  it('cluster setup: does not skip when snapshot is absent', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeMinimalOrchestrator();
+    const tasks: MockType[] = buildPipelineTasks(orchestrator);
+    const context_: MockType = {config: makeConfig(), deploymentStateSnapshot: undefined};
+
+    expect(tasks[CLUSTER_SETUP_TASK_INDEX].skip(context_)).to.be.false;
+  });
+
+  it('cluster setup: skips when pod-monitor-role already exists', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeMinimalOrchestrator();
+    const tasks: MockType[] = buildPipelineTasks(orchestrator);
+    const context_: MockType = {
+      config: makeConfig(),
+      deploymentStateSnapshot: makeSnapshot({cluster: {podMonitorRoleExists: true}}),
+    };
+
+    expect(tasks[CLUSTER_SETUP_TASK_INDEX].skip(context_)).to.be.true;
+  });
+
+  it('cluster setup: does not skip when pod-monitor-role is absent', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeMinimalOrchestrator();
+    const tasks: MockType[] = buildPipelineTasks(orchestrator);
+    const context_: MockType = {
+      config: makeConfig(),
+      deploymentStateSnapshot: makeSnapshot({cluster: {podMonitorRoleExists: false}}),
+    };
+
+    expect(tasks[CLUSTER_SETUP_TASK_INDEX].skip(context_)).to.be.false;
+  });
+
+  it('keys generate: does not skip when snapshot is absent', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeMinimalOrchestrator();
+    const tasks: MockType[] = buildPipelineTasks(orchestrator);
+    const context_: MockType = {config: makeConfig(), deploymentStateSnapshot: undefined};
+
+    expect(tasks[KEYS_GENERATE_TASK_INDEX].skip(context_)).to.be.false;
+  });
+
+  it('keys generate: skips when consensus keys are already on disk', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeMinimalOrchestrator();
+    const tasks: MockType[] = buildPipelineTasks(orchestrator);
+    const context_: MockType = {
+      config: makeConfig(),
+      deploymentStateSnapshot: makeSnapshot({keys: {consensusKeysOnDisk: true}}),
+    };
+
+    expect(tasks[KEYS_GENERATE_TASK_INDEX].skip(context_)).to.be.true;
+  });
+
+  it('keys generate: does not skip when keys are absent', (): void => {
+    const orchestrator: DefaultOneShotDeployOrchestrator = makeMinimalOrchestrator();
+    const tasks: MockType[] = buildPipelineTasks(orchestrator);
+    const context_: MockType = {
+      config: makeConfig(),
+      deploymentStateSnapshot: makeSnapshot({keys: {consensusKeysOnDisk: false}}),
+    };
+
+    expect(tasks[KEYS_GENERATE_TASK_INDEX].skip(context_)).to.be.false;
+  });
 });


### PR DESCRIPTION
## Description

Adds idempotency guards for the `cluster-ref config connect`, `cluster-ref config setup` and `keys consensus generate` steps of the `solo one-shot single deploy` workflow. If the guards are triggered, the steps are skipped.

### Related Issues

* Closes #4561 
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
