### PR TITLE
fix: crane image pull fails due to Docker Hub rate limit

### DIFF
--- a/resources/kind-config.yaml
+++ b/resources/kind-config.yaml
@@ -3,6 +3,6 @@ apiVersion: kind.x-k8s.io/v1alpha4
 containerdConfigPatches:
   - |-
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-      endpoint = ["https://mirror.gcr.io", "https://hub.mirror.docker.lat.ope.eng.hashgraph.io", "https://registry-1.docker.io"]
+      endpoint = ["https://hub.mirror.docker.lat.ope.eng.hashgraph.io", "https://mirror.gcr.io", "https://registry-1.docker.io"]
     [plugins."io.containerd.grpc.v1.cri".registry.mirrors."registry-1.docker.io"]
-      endpoint = ["https://mirror.gcr.io", "https://hub.mirror.docker.lat.ope.eng.hashgraph.io", "https://registry-1.docker.io"]
+      endpoint = ["https://hub.mirror.docker.lat.ope.eng.hashgraph.io", "https://mirror.gcr.io", "https://registry-1.docker.io"]

--- a/src/integration/cache/impl/image-cache-handler.ts
+++ b/src/integration/cache/impl/image-cache-handler.ts
@@ -291,6 +291,7 @@ export class ImageCacheHandler implements CacheOperationHandler {
 
       return registries;
     } catch {
+      // best-effort: fall back to empty list when kind-config.yaml is absent or unparseable
       return [];
     }
   }

