### PR TITLE
chore: enforce error rule for exported interfaces in ESLint configuration

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -318,8 +318,6 @@ export default [
   {
     // No exported functions in source code — see §10.3.1.
     // One exported interface per file, filename matches interface name in kebab-case — see §3.5.
-    // exported-interface-in-own-file is warned while existing multi-interface barrel files
-    // (src/types/index.ts, src/types/flag-types.ts) are migrated; escalate to 'error' once done.
     files: ['src/**/*.ts'],
     plugins: {solo: soloLocalPlugin},
     rules: {

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -324,7 +324,7 @@ export default [
     plugins: {solo: soloLocalPlugin},
     rules: {
       'solo/no-exported-function': 'error',
-      'solo/exported-interface-in-own-file': 'warn', // TODO error (migrate src/types/ barrels first)
+      'solo/exported-interface-in-own-file': 'error',
     },
   },
   {


### PR DESCRIPTION
## Description

This pull request makes a small but important change to the ESLint configuration. The rule `'solo/exported-interface-in-own-file'` is now enforced as an error instead of a warning, meaning violations will fail the linting process.

- Changed the `'solo/exported-interface-in-own-file'` rule from a warning to an error in `eslint.config.mjs`, ensuring stricter enforcement of interface export practices.
 
### Related Issues

* Closes #
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
