### PR TITLE
feat(block-node): add collect-jfr to capture JVM metrics during performance tests

### DIFF
--- a/.github/workflows/flow-performance-test.yaml
+++ b/.github/workflows/flow-performance-test.yaml
@@ -410,6 +410,16 @@ jobs:
           overwrite: true
           if-no-files-found: error
 
+      - name: Upload Java Flight Recorder Recordings to GitHub
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
+        with:
+          name: solo-performance-test-jfr
+          path: ~/.solo/logs/**/*.jfr
+          overwrite: true
+          if-no-files-found: warn
+
       - name: Performance Test Verification
         timeout-minutes: ${{ fromJSON(env.STEP_TIMEOUT_MINUTES) }}
         run: |

--- a/resources/block-node-perf-values.yaml
+++ b/resources/block-node-perf-values.yaml
@@ -1,0 +1,25 @@
+# constants.BLOCK_NODE_JFR_REPOSITORY_DIRECTORY ("/opt/hiero/block-node/output/jfr").
+# maxchunksize is kept small so chunks rotate often under load, keeping each collection close to live.
+# settings=profile uses the JVM built-in JFR profile, so no .jfc file needs to be staged into the pod.
+# npm run solo -- block node add \
+#    --deployment one-shot \
+#    --values-file resources/block-node-perf-values.yaml
+resources:
+  requests:
+    cpu: "250m"
+    memory: "512Mi"
+  limits:
+    cpu: "1"
+    memory: "1Gi"
+
+blockNode:
+  config:
+    JAVA_OPTS: >-
+      -Xms256m
+      -Xmx512m
+      -XX:MaxDirectMemorySize=64m
+      -XX:MaxMetaspaceSize=128m
+      -XX:+HeapDumpOnOutOfMemoryError
+      -XX:HeapDumpPath="/tmp/dump.hprof"
+      -XX:FlightRecorderOptions=repository=/opt/hiero/block-node/output/jfr,maxchunksize=1m
+      -XX:StartFlightRecording=name=blocknode,settings=profile,disk=true,maxsize=200m,maxage=30m,dumponexit=true,filename=/opt/hiero/block-node/output/jfr/recording.jfr

--- a/src/commands/block-node.ts
+++ b/src/commands/block-node.ts
@@ -57,6 +57,9 @@ import {SoloErrors} from '../core/errors/solo-errors.js';
 import {HelmChartValues} from '../integration/helm/model/values.js';
 import {type SoloEventBus} from '../core/events/solo-event-bus.js';
 import {BlockNodeDeployedEvent} from '../core/events/event-types/block-node-deployed-event.js';
