### PR TITLE
fix: update Solo chart and S6 node image versions to 0.64.0 and 0.46.0 respectively

### DIFF
--- a/src/business/utils/semantic-version.ts
+++ b/src/business/utils/semantic-version.ts
@@ -408,13 +408,15 @@ export class SemanticVersion<T extends string | number> {
    * @param versionString - The version string to validate
    * @param isNeedPrefix - If true, adds 'v' prefix if missing; if false, removes 'v' prefix if present
    * @param label - Label to use in error messages (e.g., 'Release tag', 'SemanticVersion')
+   * @param minimumVersion - Optional minimum version; throws if versionString is below it
    * @returns The processed version string with proper prefix handling
-   * @throws SoloError or IllegalArgumentError if the version string is invalid
+   * @throws SoloError or IllegalArgumentError if the version string is invalid or below minimum
    */
   public static getValidSemanticVersion(
     versionString: string,
     isNeedPrefix: boolean = false,
     label: string = 'SemanticVersion',
+    minimumVersion?: string,
   ): string {
     if (!versionString) {
       throw new SoloErrors.validation.illegalArgument(`${label} cannot be empty`);
@@ -426,6 +428,16 @@ export class SemanticVersion<T extends string | number> {
     }
 
     const value: SemanticVersion<string> = new SemanticVersion<string>(versionString);
+
+    if (minimumVersion !== undefined) {
+      const minimum: SemanticVersion<string> = new SemanticVersion<string>(minimumVersion);
+      if (value.lessThan(minimum)) {
+        throw new IllegalArgumentError(
+          `${label} ${versionString} is below the minimum supported version ${minimumVersion}`,
+          versionString,
+        );
+      }
+    }
 
     return isNeedPrefix ? value.toPrefixedString() : value.toString();
   }

--- a/src/commands/explorer.ts
+++ b/src/commands/explorer.ts
@@ -25,7 +25,7 @@ import {type ClusterChecks} from '../core/cluster-checks.js';
 import {inject, injectable} from 'tsyringe-neo';
 import {InjectTokens} from '../core/dependency-injection/inject-tokens.js';
 import {KeyManager} from '../core/key-manager.js';
-import {INGRESS_CONTROLLER_VERSION} from '../../version.js';
+import {INGRESS_CONTROLLER_VERSION, MINIMUM_SOLO_CHART_VERSION} from '../../version.js';
 import {patchInject} from '../core/dependency-injection/container-helper.js';
 import {ComponentTypes} from '../core/config/remote/enumerations/component-types.js';
 import {Lock} from '../core/lock/lock.js';
@@ -301,6 +301,7 @@ export class ExplorerCommand extends BaseCommand {
           config.soloChartVersion,
           false,
           'Solo chart version',
+          MINIMUM_SOLO_CHART_VERSION,
         );
 
         const {soloChartVersion} = config;

--- a/src/commands/mirror-node.ts
+++ b/src/commands/mirror-node.ts
@@ -1337,6 +1337,7 @@ export class MirrorNodeCommand extends BaseCommand {
               context_.config.soloChartVersion,
               false,
               'Solo chart version',
+              versions.MINIMUM_SOLO_CHART_VERSION,
             );
 
             // predefined values first
@@ -1596,6 +1597,7 @@ export class MirrorNodeCommand extends BaseCommand {
               context_.config.soloChartVersion,
               false,
               'Solo chart version',
+              versions.MINIMUM_SOLO_CHART_VERSION,
             );
 
             const useMirrorNodeLegacyReleaseName: boolean = process.env.USE_MIRROR_NODE_LEGACY_RELEASE_NAME === 'true';

--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -1581,6 +1581,7 @@ export class NetworkCommand extends BaseCommand {
                 config.soloChartVersion,
                 false,
                 'Solo chart version',
+                versions.MINIMUM_SOLO_CHART_VERSION,
               );
 
               await this.chartManager.upgrade(

--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -711,13 +711,6 @@ export class NetworkCommand extends BaseCommand {
 
       const nodePath: string = `hedera.nodes[${nodeIndex}]`;
       chartValuesMap[consensusNode.cluster].setLiteral(`${nodePath}.name`, consensusNode.name);
-      this.addRootImageValues(
-        chartValuesMap[consensusNode.cluster],
-        nodePath,
-        constants.S6_NODE_IMAGE_REGISTRY,
-        constants.S6_NODE_IMAGE_REPOSITORY,
-        versions.S6_NODE_IMAGE_VERSION,
-      );
     }
 
     for (const clusterReference of clusterReferences) {
@@ -787,27 +780,6 @@ export class NetworkCommand extends BaseCommand {
         }
       }
     }
-  }
-
-  /**
-   * Append root.image registry/repository/tag settings for a given node path to Helm chart values.
-   * @param chartValues - existing chart values
-   * @param nodePath - base node path, e.g. `hedera.nodes[0]`
-   * @param registry - image registry
-   * @param repository - image repository
-   * @param tag - image tag
-   */
-  private addRootImageValues(
-    chartValues: HelmChartValues,
-    nodePath: string,
-    registry: string,
-    repository: string,
-    tag: string,
-  ): void {
-    chartValues
-      .setLiteral(`${nodePath}.root.image.registry`, registry)
-      .setLiteral(`${nodePath}.root.image.tag`, tag)
-      .setLiteral(`${nodePath}.root.image.repository`, repository);
   }
 
   /**

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -66,7 +66,11 @@ import {
 } from '../../core/helpers.js';
 import chalk from 'chalk';
 import {Flags as flags} from '../flags.js';
-import {HEDERA_PLATFORM_VERSION, needsConfigTxtForConsensusVersion} from '../../../version.js';
+import {
+  HEDERA_PLATFORM_VERSION,
+  MINIMUM_SOLO_CHART_VERSION,
+  needsConfigTxtForConsensusVersion,
+} from '../../../version.js';
 import {ListrInquirerPromptAdapter} from '@listr2/prompt-adapter-inquirer';
 import {confirm as confirmPrompt} from '@inquirer/prompts';
 import {type SoloLogger} from '../../core/logging/solo-logger.js';
@@ -2589,6 +2593,7 @@ export class NodeCommandTasks {
                     config.soloChartVersion,
                     false,
                     'Solo chart version',
+                    MINIMUM_SOLO_CHART_VERSION,
                   );
 
                   await this.chartManager.upgrade(
@@ -3665,6 +3670,7 @@ export class NodeCommandTasks {
               config.soloChartVersion,
               false,
               'Solo chart version',
+              MINIMUM_SOLO_CHART_VERSION,
             );
             const chartValues: HelmChartValues = extraEnvironmentChartValuesMap[clusterReference]
               .clone()

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -66,7 +66,6 @@ import {
 } from '../../core/helpers.js';
 import chalk from 'chalk';
 import {Flags as flags} from '../flags.js';
-import * as versions from '../../../version.js';
 import {HEDERA_PLATFORM_VERSION, needsConfigTxtForConsensusVersion} from '../../../version.js';
 import {ListrInquirerPromptAdapter} from '@listr2/prompt-adapter-inquirer';
 import {confirm as confirmPrompt} from '@inquirer/prompts';
@@ -3815,13 +3814,6 @@ export class NodeCommandTasks {
           .set(`hedera.nodes[${index}].nodeId`, consensusNode.nodeId);
       }
 
-      this.addRootImageValues(
-        chartValues,
-        `hedera.nodes[${index}]`,
-        constants.S6_NODE_IMAGE_REGISTRY,
-        constants.S6_NODE_IMAGE_REPOSITORY,
-        versions.S6_NODE_IMAGE_VERSION,
-      );
       // TSS wraps extraEnv is handled via generateExtraEnvironmentValuesFile()
     }
   }
@@ -3859,14 +3851,6 @@ export class NodeCommandTasks {
         .set(`hedera.nodes[${index}].accountId`, serviceMap.get(node.name).accountId)
         .set(`hedera.nodes[${index}].name`, node.name)
         .set(`hedera.nodes[${index}].nodeId`, node.nodeId);
-
-      this.addRootImageValues(
-        chartValues,
-        `hedera.nodes[${index}]`,
-        constants.S6_NODE_IMAGE_REGISTRY,
-        constants.S6_NODE_IMAGE_REPOSITORY,
-        versions.S6_NODE_IMAGE_VERSION,
-      );
     }
 
     // Add new node
@@ -3876,14 +3860,6 @@ export class NodeCommandTasks {
       .set(`hedera.nodes[${index}].accountId`, newNode.accountId)
       .set(`hedera.nodes[${index}].name`, newNode.name)
       .set(`hedera.nodes[${index}].nodeId`, nodeId);
-
-    this.addRootImageValues(
-      chartValues,
-      `hedera.nodes[${index}]`,
-      constants.S6_NODE_IMAGE_REGISTRY,
-      constants.S6_NODE_IMAGE_REPOSITORY,
-      versions.S6_NODE_IMAGE_VERSION,
-    );
 
     // Set static IPs for HAProxy
     if (config.haproxyIps) {
@@ -3939,13 +3915,6 @@ export class NodeCommandTasks {
           .set(`hedera.nodes[${index}].name`, node.name)
           .set(`hedera.nodes[${index}].nodeId`, node.nodeId);
 
-        this.addRootImageValues(
-          chartValues,
-          `hedera.nodes[${index}]`,
-          constants.S6_NODE_IMAGE_REGISTRY,
-          constants.S6_NODE_IMAGE_REPOSITORY,
-          versions.S6_NODE_IMAGE_VERSION,
-        );
         // TSS wraps extraEnv is handled via generateExtraEnvironmentValuesFile()
 
         index++;

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -101,11 +101,6 @@ export const HEDERA_NODE_EXTERNAL_GOSSIP_PORT: string =
 export const HEDERA_NODE_DEFAULT_STAKE_AMOUNT: number =
   +getEnvironmentVariable('SOLO_NODE_DEFAULT_STAKE_AMOUNT') || 500;
 
-// S6-based consensus node image configuration (overridable via environment)
-export const S6_NODE_IMAGE_REGISTRY: string = getEnvironmentVariable('SOLO_S6_NODE_IMAGE_REGISTRY') || 'ghcr.io';
-export const S6_NODE_IMAGE_REPOSITORY: string =
-  getEnvironmentVariable('SOLO_S6_NODE_IMAGE_REPOSITORY') || 'hashgraph/solo-containers/debian-s6-java25';
-
 // Pods with a name matching one of these strings will be ignored when collecting pod metrics
 const ignorePodMetricsEnvironment: string = getEnvironmentVariable('IGNORE_POD_METRICS');
 export const IGNORE_POD_METRICS: string[] = ignorePodMetricsEnvironment

--- a/test/unit/business/utils/semantic-version.test.ts
+++ b/test/unit/business/utils/semantic-version.test.ts
@@ -72,6 +72,64 @@ describe('SemanticVersion', (): void => {
     });
   });
 
+  describe('getValidSemanticVersion', (): void => {
+    it('returns the normalized version string without a v-prefix by default', (): void => {
+      expect(SemanticVersion.getValidSemanticVersion('v1.2.3')).to.equal('1.2.3');
+      expect(SemanticVersion.getValidSemanticVersion('1.2.3')).to.equal('1.2.3');
+    });
+
+    it('returns the version string with a v-prefix when isNeedPrefix is true', (): void => {
+      expect(SemanticVersion.getValidSemanticVersion('1.2.3', true)).to.equal('v1.2.3');
+      expect(SemanticVersion.getValidSemanticVersion('v1.2.3', true)).to.equal('v1.2.3');
+    });
+
+    it('throws for an empty version string', (): void => {
+      expect((): string => SemanticVersion.getValidSemanticVersion('')).to.throw(
+        IllegalArgumentError,
+        'SemanticVersion cannot be empty',
+      );
+    });
+
+    it('includes the custom label in empty-string error messages', (): void => {
+      expect((): string => SemanticVersion.getValidSemanticVersion('', false, 'Solo chart version')).to.throw(
+        IllegalArgumentError,
+        'Solo chart version cannot be empty',
+      );
+    });
+
+    it('throws for an invalid version string', (): void => {
+      expect((): string => SemanticVersion.getValidSemanticVersion('not-a-version')).to.throw(
+        IllegalArgumentError,
+        'Invalid semanticversion: not-a-version',
+      );
+    });
+
+    it('passes when version equals minimumVersion', (): void => {
+      expect(SemanticVersion.getValidSemanticVersion('0.64.0', false, 'Solo chart version', '0.64.0')).to.equal(
+        '0.64.0',
+      );
+    });
+
+    it('passes when version is above minimumVersion', (): void => {
+      expect(SemanticVersion.getValidSemanticVersion('0.65.0', false, 'Solo chart version', '0.64.0')).to.equal(
+        '0.65.0',
+      );
+    });
+
+    it('throws when version is below minimumVersion', (): void => {
+      expect((): string =>
+        SemanticVersion.getValidSemanticVersion('0.63.0', false, 'Solo chart version', '0.64.0'),
+      ).to.throw(IllegalArgumentError, 'Solo chart version 0.63.0 is below the minimum supported version 0.64.0');
+    });
+
+    it('includes the custom label in minimum version error messages', (): void => {
+      expect((): string => SemanticVersion.getValidSemanticVersion('1.0.0', false, 'My component', '2.0.0')).to.throw(
+        IllegalArgumentError,
+        'My component 1.0.0 is below the minimum supported version 2.0.0',
+      );
+    });
+  });
+
   describe('constructor', (): void => {
     it('should create a SemanticVersion instance with a valid SemanticVersion<string>', (): void => {
       const semVersion: string = '1.0.0';

--- a/version.ts
+++ b/version.ts
@@ -23,7 +23,6 @@ export const CRANE_VERSION: string = 'v0.21.4';
 
 export const SOLO_CHART_VERSION: string = constants.getEnvironmentVariable('SOLO_CHART_VERSION') || '0.64.0';
 export const HEDERA_PLATFORM_VERSION: string = constants.getEnvironmentVariable('CONSENSUS_NODE_VERSION') || 'v0.74.0';
-export const S6_NODE_IMAGE_VERSION: string = constants.getEnvironmentVariable('SOLO_S6_NODE_IMAGE_VERSION') || '0.46.0';
 export const MIRROR_NODE_VERSION: string = constants.getEnvironmentVariable('MIRROR_NODE_VERSION') || 'v0.157.0';
 export const EXPLORER_VERSION: string = constants.getEnvironmentVariable('EXPLORER_VERSION') || '26.1.0';
 export const HEDERA_JSON_RPC_RELAY_VERSION: string = constants.getEnvironmentVariable('RELAY_VERSION') || '0.77.0';

--- a/version.ts
+++ b/version.ts
@@ -21,9 +21,9 @@ export const GVPROXY_VERSION: string = 'v0.8.7';
 export const KUBECTL_VERSION: string = 'v1.32.2';
 export const CRANE_VERSION: string = 'v0.21.4';
 
-export const SOLO_CHART_VERSION: string = constants.getEnvironmentVariable('SOLO_CHART_VERSION') || '0.63.3';
+export const SOLO_CHART_VERSION: string = constants.getEnvironmentVariable('SOLO_CHART_VERSION') || '0.64.0';
 export const HEDERA_PLATFORM_VERSION: string = constants.getEnvironmentVariable('CONSENSUS_NODE_VERSION') || 'v0.74.0';
-export const S6_NODE_IMAGE_VERSION: string = constants.getEnvironmentVariable('SOLO_S6_NODE_IMAGE_VERSION') || '0.45.3';
+export const S6_NODE_IMAGE_VERSION: string = constants.getEnvironmentVariable('SOLO_S6_NODE_IMAGE_VERSION') || '0.46.0';
 export const MIRROR_NODE_VERSION: string = constants.getEnvironmentVariable('MIRROR_NODE_VERSION') || 'v0.157.0';
 export const EXPLORER_VERSION: string = constants.getEnvironmentVariable('EXPLORER_VERSION') || '26.1.0';
 export const HEDERA_JSON_RPC_RELAY_VERSION: string = constants.getEnvironmentVariable('RELAY_VERSION') || '0.77.0';

--- a/version.ts
+++ b/version.ts
@@ -74,7 +74,7 @@ export const NETWORK_LOAD_GENERATOR_CHART_VERSION_BEFORE_CN_72: string = '0.8.0'
 export const NETWORK_LOAD_GENERATOR_CHART_VERSION_AFTER_CN_72: string = '0.14.0';
 export const MINIMUM_CN_VERSION_FOR_SMALL_MEMORY: string = 'v0.72.0-0';
 export const MINIMUM_CN_VERSION_FOR_STATE_ON_DISK: string = 'v0.73.0-0';
-
+export const MINIMUM_SOLO_CHART_VERSION: string = '0.64.0';
 export function needsConfigTxtForConsensusVersion(releaseTag?: string): boolean {
   const versionTag: SemanticVersion<string> = new SemanticVersion(releaseTag || HEDERA_PLATFORM_VERSION);
   return versionTag.lessThanOrEqual(LAST_HIERO_CONSENSUS_NODE_VERSION_NEED_CONFIG_TXT);


### PR DESCRIPTION
## Description

This pull request enforces a minimum supported Solo chart version (`0.64.0`) throughout the codebase and removes legacy S6 node image overrides. It also improves the validation logic for semantic versions and adds comprehensive tests for these changes.

**Minimum Solo chart version enforcement:**
* Added `MINIMUM_SOLO_CHART_VERSION` constant (`0.64.0`) to `version.ts` and updated all relevant commands (`explorer`, `mirror-node`, `network`, `node/tasks`) to require that the configured Solo chart version is at least this minimum. Attempts to use an older version now result in a clear error. [[1]](diffhunk://#diff-9840df415b2e8f8effbd38bf4c4cefaa5f691dcc8d6585c41fbcf84a167e6226L78-R77) [[2]](diffhunk://#diff-1e98e31967fc6e63e1e65eb39a2b1c00e5d007a95067861acbde89787f995098L28-R28) [[3]](diffhunk://#diff-1e98e31967fc6e63e1e65eb39a2b1c00e5d007a95067861acbde89787f995098R304) [[4]](diffhunk://#diff-8a32942c66b48f26bafe6bbc26f6592a6704a9794b3a0fc48048a0389af4f692R1268) [[5]](diffhunk://#diff-8a32942c66b48f26bafe6bbc26f6592a6704a9794b3a0fc48048a0389af4f692R1528) [[6]](diffhunk://#diff-78a2daa5946cea6ec984eab3d9e0e650ccfea147c8a7bd7f9f8a6f1791490c93R1584) [[7]](diffhunk://#diff-8cefeed9413cc4af123b03dae754f7a9f148f4b7917f5b2743000ee370bfdd13L69-R73) [[8]](diffhunk://#diff-8cefeed9413cc4af123b03dae754f7a9f148f4b7917f5b2743000ee370bfdd13R2596) [[9]](diffhunk://#diff-8cefeed9413cc4af123b03dae754f7a9f148f4b7917f5b2743000ee370bfdd13R3673)
* Updated the default `SOLO_CHART_VERSION` to `0.64.0`.

**Semantic version validation improvements:**
* Enhanced `SemanticVersion.getValidSemanticVersion` to accept an optional `minimumVersion` parameter and throw an error if the version is below this minimum, with improved error messages. [[1]](diffhunk://#diff-f3859d32a789bfb7de653d63f8cf7bf69d6c9daf1368c9db36621075c9e79636R411-R419) [[2]](diffhunk://#diff-f3859d32a789bfb7de653d63f8cf7bf69d6c9daf1368c9db36621075c9e79636R432-R441)
* Added comprehensive unit tests for the new validation logic, including minimum version checks and error messaging.

**Code cleanup and legacy removal:**
* Removed the S6 node image registry/repository/tag constants and all related code, as S6 image overrides are no longer supported. [[1]](diffhunk://#diff-97e2f449c66fc3d302619d495bf066a36f9075ad7a21b483c60113f21beb8758L104-L108) [[2]](diffhunk://#diff-78a2daa5946cea6ec984eab3d9e0e650ccfea147c8a7bd7f9f8a6f1791490c93L714-L720) [[3]](diffhunk://#diff-78a2daa5946cea6ec984eab3d9e0e650ccfea147c8a7bd7f9f8a6f1791490c93L792-L812) [[4]](diffhunk://#diff-8cefeed9413cc4af123b03dae754f7a9f148f4b7917f5b2743000ee370bfdd13L3818-L3824) [[5]](diffhunk://#diff-8cefeed9413cc4af123b03dae754f7a9f148f4b7917f5b2743000ee370bfdd13L3862-L3869) [[6]](diffhunk://#diff-8cefeed9413cc4af123b03dae754f7a9f148f4b7917f5b2743000ee370bfdd13L3880-L3887) [[7]](diffhunk://#diff-8cefeed9413cc4af123b03dae754f7a9f148f4b7917f5b2743000ee370bfdd13L3942-L3948)
* Removed the unused `S6_NODE_IMAGE_VERSION` export from `version.ts`.

These changes ensure users cannot deploy with unsupported Solo chart versions and simplify the codebase by removing legacy image configuration logic.
### Related Issues

* Closes #4002 
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