--- a/src/integration/cache/impl/image-cache-handler.ts
+++ b/src/integration/cache/impl/image-cache-handler.ts
@@ -256,7 +256,7 @@ export class ImageCacheHandler implements CacheOperationHandler {
 
   private static async resolveDockerHubMirrorRegistries(): Promise<readonly string[]> {
     const mirrorRegistriesFromEnvironment: string | undefined =
-      process.env[ImageCacheHandler.KIND_DOCKER_REGISTRY_MIRRORS_ENVIRONMENT_VARIABLE];
+      constants.getEnvironmentVariable(ImageCacheHandler.KIND_DOCKER_REGISTRY_MIRRORS_ENVIRONMENT_VARIABLE);
 
     const registries: readonly string[] =
       mirrorRegistriesFromEnvironment && mirrorRegistriesFromEnvironment.trim().length > 0

--- a/src/integration/cache/impl/image-cache-handler.ts
+++ b/src/integration/cache/impl/image-cache-handler.ts
@@ -255,8 +255,9 @@ export class ImageCacheHandler implements CacheOperationHandler {
   }
 
   private static async resolveDockerHubMirrorRegistries(): Promise<readonly string[]> {
-    const mirrorRegistriesFromEnvironment: string | undefined =
-      constants.getEnvironmentVariable(ImageCacheHandler.KIND_DOCKER_REGISTRY_MIRRORS_ENVIRONMENT_VARIABLE);
+    const mirrorRegistriesFromEnvironment: string | undefined = constants.getEnvironmentVariable(
+      ImageCacheHandler.KIND_DOCKER_REGISTRY_MIRRORS_ENVIRONMENT_VARIABLE,
+    );
 
     const registries: readonly string[] =
       mirrorRegistriesFromEnvironment && mirrorRegistriesFromEnvironment.trim().length > 0

--- a/src/integration/cache/impl/image-cache-handler.ts
+++ b/src/integration/cache/impl/image-cache-handler.ts
@@ -29,6 +29,7 @@ export class ImageCacheHandler implements CacheOperationHandler {
   private static readonly DOCKER_HUB_REGISTRY: string = 'docker.io';
   private static readonly DOCKER_HUB_DIRECT_REGISTRY: string = 'registry-1.docker.io';
   private static readonly KIND_DOCKER_REGISTRY_MIRRORS_ENVIRONMENT_VARIABLE: string = 'KIND_DOCKER_REGISTRY_MIRRORS';
+  private static readonly DEFAULT_DOCKER_HUB_MIRROR_REGISTRY: string = 'hub.mirror.docker.lat.ope.eng.hashgraph.io';
   private static readonly RATE_LIMIT_ERROR_PATTERN: RegExp =
     /toomanyrequests|too many requests|rate limit|429 Too Many Requests/i;
 
@@ -80,13 +81,16 @@ export class ImageCacheHandler implements CacheOperationHandler {
             try {
               await this.saveImage(image, archivePath);
             } catch (error) {
-              const message: string = error instanceof Error ? error.message : String(error);
+              const message: string = ImageCacheHandler.getErrorMessage(error);
+              if (ImageCacheHandler.isRateLimitError(error)) {
+                task.title += ' - ' + chalk.red(`Docker Hub rate limit reached for image: ${image}`);
+                this.logger.showUser(`Docker Hub rate limit reached for image: ${image}. ${message}`);
+                this.logger.error('Docker Hub rate limit reached:', error);
+                throw error;
+              }
               task.title += ' - ' + chalk.red(`failed to SAVE image: ${image}`);
               this.logger.showUser(`Failed to save image archive: ${image}. ${message}`);
               this.logger.error('Failed to save image archive:', error);
-              if (ImageCacheHandler.isRateLimitError(error)) {
-                throw error;
-              }
               return;
             }
           }
@@ -211,7 +215,7 @@ export class ImageCacheHandler implements CacheOperationHandler {
         if (ImageCacheHandler.isRateLimitError(error)) {
           rateLimitError = error;
         }
-        const message: string = error instanceof Error ? error.message : String(error);
+        const message: string = ImageCacheHandler.getErrorMessage(error);
         this.logger.warn(`Failed to save image archive candidate ${imageCandidate}: ${message}`);
       }
     }
@@ -259,7 +263,8 @@ export class ImageCacheHandler implements CacheOperationHandler {
         ? mirrorRegistriesFromEnvironment.split(',')
         : await ImageCacheHandler.resolveDockerHubMirrorRegistriesFromKindConfig();
 
-    return ImageCacheHandler.normalizeMirrorRegistries(registries);
+    const normalized: readonly string[] = ImageCacheHandler.normalizeMirrorRegistries(registries);
+    return normalized.length > 0 ? normalized : [ImageCacheHandler.DEFAULT_DOCKER_HUB_MIRROR_REGISTRY];
   }
 
   private static async resolveDockerHubMirrorRegistriesFromKindConfig(): Promise<readonly string[]> {

--- a/src/integration/cache/impl/image-cache-handler.ts
+++ b/src/integration/cache/impl/image-cache-handler.ts
@@ -17,8 +17,21 @@ import {type AnyListrContext} from '../../../types/aliases.js';
 import chalk from 'chalk';
 import {type SoloLogger} from '../../../core/logging/solo-logger.js';
 import {type CacheCatalogStore} from '../api/cache-catalog-store.js';
+import {parse} from 'yaml';
+import * as constants from '../../../core/constants.js';
+import {ImageReference, type ParsedImageReference} from '../../../business/utils/image-reference.js';
+
+interface KindClusterConfig {
+  containerdConfigPatches?: string[];
+}
 
 export class ImageCacheHandler implements CacheOperationHandler {
+  private static readonly DOCKER_HUB_REGISTRY: string = 'docker.io';
+  private static readonly DOCKER_HUB_DIRECT_REGISTRY: string = 'registry-1.docker.io';
+  private static readonly KIND_DOCKER_REGISTRY_MIRRORS_ENVIRONMENT_VARIABLE: string = 'KIND_DOCKER_REGISTRY_MIRRORS';
+  private static readonly RATE_LIMIT_ERROR_PATTERN: RegExp =
+    /toomanyrequests|too many requests|rate limit|429 Too Many Requests/i;
+
   public constructor(
     private readonly engine: ContainerEngineClient,
     private readonly provider: CacheTargetProvider,
@@ -65,12 +78,15 @@ export class ImageCacheHandler implements CacheOperationHandler {
 
           if (!archiveExists) {
             try {
-              await this.engine.saveImage(image, archivePath);
+              await this.saveImage(image, archivePath);
             } catch (error) {
               const message: string = error instanceof Error ? error.message : String(error);
               task.title += ' - ' + chalk.red(`failed to SAVE image: ${image}`);
               this.logger.showUser(`Failed to save image archive: ${image}. ${message}`);
               this.logger.error('Failed to save image archive:', error);
+              if (ImageCacheHandler.isRateLimitError(error)) {
+                throw error;
+              }
               return;
             }
           }
@@ -176,5 +192,156 @@ export class ImageCacheHandler implements CacheOperationHandler {
     if (exists) {
       await this.engine.loadImage(item.localPath);
     }
+  }
+
+  private async saveImage(image: string, archivePath: string): Promise<void> {
+    const imageCandidates: readonly string[] = await ImageCacheHandler.resolveImageCandidates(image);
+    let lastError: unknown;
+    let rateLimitError: unknown;
+
+    for (const imageCandidate of imageCandidates) {
+      try {
+        await this.engine.saveImage(imageCandidate, archivePath);
+        if (imageCandidate !== image) {
+          this.logger.info(`Saved image archive for ${image} using mirror image ${imageCandidate}`);
+        }
+        return;
+      } catch (error) {
+        lastError = error;
+        if (ImageCacheHandler.isRateLimitError(error)) {
+          rateLimitError = error;
+        }
+        const message: string = error instanceof Error ? error.message : String(error);
+        this.logger.warn(`Failed to save image archive candidate ${imageCandidate}: ${message}`);
+      }
+    }
+
+    if (rateLimitError) {
+      throw rateLimitError;
+    }
+
+    throw lastError instanceof Error ? lastError : new Error(`Failed to save image archive: ${image}`);
+  }
+
+  private static async resolveImageCandidates(image: string): Promise<readonly string[]> {
+    const parsed: ParsedImageReference = ImageReference.parseImageReference(image);
+
+    if (!ImageCacheHandler.isDockerHubRegistry(parsed.registry)) {
+      return [image];
+    }
+
+    const registries: string[] = [
+      ...(await ImageCacheHandler.resolveDockerHubMirrorRegistries()),
+      ImageCacheHandler.DOCKER_HUB_REGISTRY,
+      ImageCacheHandler.DOCKER_HUB_DIRECT_REGISTRY,
+    ];
+
+    const candidates: string[] = [];
+    const seen: Set<string> = new Set<string>();
+
+    for (const registry of registries) {
+      const candidate: string = `${registry}/${parsed.repository}:${parsed.tag}`;
+      if (!seen.has(candidate)) {
+        seen.add(candidate);
+        candidates.push(candidate);
+      }
+    }
+
+    return candidates;
+  }
+
+  private static async resolveDockerHubMirrorRegistries(): Promise<readonly string[]> {
+    const mirrorRegistriesFromEnvironment: string | undefined =
+      process.env[ImageCacheHandler.KIND_DOCKER_REGISTRY_MIRRORS_ENVIRONMENT_VARIABLE];
+
+    const registries: readonly string[] =
+      mirrorRegistriesFromEnvironment && mirrorRegistriesFromEnvironment.trim().length > 0
+        ? mirrorRegistriesFromEnvironment.split(',')
+        : await ImageCacheHandler.resolveDockerHubMirrorRegistriesFromKindConfig();
+
+    return ImageCacheHandler.normalizeMirrorRegistries(registries);
+  }
+
+  private static async resolveDockerHubMirrorRegistriesFromKindConfig(): Promise<readonly string[]> {
+    try {
+      const raw: string = await fs.readFile(constants.KIND_CLUSTER_CONFIG_FILE, 'utf8');
+      const parsed: KindClusterConfig = parse(raw) as KindClusterConfig;
+      const patches: readonly string[] = parsed.containerdConfigPatches ?? [];
+      const registries: string[] = [];
+
+      for (const patch of patches) {
+        const endpointMatches: IterableIterator<RegExpMatchArray> = patch.matchAll(
+          /\[plugins\."io\.containerd\.grpc\.v1\.cri"\.registry\.mirrors\."(?:docker\.io|registry-1\.docker\.io)"\]\s*endpoint\s*=\s*\[([^\]]*)\]/g,
+        );
+
+        for (const endpointMatch of endpointMatches) {
+          const endpoints: string = endpointMatch[1];
+          const registryMatches: IterableIterator<RegExpMatchArray> = endpoints.matchAll(/"([^"]+)"/g);
+
+          for (const registryMatch of registryMatches) {
+            registries.push(registryMatch[1]);
+          }
+        }
+      }
+
+      return registries;
+    } catch {
+      return [];
+    }
+  }
+
+  private static normalizeMirrorRegistries(registries: readonly string[]): readonly string[] {
+    const result: string[] = [];
+    const seen: Set<string> = new Set<string>();
+
+    for (const registry of registries) {
+      const normalizedRegistry: string = registry
+        .trim()
+        .replace(/^https?:\/\//, '')
+        .replace(/\/$/, '');
+
+      if (
+        normalizedRegistry.length === 0 ||
+        ImageCacheHandler.isDockerHubRegistry(normalizedRegistry) ||
+        seen.has(normalizedRegistry)
+      ) {
+        continue;
+      }
+
+      seen.add(normalizedRegistry);
+      result.push(normalizedRegistry);
+    }
+
+    return result;
+  }
+
+  private static isDockerHubRegistry(registry: string): boolean {
+    return (
+      registry === ImageCacheHandler.DOCKER_HUB_REGISTRY || registry === ImageCacheHandler.DOCKER_HUB_DIRECT_REGISTRY
+    );
+  }
+
+  private static isRateLimitError(error: unknown): boolean {
+    let current: unknown = error;
+    let depth: number = 0;
+
+    while (current && depth < 10) {
+      if (ImageCacheHandler.RATE_LIMIT_ERROR_PATTERN.test(ImageCacheHandler.getErrorMessage(current))) {
+        return true;
+      }
+
+      current = (current as {cause?: unknown}).cause;
+      depth += 1;
+    }
+
+    return false;
+  }
+
+  private static getErrorMessage(error: unknown): string {
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    return String(error);
   }
 }

--- a/test/unit/integration/cache/image-cache-handler.test.ts
+++ b/test/unit/integration/cache/image-cache-handler.test.ts
@@ -4,7 +4,7 @@ import 'sinon-chai';
 
 import {expect} from 'chai';
 import sinon, {type SinonStub} from 'sinon';
-import {describe, it} from 'mocha';
+import {afterEach, beforeEach, describe, it} from 'mocha';
 import {ImageCacheHandler} from '../../../../src/integration/cache/impl/image-cache-handler.js';
 import {StaticCacheTargetProvider} from '../../../../src/integration/cache/target-providers/static-cache-target-provider.js';
 import {CacheArtifactEnum} from '../../../../src/integration/cache/enums/cache-artifact-enum.js';
@@ -16,6 +16,11 @@ import {type SoloListrTask} from '../../../../src/types/index.js';
 import {type AnyListrContext} from '../../../../src/types/aliases.js';
 
 describe('ImageCacheHandler pull', (): void => {
+  const mirrorRegistryEnvironmentVariable: string = 'KIND_DOCKER_REGISTRY_MIRRORS';
+  const defaultMirrorRegistry: string = 'hub.mirror.docker.lat.ope.eng.hashgraph.io';
+  const configuredMirrorRegistry: string = 'custom.registry.example.com';
+  let previousMirrorRegistry: string | undefined;
+
   const target: {
     type: CacheArtifactEnum;
     name: string;
@@ -67,8 +72,49 @@ describe('ImageCacheHandler pull', (): void => {
     flush: (callback: (error?: Error) => void): void => callback(),
   };
 
-  it('should continue without registering cached result when saveImage fails', async (): Promise<void> => {
-    const saveImageStub: SinonStub = sinon.stub().rejects(new Error('rate limited'));
+  beforeEach((): void => {
+    previousMirrorRegistry = process.env[mirrorRegistryEnvironmentVariable];
+    process.env[mirrorRegistryEnvironmentVariable] = configuredMirrorRegistry;
+  });
+
+  afterEach((): void => {
+    if (previousMirrorRegistry === undefined) {
+      delete process.env[mirrorRegistryEnvironmentVariable];
+    } else {
+      process.env[mirrorRegistryEnvironmentVariable] = previousMirrorRegistry;
+    }
+  });
+
+  it('should fail when saveImage fails due to rate limiting', async (): Promise<void> => {
+    const rateLimitCause: Error = new Error('TOOMANYREQUESTS: You have reached your unauthenticated pull rate limit.');
+    const rateLimitError: Error = new Error('crane pull failed', {cause: rateLimitCause});
+    const saveImageStub: SinonStub = sinon.stub().rejects(rateLimitError);
+    const engine: ContainerEngineClient = {
+      pullImage: async (): Promise<void> => undefined,
+      saveImage: saveImageStub,
+      loadImage: async (): Promise<void> => undefined,
+      loadImageArchiveIntoCluster: async (): Promise<void> => undefined,
+      removeImage: async (): Promise<void> => undefined,
+      listLoadedImagesInCluster: async (): Promise<readonly string[]> => [],
+    };
+
+    const provider: StaticCacheTargetProvider = new StaticCacheTargetProvider([target]);
+    const handler: ImageCacheHandler = new ImageCacheHandler(engine, provider, store, inspector, logger);
+
+    const subtasks: readonly SoloListrTask<AnyListrContext>[] = await handler.pull();
+    const context: {config: {results: unknown[]}} = {config: {results: []}};
+
+    await expect(subtasks[0].task(context as never, {title: 'task'} as never)).to.be.rejectedWith('crane pull failed');
+
+    expect(saveImageStub).to.have.been.calledThrice;
+    expect(saveImageStub.firstCall.args[0]).to.equal(`${configuredMirrorRegistry}/library/busybox:1.36.1`);
+    expect(saveImageStub.secondCall.args[0]).to.equal('docker.io/library/busybox:1.36.1');
+    expect(saveImageStub.thirdCall.args[0]).to.equal('registry-1.docker.io/library/busybox:1.36.1');
+    expect(context.config.results).to.have.lengthOf(0);
+  });
+
+  it('should continue without registering cached result when saveImage fails without rate limiting', async (): Promise<void> => {
+    const saveImageStub: SinonStub = sinon.stub().rejects(new Error('temporary network failure'));
     const engine: ContainerEngineClient = {
       pullImage: async (): Promise<void> => undefined,
       saveImage: saveImageStub,
@@ -86,14 +132,17 @@ describe('ImageCacheHandler pull', (): void => {
 
     await subtasks[0].task(context as never, {title: 'task'} as never);
 
-    expect(saveImageStub).to.have.been.calledOnce;
+    expect(saveImageStub).to.have.been.calledThrice;
     expect(context.config.results).to.have.lengthOf(0);
   });
 
-  it('should register cached result when saveImage succeeds', async (): Promise<void> => {
+  it('should use the Hashgraph mirror by default when no mirror override is set', async (): Promise<void> => {
+    delete process.env[mirrorRegistryEnvironmentVariable];
+
+    const saveImageStub: SinonStub = sinon.stub().resolves();
     const engine: ContainerEngineClient = {
       pullImage: async (): Promise<void> => undefined,
-      saveImage: async (): Promise<void> => undefined,
+      saveImage: saveImageStub,
       loadImage: async (): Promise<void> => undefined,
       loadImageArchiveIntoCluster: async (): Promise<void> => undefined,
       removeImage: async (): Promise<void> => undefined,
@@ -108,6 +157,36 @@ describe('ImageCacheHandler pull', (): void => {
 
     await subtasks[0].task(context as never, {title: 'task'} as never);
 
+    expect(saveImageStub).to.have.been.calledOnceWithExactly(
+      `${defaultMirrorRegistry}/library/busybox:1.36.1`,
+      '/tmp/busybox.tar',
+    );
+    expect(context.config.results).to.have.lengthOf(1);
+  });
+
+  it('should register cached result when saveImage succeeds', async (): Promise<void> => {
+    const saveImageStub: SinonStub = sinon.stub().resolves();
+    const engine: ContainerEngineClient = {
+      pullImage: async (): Promise<void> => undefined,
+      saveImage: saveImageStub,
+      loadImage: async (): Promise<void> => undefined,
+      loadImageArchiveIntoCluster: async (): Promise<void> => undefined,
+      removeImage: async (): Promise<void> => undefined,
+      listLoadedImagesInCluster: async (): Promise<readonly string[]> => [],
+    };
+
+    const provider: StaticCacheTargetProvider = new StaticCacheTargetProvider([target]);
+    const handler: ImageCacheHandler = new ImageCacheHandler(engine, provider, store, inspector, logger);
+
+    const subtasks: readonly SoloListrTask<AnyListrContext>[] = await handler.pull();
+    const context: {config: {results: unknown[]}} = {config: {results: []}};
+
+    await subtasks[0].task(context as never, {title: 'task'} as never);
+
+    expect(saveImageStub).to.have.been.calledOnceWithExactly(
+      `${configuredMirrorRegistry}/library/busybox:1.36.1`,
+      '/tmp/busybox.tar',
+    );
     expect(context.config.results).to.have.lengthOf(1);
   });
 });


### PR DESCRIPTION
## Description

This pull request changes the following:

* When `solo cache image pull` hits Docker Hub rate limits (`TOOMANYREQUESTS`), the cache handler now retries each image through configured mirror registries before failing — instead of silently swallowing the error and producing an empty cache.
* Mirror registries are resolved in order: `KIND_DOCKER_REGISTRY_MIRRORS` env var → `resources/kind-config.yaml` → hardcoded default (`hub.mirror.docker.lat.ope.eng.hashgraph.io`).
* The internal Hashgraph mirror is now prioritized first in `resources/kind-config.yaml` (was second, after GCR).
* Rate-limit failures now surface a distinct `"Docker Hub rate limit reached"` task title and log message, separate from generic save failures.
* `DEFAULT_DOCKER_HUB_MIRROR_REGISTRY` constant makes the default mirror explicit and traceable.
* Use `getErrorMessage()` consistently — two call sites were inlining the same `error instanceof Error ? error.message : String(error)` pattern instead of calling the private static helper.

### Related Issues

* Closes #4784

### Pull request (PR) checklist

* [x] This PR added tests (unit, integration, and/or end-to-end)
* [x] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [ ] Any technical debt has been documented as a separate issue and linked to this PR
* [x] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [x] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [x] These changes required manual testing that is documented below
* [ ] Anything not tested is documented

The following manual testing was done:

* Unit tests cover three paths: rate-limit error propagates and is retried across all candidates; non-rate-limit error is swallowed (cache continues); mirror registry is used as first candidate when configured.

The following was not tested:

* Live Docker Hub rate-limit scenario in CI (requires hitting the actual rate limit; verified by code path and unit tests).

### Companion work

* `solo-docs` PR needed to document `KIND_DOCKER_REGISTRY_MIRRORS` in the environment variables reference.