### PR TITLE
fix: increase relay memory for one-shot timing

### DIFF
--- a/resources/relay-values.yaml
+++ b/resources/relay-values.yaml
@@ -27,7 +27,7 @@ relay:
       memory: 350Mi
     limits:
       cpu: 500m
-      memory: 350Mi
+      memory: 700Mi
 ws:
   config:
     WORKERS_POOL_ENABLED: false

--- a/resources/relay-values.yaml
+++ b/resources/relay-values.yaml
@@ -24,10 +24,10 @@ relay:
   resources:
     requests:
       cpu: 0
-      memory: 0
+      memory: 350Mi
     limits:
       cpu: 500m
-      memory: 250Mi
+      memory: 350Mi
 ws:
   config:
     WORKERS_POOL_ENABLED: false


### PR DESCRIPTION
## Summary
- Increase the default HTTP relay memory request from `0` to `350Mi`.
- Increase the default HTTP relay memory limit from `250Mi` to `700Mi`.

## Root Cause
The One-Shot Timing workflow failure in https://github.com/hiero-ledger/solo/actions/runs/28038802362/job/82999317871 occurred while deploying `relay-1`. Diagnostics showed the relay pod existed but never passed `/health/readiness`; the container had restarted and the prior state exited with code `137`, consistent with memory pressure under the existing `250Mi` HTTP relay cap.

The websocket relay values already use a larger memory envelope. This change gives the HTTP relay the same request/limit profile so the default one-shot timing path can keep parallel deploy enabled without starving relay startup.

Closes #4801

## Validation
- `task format` completed with existing lint warnings and no errors.
- Parsed `resources/relay-values.yaml` with the repo's YAML parser dependency.
- Inspected the final branch diff against `origin/main`; it is scoped to `resources/relay-values.yaml`.
