### PR TITLE
fix: pass GITHUB_TOKEN to dependency manager GitHub API requests

### DIFF
--- a/src/core/dependency-managers/crane-dependency-manager.ts
+++ b/src/core/dependency-managers/crane-dependency-manager.ts
@@ -116,12 +116,18 @@ export class CraneDependencyManager extends BaseDependencyManager {
 
   private async fetchReleaseInfo(tagName: string): Promise<ReleaseInfo> {
     try {
+      const headers: Record<string, string> = {
+        'User-Agent': constants.SOLO_USER_AGENT_HEADER,
+        Accept: 'application/vnd.github.v3+json',
+      };
+      // GITHUB_TOKEN is injected automatically into every GitHub Actions job,
+      // raising the rate limit from 60 req/hour (unauthenticated) to 1000 req/hour.
+      if (process.env.GITHUB_TOKEN) {
+        headers['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
+      }
       const response: Response = await fetch(CRANE_RELEASES_LIST_URL, {
         method: 'GET',
-        headers: {
-          'User-Agent': constants.SOLO_USER_AGENT_HEADER,
-          Accept: 'application/vnd.github.v3+json',
-        },
+        headers,
       });
 
       if (!response.ok) {

--- a/src/core/dependency-managers/gvproxy-dependency-manager.ts
+++ b/src/core/dependency-managers/gvproxy-dependency-manager.ts
@@ -106,13 +106,16 @@ export class GvproxyDependencyManager extends BaseDependencyManager {
    */
   private async fetchReleaseInfo(tagName: string): Promise<ReleaseInfo> {
     try {
-      // Make a GET request to GitHub API using fetch
+      const headers: Record<string, string> = {
+        'User-Agent': constants.SOLO_USER_AGENT_HEADER,
+        Accept: 'application/vnd.github.v3+json',
+      };
+      if (process.env.GITHUB_TOKEN) {
+        headers['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
+      }
       const response = await fetch(GVPROXY_RELEASES_LIST_URL, {
         method: 'GET',
-        headers: {
-          'User-Agent': constants.SOLO_USER_AGENT_HEADER,
-          Accept: 'application/vnd.github.v3+json', // Explicitly request GitHub API v3 format
-        },
+        headers,
       });
 
       if (!response.ok) {

--- a/src/core/dependency-managers/podman-dependency-manager.ts
+++ b/src/core/dependency-managers/podman-dependency-manager.ts
@@ -90,13 +90,16 @@ export class PodmanDependencyManager extends BaseDependencyManager {
    */
   private async fetchReleaseInfo(tagName: string): Promise<ReleaseInfo> {
     try {
-      // Make a GET request to GitHub API using fetch
+      const headers: Record<string, string> = {
+        'User-Agent': constants.SOLO_USER_AGENT_HEADER,
+        Accept: 'application/vnd.github.v3+json',
+      };
+      if (process.env.GITHUB_TOKEN) {
+        headers['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
+      }
       const response = await fetch(PODMAN_RELEASES_LIST_URL, {
-        method: 'GET', // Changed from HEAD to GET to retrieve the body
-        headers: {
-          'User-Agent': constants.SOLO_USER_AGENT_HEADER,
-          Accept: 'application/vnd.github.v3+json', // Explicitly request GitHub API v3 format
-        },
+        method: 'GET',
+        headers,
       });
 
       if (!response.ok) {

--- a/src/core/dependency-managers/vfkit-dependency-manager.ts
+++ b/src/core/dependency-managers/vfkit-dependency-manager.ts
@@ -82,13 +82,16 @@ export class VfkitDependencyManager extends BaseDependencyManager {
    */
   private async fetchReleaseInfo(tagName: string): Promise<ReleaseInfo> {
     try {
-      // Make a GET request to GitHub API using fetch
+      const headers: Record<string, string> = {
+        'User-Agent': constants.SOLO_USER_AGENT_HEADER,
+        Accept: 'application/vnd.github.v3+json',
+      };
+      if (process.env.GITHUB_TOKEN) {
+        headers['Authorization'] = `Bearer ${process.env.GITHUB_TOKEN}`;
+      }
       const response = await fetch(VFKIT_RELEASES_LIST_URL, {
-        method: 'GET', // Changed from HEAD to GET to retrieve the body
-        headers: {
-          'User-Agent': constants.SOLO_USER_AGENT_HEADER,
-          Accept: 'application/vnd.github.v3+json', // Explicitly request GitHub API v3 format
-        },
+        method: 'GET',
+        headers,
       });
 
       if (!response.ok) {


### PR DESCRIPTION
## Description

This pull request changes the following:

* Adds `Authorization: Bearer $GITHUB_TOKEN` to GitHub API requests in all four dependency managers (`crane`, `podman`, `gvproxy`, `vfkit`) when `GITHUB_TOKEN` is present in the environment.

### Related Issues

* Closes #4659

### Pull request (PR) checklist

* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description

### Testing

* [x] Anything not tested is documented

The following manual testing was done:

* `task build` passes with 0 errors
* The pattern is identical to the existing working implementation in `network.ts` (lines 1248–1249) for CRD downloads

The following was not tested:

* Live GitHub Actions run — the fix is a conditional header addition that only activates when `GITHUB_TOKEN` is set; no behavior change in local dev where the variable is absent.

### Root cause

All four dependency managers (`CraneDependencyManager`, `PodmanDependencyManager`, `GvproxyDependencyManager`, `VfkitDependencyManager`) call `api.github.com` to fetch release metadata without authentication. GitHub's unauthenticated rate limit is **60 requests/hour per IP**, shared across all concurrent jobs on the same runner pool. Under load this is exhausted and GitHub returns HTTP 403.

### Fix

When `GITHUB_TOKEN` is present (automatically injected by every GitHub Actions job), include it as a `Bearer` token in the `Authorization` header. This raises the rate limit to **1000 req/hour** per installation token, eliminating the transient failures. The pattern is already applied in `src/commands/network.ts` for CRD downloads.