+import {type Container} from '../integration/kube/resources/container/container.js';
+import {PathEx} from '../business/utils/path-ex.js';
+import fs from 'node:fs';
 
 interface BlockNodeDeployConfigClass {
   chartVersion: string;
@@ -163,6 +166,20 @@ interface BlockNodeDeleteExternalContext {
   config: BlockNodeDeleteExternalConfigClass;
 }
 
+interface BlockNodeCollectJfrConfigClass {
+  clusterRef: ClusterReferenceName;
+  deployment: DeploymentName;
+  devMode: boolean;
+  quiet: boolean;
+  namespace: NamespaceName;
+  context: string;
+  id: ComponentId;
+}
+
+interface BlockNodeCollectJfrContext {
+  config: BlockNodeCollectJfrConfigClass;
+}
+
 interface InferredData {
   id: ComponentId;
   releaseName: string;
@@ -186,6 +203,11 @@ export class BlockNodeCommand extends BaseCommand {
   private static readonly ADD_EXTERNAL_CONFIGS_NAME: string = 'addExternalConfigs';
 
   private static readonly DELETE_CONFIGS_NAME: string = 'deleteExternalConfigs';
+
+  private static readonly COLLECT_JFR_CONFIGS_NAME: string = 'collectJfrConfigs';
+
+  // Sentinel printed by the in-pod consolidation script when no JFR recording is present.
+  private static readonly NO_JFR_MARKER: string = 'SOLO_NO_JFR_RECORDING';
   private static readonly MIGRATION_COMPONENT_KEY: string = 'block-node';
 
   public static readonly ADD_FLAGS_LIST: CommandFlags = {
@@ -233,6 +255,11 @@ export class BlockNodeCommand extends BaseCommand {
   public static readonly DESTROY_FLAGS_LIST: CommandFlags = {
     required: [flags.deployment],
     optional: [flags.chartDirectory, flags.clusterRef, flags.devMode, flags.force, flags.quiet, flags.id],
+  };
+
+  public static readonly COLLECT_JFR_FLAGS_LIST: CommandFlags = {
+    required: [flags.deployment],
+    optional: [flags.clusterRef, flags.devMode, flags.quiet, flags.id],
   };
 
   public static readonly UPGRADE_FLAGS_LIST: CommandFlags = {
@@ -778,6 +805,132 @@ export class BlockNodeCommand extends BaseCommand {
         await tasks.run();
       } catch (error) {
         throw new SoloErrors.component.blockNodeDestroyFailed(error);
+      } finally {
+        if (!this.oneShotState.isActive()) {
+          await lease?.release();
+        }
+      }
+    } else {
+      this.taskList.registerCloseFunction(async (): Promise<void> => {
+        if (!this.oneShotState.isActive()) {
+          await lease?.release();
+        }
+      });
+    }
+
+    return true;
+  }
+
+  private downloadBlockNodeJavaFlightRecorderLogs(): SoloListrTask<BlockNodeCollectJfrContext> {
+    return {
+      title: 'Download Java Flight Recorder logs from block node pod',
+      task: async ({config}, task): Promise<void> => {
+        const labels: string[] = Templates.renderBlockNodeLabels(config.id);
+        const blockNodePods: Pod[] = await this.k8Factory.getK8(config.context).pods().list(config.namespace, labels);
+
+        if (blockNodePods.length === 0) {
+          throw new SoloErrors.system.blockNodePodNotFound();
+        }
+
+        const podReference: PodReference = blockNodePods[0].podReference;
+        const containerReference: ContainerReference = ContainerReference.of(
+          podReference,
+          constants.BLOCK_NODE_CONTAINER_NAME,
+        );
+        const k8Container: Container = this.k8Factory.getK8(config.context).containers().readByRef(containerReference);
+
+        const repositoryDirectory: string = constants.BLOCK_NODE_JFR_REPOSITORY_DIRECTORY;
+        const collectedRecordingPath: string = `${repositoryDirectory}/collected-recording.jfr`;
+
+        const consolidateScript: string =
+          'set -e; ' +
+          `finalized=$(ls -1 ${repositoryDirectory}/*/*.jfr 2>/dev/null | sort | sed '$d'); ` +
+          `if [ -z "$finalized" ]; then echo "${BlockNodeCommand.NO_JFR_MARKER}"; exit 0; fi; ` +
+          `cat $finalized > ${collectedRecordingPath}`;
+
+        let consolidateResult: string;
+        try {
+          consolidateResult = await k8Container.execContainer(['bash', '-c', consolidateScript]);
+        } catch (error) {
+          throw new SoloErrors.component.blockNodeJfrCollectionFailed(error);
+        }
+
+        if (consolidateResult.includes(BlockNodeCommand.NO_JFR_MARKER)) {
+          const reason: string = `no finalized Java Flight Recorder chunk found in ${repositoryDirectory} on block node pod ${podReference.name}; the block node may not have been deployed with Java Flight Recorder enabled, or the recording is still shorter than one chunk`;
+          this.logger.warn(reason);
+          task.skip(`${task.title} ${chalk.yellow('[SKIPPING]')} ${chalk.grey(reason)}`);
+          return;
+        }
+
+        const localJfrLogsDirectory: string = PathEx.join(constants.SOLO_LOGS_DIR, config.deployment);
+        fs.mkdirSync(localJfrLogsDirectory, {recursive: true});
+
+        await k8Container.copyFrom(collectedRecordingPath, localJfrLogsDirectory);
+
+        const downloadedRecordingPath: string = PathEx.join(localJfrLogsDirectory, 'collected-recording.jfr');
+        this.logger.showUser(`Downloaded Java Flight Recorder recording to ${downloadedRecordingPath}`);
+      },
+    };
+  }
+
+  public async collectJfr(argv: ArgvStruct): Promise<boolean> {
+    let lease: Lock;
+
+    const tasks: SoloListr<BlockNodeCollectJfrContext> = this.taskList.newTaskList<BlockNodeCollectJfrContext>(
+      [
+        {
+          title: 'Initialize',
+          task: async (context_, task): Promise<Listr<AnyListrContext>> => {
+            await this.localConfig.load();
+            await this.remoteConfig.loadAndValidate(argv);
+            if (!this.oneShotState.isActive()) {
+              lease = await this.leaseManager.create();
+            }
+
+            this.configManager.update(argv);
+
+            flags.disablePrompts(BlockNodeCommand.COLLECT_JFR_FLAGS_LIST.optional);
+
+            const allFlags: CommandFlag[] = [
+              ...BlockNodeCommand.COLLECT_JFR_FLAGS_LIST.required,
+              ...BlockNodeCommand.COLLECT_JFR_FLAGS_LIST.optional,
+            ];
+
+            await this.configManager.executePrompt(task, allFlags);
+
+            const config: BlockNodeCollectJfrConfigClass = this.configManager.getConfig(
+              BlockNodeCommand.COLLECT_JFR_CONFIGS_NAME,
+              allFlags,
+            ) as BlockNodeCollectJfrConfigClass;
+
+            context_.config = config;
+
+            config.namespace = await this.getNamespace(task);
+            config.clusterRef = this.getClusterReference();
+            config.context = this.getClusterContext(config.clusterRef);
+
+            config.id = this.inferBlockNodeId(config.id);
+
+            await this.throwIfNamespaceIsMissing(config.context, config.namespace);
+
+            if (!this.oneShotState.isActive()) {
+              return ListrLock.newAcquireLockTask(lease, task);
+            }
+            return ListrLock.newSkippedLockTask(task);
+          },
+        },
+        this.downloadBlockNodeJavaFlightRecorderLogs(),
+      ],
+      constants.LISTR_DEFAULT_OPTIONS.DEFAULT,
+      undefined,
+      'block node collect-jfr',
+    );
+
+    if (tasks.isRoot()) {
+      try {
+        await tasks.run();
+      } catch (error) {
+        throw new SoloErrors.component.blockNodeJfrCollectionFailed(error);
       } finally {
         if (!this.oneShotState.isActive()) {
           await lease?.release();

--- a/src/commands/command-definitions/block-command-definition.ts
+++ b/src/commands/command-definitions/block-command-definition.ts
@@ -36,6 +36,7 @@ export class BlockCommandDefinition extends BaseCommandDefinition {
 
   public static readonly NODE_ADD_EXTERNAL: string = 'add-external';
   public static readonly NODE_DELETE_EXTERNAL: string = 'delete-external';
+  public static readonly NODE_COLLECT_JFR: string = 'collect-jfr';
 
   public static readonly ADD_COMMAND: string =
     `${BlockCommandDefinition.COMMAND_NAME} ${BlockCommandDefinition.NODE_SUBCOMMAND_NAME} ${BlockCommandDefinition.NODE_ADD}` as const;
@@ -43,6 +44,8 @@ export class BlockCommandDefinition extends BaseCommandDefinition {
     `${BlockCommandDefinition.COMMAND_NAME} ${BlockCommandDefinition.NODE_SUBCOMMAND_NAME} ${BlockCommandDefinition.NODE_DESTROY}` as const;
   public static readonly UPGRADE_COMMAND: string =
     `${BlockCommandDefinition.COMMAND_NAME} ${BlockCommandDefinition.NODE_SUBCOMMAND_NAME} ${BlockCommandDefinition.NODE_UPGRADE}` as const;
+  public static readonly COLLECT_JFR_COMMAND: string =
+    `${BlockCommandDefinition.COMMAND_NAME} ${BlockCommandDefinition.NODE_SUBCOMMAND_NAME} ${BlockCommandDefinition.NODE_COLLECT_JFR}` as const;
 
   public getCommandDefinition(): CommandDefinition {
     return new CommandBuilder(BlockCommandDefinition.COMMAND_NAME, BlockCommandDefinition.DESCRIPTION, this.logger)
@@ -103,6 +106,18 @@ export class BlockCommandDefinition extends BaseCommandDefinition {
               this.blockNodeCommand,
               this.blockNodeCommand.deleteExternal,
               BlockNodeCommand.DELETE_EXTERNAL_FLAGS_LIST,
+              [...constants.BASE_DEPENDENCIES],
+            ),
+          )
+          .addSubcommand(
+            new Subcommand(
+              BlockCommandDefinition.NODE_COLLECT_JFR,
+              'Downloads the Java Flight Recorder recording from a block node instance in the specified ' +
+                'deployment to the local solo logs directory. Requires the block node to have been deployed ' +
+                'with Java Flight Recorder enabled.',
+              this.blockNodeCommand,
+              this.blockNodeCommand.collectJfr,
+              BlockNodeCommand.COLLECT_JFR_FLAGS_LIST,
               [...constants.BASE_DEPENDENCIES],
             ),
           ),

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -190,6 +190,11 @@ export const BLOCK_NODE_CHART: string = getEnvironmentVariable('BLOCK_NODE_CHART
 export const BLOCK_NODE_RELEASE_NAME: string = 'block-node';
 export const BLOCK_NODE_CONTAINER_NAME: ContainerName = ContainerName.of(BLOCK_NODE_CHART);
 
+// In-pod JFR disk-repository path `solo block node collect-jfr` reads from; mirrors the consensus node's
+// ${HEDERA_HAPI_PATH}/output convention. The overlay's repository path is kept in sync with this constant by
+// block-node-values.test.ts.
+export const BLOCK_NODE_JFR_REPOSITORY_DIRECTORY: string = '/opt/hiero/block-node/output/jfr';
+
 export const NETWORK_LOAD_GENERATOR_CHART: string = 'network-load-generator';
 export const NETWORK_LOAD_GENERATOR_RELEASE_NAME: string = 'network-load-generator';
 export const NETWORK_LOAD_GENERATOR_CHART_URL: string =

--- a/src/core/errors/classes/component/block-node-jfr-collection-failed-solo-error.ts
+++ b/src/core/errors/classes/component/block-node-jfr-collection-failed-solo-error.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {SoloError} from '../../solo-error.js';
+import {ErrorOwnership} from '../../error-ownership.js';
+import {ErrorCodeRegistry} from '../../error-code-registry.js';
+
+/**
+ * @description Thrown when `solo block node collect-jfr` cannot collect the Java Flight Recorder recording from a
+ * block node; the underlying failure is wrapped in `cause`. Retryable, since a transient pod or cluster-API problem
+ * often clears on a later attempt.
+ */
+export class BlockNodeJfrCollectionFailedSoloError extends SoloError {
+  protected override readonly retryable: boolean = true;
+  protected override readonly ownership: ErrorOwnership = ErrorOwnership.Infrastructure;
+
+  public constructor(cause: Error) {
+    super(
+      {
+        message: `Error collecting Java Flight Recorder recording from block node: ${cause.message}`,
+        code: ErrorCodeRegistry.BLOCK_NODE_JFR_COLLECTION_FAILED,
+        troubleshootingSteps:
+          'Check solo logs: tail -n 100 ~/.solo/logs/solo.log\n' +
+          'Inspect block node pods: kubectl get pods -A -l block-node.hiero.com/type=block-node\n' +
+          'Verify the block node was deployed with Java Flight Recorder enabled\n' +
+          'Verify the cluster is reachable: kubectl cluster-info --context <context>',
+      },
+      cause,
+    );
+  }
+}

--- a/src/core/errors/error-code-registry.ts
+++ b/src/core/errors/error-code-registry.ts
@@ -128,6 +128,7 @@ export const ErrorCodeRegistry: Record<string, string> = {
   PREDEFINED_ACCOUNTS_CREATION_FAILED: 'SOLO-3087',
   FILE_CONTENT_MISMATCH: 'SOLO-3088',
   NODE_SERVICE_NOT_FOUND: 'SOLO-3089',
+  BLOCK_NODE_JFR_COLLECTION_FAILED: 'SOLO-3090',
 
   // 4xxx - Validation: User input, flags, IDs, formatting
   MISSING_ARGUMENT: 'SOLO-4001',

--- a/src/core/errors/solo-errors.ts
+++ b/src/core/errors/solo-errors.ts
@@ -38,6 +38,7 @@ import {BlockNodeConfigFailedSoloError} from './classes/component/block-node-con
 import {BlockNodeDeleteExternalFailedSoloError} from './classes/component/block-node-delete-external-failed-solo-error.js';
 import {BlockNodeDeployFailedSoloError} from './classes/component/block-node-deploy-failed-solo-error.js';
 import {BlockNodeDestroyFailedSoloError} from './classes/component/block-node-destroy-failed-solo-error.js';
+import {BlockNodeJfrCollectionFailedSoloError} from './classes/component/block-node-jfr-collection-failed-solo-error.js';
 import {BlockNodeHealthCheckFailedSoloError} from './classes/component/block-node-health-check-failed-solo-error.js';
 import {BlockNodeUpgradeFailedSoloError} from './classes/component/block-node-upgrade-failed-solo-error.js';
 import {ChartInstallFailedSoloError} from './classes/component/chart-install-failed-solo-error.js';
@@ -381,6 +382,7 @@ export class SoloErrors {
     readonly blockNodeConfigFailed: typeof BlockNodeConfigFailedSoloError;
     readonly blockNodeDeployFailed: typeof BlockNodeDeployFailedSoloError;
     readonly blockNodeDestroyFailed: typeof BlockNodeDestroyFailedSoloError;
+    readonly blockNodeJfrCollectionFailed: typeof BlockNodeJfrCollectionFailedSoloError;
     readonly blockNodeUpgradeFailed: typeof BlockNodeUpgradeFailedSoloError;
     readonly blockNodeAddExternalFailed: typeof BlockNodeAddExternalFailedSoloError;
     readonly blockNodeDeleteExternalFailed: typeof BlockNodeDeleteExternalFailedSoloError;
@@ -469,6 +471,7 @@ export class SoloErrors {
     blockNodeConfigFailed: BlockNodeConfigFailedSoloError,
     blockNodeDeployFailed: BlockNodeDeployFailedSoloError,
     blockNodeDestroyFailed: BlockNodeDestroyFailedSoloError,
+    blockNodeJfrCollectionFailed: BlockNodeJfrCollectionFailedSoloError,
     blockNodeUpgradeFailed: BlockNodeUpgradeFailedSoloError,
     blockNodeAddExternalFailed: BlockNodeAddExternalFailedSoloError,
     blockNodeDeleteExternalFailed: BlockNodeDeleteExternalFailedSoloError,

--- a/test/e2e/commands/performance.test.ts
+++ b/test/e2e/commands/performance.test.ts
@@ -17,6 +17,7 @@ import {type BaseTestOptions} from './tests/base-test-options.js';
 import {main} from '../../../src/index.js';
 import {BaseCommandTest} from './tests/base-command-test.js';
 import {OneShotCommandDefinition} from '../../../src/commands/command-definitions/one-shot-command-definition.js';
+import {BlockCommandDefinition} from '../../../src/commands/command-definitions/block-command-definition.js';
 import {MetricsServerImpl} from '../../../src/business/runtime-state/services/metrics-server-impl.js';
 import * as constants from '../../../src/core/constants.js';
 import {sleep} from '../../../src/core/helpers.js';
@@ -105,6 +106,13 @@ const endToEndTestSuite: EndToEndTestSuite = new EndToEndTestSuiteBuilder()
           await main(soloOneShotDeploy(testName, deployment));
           testLogger.info(`${testName}: finished ${testName}: deploy`);
 
+          // Opt-in: deploy a JFR-enabled block node so its JVM metrics are recorded and collected at teardown.
+          if (process.env.PERFORMANCE_TEST_WITH_BLOCK_NODE === 'true') {
+            testLogger.info(`${testName}: beginning ${testName}: block node deploy (JFR enabled)`);
+            await main(soloBlockNodeJfrDeploy(testName, deployment));
+            testLogger.info(`${testName}: finished ${testName}: block node deploy`);
+          }
+
           startTime = new Date();
           metricsInterval = setInterval(async (): Promise<void> => {
             logMetrics(startTime);
@@ -121,8 +129,11 @@ const endToEndTestSuite: EndToEndTestSuite = new EndToEndTestSuiteBuilder()
           const namespace: string = await getNamespaceFromDeployment();
           const tartgetDirectory: string = PathEx.join(constants.SOLO_LOGS_DIR, `${namespace}`);
           const files: string[] = fs.readdirSync(tartgetDirectory);
+          // Only the per-snapshot metric files are JSON. Ignore other artifacts in the logs tree (e.g.
+          // Java Flight Recorder .jfr recordings collected by the teardown) so they don't break parsing.
+          const metricFiles: string[] = files.filter((file: string): boolean => file.endsWith('.json'));
           const allMetrics: Record<string, AggregatedMetrics> = {};
-          for (const file of files) {
+          for (const file of metricFiles) {
             const filePath: string = PathEx.join(tartgetDirectory, file);
             const fileContents: string = fs.readFileSync(filePath, 'utf8');
             const fileName: string = file.split('.')[0];
@@ -163,19 +174,20 @@ const endToEndTestSuite: EndToEndTestSuite = new EndToEndTestSuiteBuilder()
           };
           fs.writeFileSync(PathEx.join(tartgetDirectory, `${namespace}.json`), JSON.stringify(namespaceJson), 'utf8');
 
-          // remove all snapshot files except the representative one
+          // remove all snapshot files except the representative one (only the JSON snapshots; leave other
+          // artifacts such as .jfr recordings in place for collection/upload)
           const filesToKeep: Set<string> = new Set([representativeFileName, aggregatedMetricsFileName]);
-          for (const file of files) {
+          for (const file of metricFiles) {
             if (!filesToKeep.has(file)) {
               fs.rmSync(PathEx.join(tartgetDirectory, file));
             }
           }
 
-          // copy the summary to the main solo logs directory to be accessible by existing scripts
-          fs.copyFileSync(
-            PathEx.join(tartgetDirectory, `${namespace}.json`),
-            PathEx.join(constants.SOLO_LOGS_DIR, `${namespace}.json`),
-          );
+          // copy the summary to the main solo logs directory (guard against a missing summary on disrupted runs)
+          const summaryPath: string = PathEx.join(tartgetDirectory, `${namespace}.json`);
+          if (fs.existsSync(summaryPath)) {
+            fs.copyFileSync(summaryPath, PathEx.join(constants.SOLO_LOGS_DIR, `${namespace}.json`));
+          }
 
           await preDestroy(endToEndTestSuite);
 
@@ -311,6 +323,25 @@ export function soloOneShotDeploy(testName: string, deployment: string): string[
   if (process.env.ONE_SHOT_USE_EDGE === 'true') {
     argv.push(optionFromFlag(Flags.edgeEnabled));
   }
+  return argv;
+}
+
+export function soloBlockNodeJfrDeploy(testName: string, deployment: string): string[] {
+  const {newArgv, argvPushGlobalFlags, optionFromFlag} = BaseCommandTest;
+
+  const argv: string[] = newArgv();
+  argv.push(
+    BlockCommandDefinition.COMMAND_NAME,
+    BlockCommandDefinition.NODE_SUBCOMMAND_NAME,
+    BlockCommandDefinition.NODE_ADD,
+  );
+  argvPushGlobalFlags(argv, testName);
+  argv.push(
+    optionFromFlag(Flags.deployment),
+    deployment,
+    optionFromFlag(Flags.valuesFile),
+    PathEx.joinWithRealPath(constants.RESOURCES_DIR, 'block-node-perf-values.yaml'),
+  );
   return argv;
 }
 

--- a/test/e2e/commands/tests/base-command-test.ts
+++ b/test/e2e/commands/tests/base-command-test.ts
@@ -13,6 +13,8 @@ import {NamespaceName} from '../../../../src/types/namespace/namespace-name.js';
 import {type SoloLogger} from '../../../../src/core/logging/solo-logger.js';
 import {getEnvironmentVariable} from '../../../../src/core/constants.js';
 import {ConsensusCommandDefinition} from '../../../../src/commands/command-definitions/consensus-command-definition.js';
+import {BlockCommandDefinition} from '../../../../src/commands/command-definitions/block-command-definition.js';
+import type BlockNodeCommand from '../../../../src/commands/block-node.js';
 import {Templates} from '../../../../src/core/templates.js';
 import {type NodeAlias} from '../../../../src/types/aliases.js';
 import {PathEx} from '../../../../src/business/utils/path-ex.js';
@@ -112,6 +114,35 @@ export class BaseCommandTest {
     }
   }
 
+  public static async collectBlockNodeJavaFlightRecorderLogs(
+    testName: string,
+    testLogger: SoloLogger,
+    deployment: string,
+  ): Promise<void> {
+    try {
+      testLogger.info(`${testName}: Collecting block node jfr logs...`);
+
+      const argv: Argv = Argv.getDefaultArgv(NamespaceName.of(testName), testName);
+      argv.setArg(Flags.deployment, deployment);
+      argv.setCommand(
+        BlockCommandDefinition.COMMAND_NAME,
+        BlockCommandDefinition.NODE_SUBCOMMAND_NAME,
+        BlockCommandDefinition.NODE_COLLECT_JFR,
+      );
+
+      const blockNodeCommand: BlockNodeCommand = container.resolve<BlockNodeCommand>(InjectTokens.BlockNodeCommand);
+      await blockNodeCommand.collectJfr(argv.build());
+
+      testLogger.info(`${testName}: Block node Java Flight Recorder logs collected successfully`);
+    } catch (error: unknown) {
+      // Best-effort: a run without a JFR-enabled block node should not fail teardown.
+      testLogger.error(`${testName}: Error collecting block node Java Flight Recorder logs: ${error}`);
+      if (error instanceof Error && error.stack) {
+        testLogger.error(`${testName}: Stack trace:\n${error.stack}`);
+      }
+    }
+  }
+
   /**
    * Sets up an after() hook for diagnostic log collection in E2E tests.
    * Call this within your test suite describe block.
@@ -125,15 +156,18 @@ export class BaseCommandTest {
    * Sets up an after() hook for diagnostic log collection in E2E tests.
    * Call this within your test suite describe block.
    */
-  public static setupJavaFlightRecorderLogCollection(options: BaseTestOptions): Promise<void[]> {
+  public static async setupJavaFlightRecorderLogCollection(options: BaseTestOptions): Promise<void> {
     const {testName, testLogger, deployment} = options;
     const promises: Promise<void>[] = [];
     for (let index: number = 0; index < options.consensusNodesCount; index++) {
       const nodeAlias: NodeAlias = Templates.renderNodeAliasFromNumber(index + 1);
       promises.push(BaseCommandTest.collectJavaFlightRecorderLogs(testName, testLogger, deployment, nodeAlias));
     }
+    await Promise.all(promises);
 
-    return Promise.all(promises);
+    if (process.env.PERFORMANCE_TEST_WITH_BLOCK_NODE === 'true') {
+      await BaseCommandTest.collectBlockNodeJavaFlightRecorderLogs(testName, testLogger, deployment);
+    }
   }
 
   public static async runMainAndCaptureOutputToJson(

--- a/test/unit/commands/block-node-values.test.ts
+++ b/test/unit/commands/block-node-values.test.ts
@@ -5,6 +5,7 @@ import {describe, it} from 'mocha';
 import fs from 'node:fs';
 import yaml from 'yaml';
 import * as constants from '../../../src/core/constants.js';
+import {PathEx} from '../../../src/business/utils/path-ex.js';
 
 interface BlockNodePersistenceVolumeConfig {
   size?: string;
@@ -39,6 +40,47 @@ describe('Block node default values', (): void => {
     expect(persistence?.live?.existingClaim, 'live existingClaim must remain unset by default').to.equal(undefined);
     expect(persistence?.logging?.existingClaim, 'logging existingClaim must remain unset by default').to.equal(
       undefined,
+    );
+  });
+});
+
+interface BlockNodePerformanceValuesConfig {
+  blockNode?: {
+    config?: {
+      JAVA_OPTS?: string;
+    };
+  };
+}
+
+describe('Block node performance (JFR) values', (): void => {
+  const performanceValuesFile: string = PathEx.joinWithRealPath(constants.RESOURCES_DIR, 'block-node-perf-values.yaml');
+
+  it('should enable a continuous on-disk Java Flight Recording', (): void => {
+    const valuesContent: string = fs.readFileSync(performanceValuesFile, 'utf8');
+    const parsedValues: BlockNodePerformanceValuesConfig = yaml.parse(
+      valuesContent,
+    ) as BlockNodePerformanceValuesConfig;
+    const javaOptions: string | undefined = parsedValues.blockNode?.config?.JAVA_OPTS;
+
+    expect(javaOptions, 'blockNode.config.JAVA_OPTS should be defined').to.be.a('string');
+    expect(javaOptions, 'JAVA_OPTS should start a flight recording').to.include('-XX:StartFlightRecording=');
+    expect(javaOptions, 'recording should stream to disk').to.include('disk=true');
+    expect(javaOptions, 'recording should dump on JVM exit').to.include('dumponexit=true');
+    expect(javaOptions, 'recording should use the built-in profile settings').to.include('settings=profile');
+    expect(javaOptions, 'chunks should rotate at a bounded size').to.include('maxchunksize=');
+  });
+
+  it('should point the JFR repository at constants.BLOCK_NODE_JFR_REPOSITORY_DIRECTORY', (): void => {
+    const valuesContent: string = fs.readFileSync(performanceValuesFile, 'utf8');
+    const parsedValues: BlockNodePerformanceValuesConfig = yaml.parse(
+      valuesContent,
+    ) as BlockNodePerformanceValuesConfig;
+    const javaOptions: string | undefined = parsedValues.blockNode?.config?.JAVA_OPTS;
+
+    // `solo block node collect-jfr` reads chunks from constants.BLOCK_NODE_JFR_REPOSITORY_DIRECTORY, so the
+    // repository configured in this overlay must match it exactly.
+    expect(javaOptions, 'FlightRecorderOptions repository must match the constant collect-jfr reads from').to.include(
+      `repository=${constants.BLOCK_NODE_JFR_REPOSITORY_DIRECTORY}`,
     );
   });
 });


### PR DESCRIPTION
## Description

This pull request adds the ability to capture **JVM metrics for the Block Node** (heap, GC, threads, allocations) via Java Flight Recorder (JFR), mirroring the existing consensus-node JFR collection (#3386) and adapting it to the Block Node's constraints.

The Block Node image is a JRE (`eclipse-temurin:*-jre-*`), so `jcmd` is not available to dump a recording on demand. Instead:

* A new values overlay, `resources/block-node-perf-values.yaml`, enables JFR on the Block Node JVM — a continuous on-disk recording using the JVM built-in `profile` settings, writing timestamped chunk files to `/opt/hiero/block-node/output/jfr` with a small `maxchunksize` so chunks rotate frequently under load.
* A new command, `solo block node collect-jfr --deployment <name>`, consolidates the **finalized** chunks (excluding the still-open active chunk) into a single readable `.jfr` and downloads it to `~/.solo/logs/<deployment>/collected-recording.jfr`. It is **non-destructive** and can be run **repeatedly during** a performance test (each run captures everything finalized so far, at most one open chunk "behind").
* The e2e performance test can deploy a JFR-enabled Block Node (using the overlay) and collects its recording automatically at teardown alongside the consensus-node JFR collection. The block-node deploy is opt-in via the `PERFORMANCE_TEST_WITH_BLOCK_NODE=true` env var, so default performance runs (and the CI memory budget) are unchanged; the teardown collection is best-effort and no-ops when the block node is absent.

Changes:

* `src/commands/block-node.ts` — `collect-jfr` command, config/context, flags list, and the chunk-consolidation download task.
* `src/commands/command-definitions/block-command-definition.ts` — registers the `block node collect-jfr` subcommand.
* `src/core/constants.ts` — `BLOCK_NODE_JFR_REPOSITORY_DIRECTORY` (in-pod JFR repository path).
* `resources/block-node-perf-values.yaml` — JFR-enabling values overlay (new).
* `test/unit/commands/block-node-values.test.ts` — unit tests for the JFR overlay (recording enabled + repository path matches the constant `collect-jfr` reads from).
* `test/e2e/commands/tests/base-command-test.ts` — collects the Block Node JFR recording during performance-test teardown.
* `test/e2e/commands/performance.test.ts` — optionally deploys a JFR-enabled Block Node (opt-in via `PERFORMANCE_TEST_WITH_BLOCK_NODE`); also hardens the metrics aggregation to parse only `.json` snapshot files so `.jfr` recordings in the logs tree don't break it.
* `.github/workflows/flow-performance-test.yaml` — uploads the collected `.jfr` recordings as a dedicated CI artifact (`solo-performance-test-jfr`).


### Related Issues

* Closes #3512

### Pull request (PR) checklist

* [x] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [x] Any technical debt has been documented as a separate issue and linked to this PR
* [x] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [x] This PR added unit tests
* [x] This PR added integration/end-to-end tests
* [x] These changes required manual testing that is documented below
* [x] Anything not tested is documented

Automated tests added:

* Unit tests (`test/unit/commands/block-node-values.test.ts`) asserting the JFR overlay enables a continuous on-disk recording and that its repository path matches `constants.BLOCK_NODE_JFR_REPOSITORY_DIRECTORY` (the path `collect-jfr` reads from).
* E2E performance-test teardown now invokes Block Node JFR collection (`test/e2e/commands/tests/base-command-test.ts`).

The following manual testing was done (against a local Kind cluster, JFR validated with the OpenJDK `jfr` CLI):

* Deployed a Block Node with the JFR overlay (`solo block node add -d <dep> --values-file resources/block-node-perf-values.yaml`) and confirmed the JVM starts cleanly and JFR begins recording to `/opt/hiero/block-node/output/jfr`.
* Confirmed chunks rotate/finalize during the run.
* Ran `solo block node collect-jfr -d <dep>` and confirmed it downloads a single recording to `~/.solo/logs/<dep>/collected-recording.jfr`.
* Verified the downloaded recording opens in the `jfr` CLI (`jfr summary`/`jfr print`) and contains the expected JVM events: `jdk.GCHeapSummary` (heap used/committed), `jdk.GarbageCollection`/`jdk.YoungGarbageCollection` (GC pauses), `jdk.JavaThreadStatistics`/`jdk.ThreadCPULoad` (threads/CPU), `jdk.ObjectAllocationSample` (allocations).
* Verified the still-open active chunk is excluded so the output is never in a "locked stream" state, and that `collect-jfr` skips gracefully (clear message) when no finalized chunk exists yet or JFR was not enabled.

* The collected `.jfr` is uploaded from CI performance runs as the `solo-performance-test-jfr` artifact.
