### PR TITLE
test(ci): add per-distro install validation workflow (Ubuntu)

### DIFF
--- a/.github/workflows/flow-install-validation.yaml
+++ b/.github/workflows/flow-install-validation.yaml
@@ -65,7 +65,13 @@ jobs:
       - name: Install Dependencies
         run: npm ci
 
+      - name: Install Task
+        uses: arduino/setup-task@b91d5d2c96a56797b48ac1e0e89220bf64044611 # v2.0.0
+        with:
+          version: 3.49.1
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Validate System-Dependency Install
         env:
           SOLO_OS_INSTALL_VALIDATION: 'true'
-        run: npx mocha 'test/e2e/integration/core/package-managers/os-package-manager-install.test.ts'
+        run: task test-install-validation

--- a/.github/workflows/flow-install-validation.yaml
+++ b/.github/workflows/flow-install-validation.yaml
@@ -1,0 +1,71 @@
+##
+# Copyright (C) 2025 Hedera Hashgraph, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+##
+
+# Validates Solo's real per-distribution system-dependency install (git, iptables) inside a
+# disposable distribution container. This foundation runs a single distro (Ubuntu); follow-up
+# work fans the matrix out across the remaining supported distributions.
+# Tracked by hiero-ledger/solo#4888.
+name: 'Install Validation'
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - main
+
+defaults:
+  run:
+    shell: bash
+
+permissions:
+  contents: read
+
+jobs:
+  install-validation:
+    name: 'Install Validation (${{ matrix.distro }})'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # Follow-up work (hiero-ledger/solo#4888) appends the remaining supported distributions here.
+        include:
+          - distro: ubuntu
+            image: ubuntu:24.04
+    container:
+      image: ${{ matrix.image }}
+    steps:
+      # The base distribution image ships none of git/curl/sudo. git and curl are needed for
+      # checkout and the Node setup; sudo is needed because Solo elevates package installs via sudo.
+      - name: Bootstrap Container
+        run: |
+          apt-get update
+          apt-get install -y git curl sudo ca-certificates
+
+      - name: Checkout Code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      - name: Setup Node
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: 22
+
+      - name: Install Dependencies
+        run: npm ci
+
+      - name: Validate System-Dependency Install
+        env:
+          SOLO_OS_INSTALL_VALIDATION: 'true'
+        run: npx mocha 'test/e2e/integration/core/package-managers/os-package-manager-install.test.ts'

--- a/Taskfile.tests.yml
+++ b/Taskfile.tests.yml
@@ -60,6 +60,14 @@ tasks:
         {{ .mocha_bin }} 'test/e2e/integration/**/*.ts'
         {{ .reporter_options_prefix }}-e2e-integration.xml"
 
+  test-install-validation:
+    desc: "Runs the per-distribution system-dependency install validation and generates reports in coverage/install-validation"
+    cmds:
+      - "{{ .test_prefix }}=\"Mocha Install Validation Tests\"
+        {{ .reporter_prefix }}='coverage/install-validation'
+        {{ .mocha_bin }} 'test/e2e/integration/core/package-managers/os-package-manager-install.test.ts'
+        {{ .reporter_options_prefix }}-install-validation.xml --timeout 300000"
+
   test-e2e-leases:
     desc: "Runs E2E lease tests with coverage and generates reports in coverage/e2e-leases"
     cmds:

--- a/test/e2e/integration/core/package-managers/os-package-manager-install.test.ts
+++ b/test/e2e/integration/core/package-managers/os-package-manager-install.test.ts
@@ -1,0 +1,50 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {expect} from 'chai';
+import {before, describe, it} from 'mocha';
+import {execFileSync} from 'node:child_process';
+import {container} from 'tsyringe-neo';
+import {resetForTest} from '../../../../test-container.js';
+import {InjectTokens} from '../../../../../src/core/dependency-injection/inject-tokens.js';
+import {OsPackageManager} from '../../../../../src/core/package-managers/os-package-manager.js';
+import {type PackageManager} from '../../../../../src/core/package-managers/package-manager.js';
+
+/**
+ * Validates the real per-distribution install path introduced in #4773 by running an actual
+ * native-package-manager install of `git` and `iptables` and asserting both binaries land on the
+ * system. This mutates the host, so it only runs inside disposable CI distribution containers when
+ * {@link SOLO_OS_INSTALL_VALIDATION} is set; every other run skips it.
+ *
+ * Tracked by hiero-ledger/solo#4888 (per-distro install validation epic).
+ */
+const SOLO_OS_INSTALL_VALIDATION: string = 'SOLO_OS_INSTALL_VALIDATION';
+const PACKAGES_TO_INSTALL: string[] = ['git', 'iptables'];
+
+/** Throws if the given executable cannot be resolved on the PATH (including the sbin directories). */
+function assertExecutableInstalled(executable: string): void {
+  execFileSync('sh', ['-c', `command -v ${executable}`], {stdio: 'pipe'});
+}
+
+describe('OsPackageManager real install validation', function (this: Mocha.Suite): void {
+  // A real package-index refresh plus install is well beyond the default unit-test timeout.
+  this.timeout(300_000);
+
+  before(function (this: Mocha.Context): void {
+    if (process.env[SOLO_OS_INSTALL_VALIDATION] !== 'true') {
+      this.skip();
+    }
+    resetForTest();
+    // Force the Linux distribution-detection branch regardless of the host the harness runs on.
+    container.register(InjectTokens.OsPlatform, {useValue: 'linux'});
+  });
+
+  it('installs git and iptables via the distribution package manager', async (): Promise<void> => {
+    const packageManager: PackageManager = new OsPackageManager().getPackageManager();
+    await packageManager.update();
+    await packageManager.installPackages(PACKAGES_TO_INSTALL);
+
+    for (const executable of PACKAGES_TO_INSTALL) {
+      expect((): void => assertExecutableInstalled(executable), `${executable} should be installed`).to.not.throw();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Foundation for automated per-distro install validation. Adds a GitHub Actions
workflow that runs Solo's **real** native package-manager install path inside a
disposable Ubuntu container and asserts `git` and `iptables` land on the system.

Today the only coverage for the per-distro install logic (#4773) is mocked unit
tests for package-manager *selection* — nothing exercises an actual install, so
per-distro regressions (package naming, repo availability) would go undetected.

This is a thin vertical slice: a single distro wired as a one-row matrix, proving
the harness end to end. Follow-up work fans the matrix out across the remaining
supported distributions by appending entries to `matrix.include`.

## Changes
- `.github/workflows/flow-install-validation.yaml` — runs in a `container: ubuntu:24.04`
  job (no VM / nested virtualization). Bootstraps git/curl/sudo, checks out, `npm ci`,
  then runs the validation test with `SOLO_OS_INSTALL_VALIDATION=true`. Triggers on PRs
  to `main` and `workflow_dispatch`.
- `test/e2e/integration/core/package-managers/os-package-manager-install.test.ts` —
  exercises the real `OsPackageManager` → `AptGetPackageManager` path
  (`update()` + `installPackages(['git', 'iptables'])`) and asserts both binaries
  resolve on PATH. Gated behind `SOLO_OS_INSTALL_VALIDATION` so it only runs inside CI
  distribution containers and never mutates a developer host.

## Scope
- Distro: Ubuntu (apt-get) only.
- Validates: the native package-manager install path for `git` and `iptables`.

## Out of scope (tracked in #4888)
- Remaining distros (Debian, Fedora/Rocky/Alma, CentOS 7, openSUSE, Arch, Alpine) —
  matrix fan-out follow-up.
- Podman + Homebrew bootstrap and `kind` runtime validation — separate follow-up.
  On Linux, Solo obtains podman via the brew bootstrap rather than the native package
  manager, and running podman/kind needs a privileged/VM-capable runner, so it's
  deliberately kept out of this container-based slice.

## Testing
- The workflow is the test — a green job is the validation.
- Locally, the test skips cleanly when `SOLO_OS_INSTALL_VALIDATION` is unset (verified:
  1 pending, no system mutation).
- Container sanity check:
  `docker run --rm ubuntu:24.04 bash -c '<bootstrap + npm ci + mocha>'`.

Part of #4888