### PR TITLE
fix: wait for nodes before one-shot relay and pinger

### DIFF
--- a/.github/workflows/script/launch_network.sh
+++ b/.github/workflows/script/launch_network.sh
@@ -625,7 +625,8 @@ BLOCK_NODE_VERSION="${PREV_BLOCK_VERSION#v}" \
   solo one-shot falcon deploy \
   --num-consensus-nodes 2 \
   --consensus-node-version "${FROM_CONSENSUS_NODE_VERSION}" \
-  --values-file "${TEMP_ONE_SHOT_VALUES_FILE}"
+  --values-file "${TEMP_ONE_SHOT_VALUES_FILE}" \
+  --no-parallel-deploy
 
 echo "::endgroup::"
 

--- a/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
+++ b/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
@@ -731,10 +731,12 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
                 this.taskList,
                 (): boolean => !getConfig().deployRelay && !getConfig().minimalSetup,
               ),
-          }).withWaitCondition(
-            SoloEventType.MirrorNodeDeployed,
-            Duration.ofMinutes(constants.MIRROR_NODE_DEPLOYED_EVENT_TIMEOUT_MINUTES),
-          ),
+          })
+            .withWaitCondition(
+              SoloEventType.MirrorNodeDeployed,
+              Duration.ofMinutes(constants.MIRROR_NODE_DEPLOYED_EVENT_TIMEOUT_MINUTES),
+            )
+            .withWaitCondition(SoloEventType.NodesStarted, Duration.ofMinutes(10)),
         ],
         (getConfig: () => OneShotSingleDeployConfigClass): ExecutionMode =>
           getConfig().parallelDeploy

--- a/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
+++ b/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
@@ -708,10 +708,12 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
                 this.taskList,
                 (): boolean => !getConfig().deployMirrorNode || !getConfig().pinger,
               ),
-          }).withWaitCondition(
-            SoloEventType.MirrorNodeDeployed,
-            Duration.ofMinutes(constants.MIRROR_NODE_DEPLOYED_EVENT_TIMEOUT_MINUTES),
-          ),
+          })
+            .withWaitCondition(
+              SoloEventType.MirrorNodeDeployed,
+              Duration.ofMinutes(constants.MIRROR_NODE_DEPLOYED_EVENT_TIMEOUT_MINUTES),
+            )
+            .withWaitCondition(SoloEventType.NodesStarted, Duration.ofMinutes(10)),
           new OrchestratorPipelinePhase('Deploy explorer', {
             asListrTask: (getConfig: () => OneShotSingleDeployConfigClass): SoloListrTask<OneShotSingleDeployContext> =>
               invokeSoloCommand(


### PR DESCRIPTION
## Description

This pull request changes the following:

* Gates one-shot JSON-RPC relay deployment on both `MirrorNodeDeployed` and `NodesStarted`.
* Gates one-shot mirror pinger enablement on both `MirrorNodeDeployed` and `NodesStarted`.
* Prevents relay chart value preparation and mirror pinger SDK client setup from reading consensus service mappings before consensus services exist.
* Fixes one-shot parallel deploy races where dependent components can start while consensus nodes are still only `requested`.
* Serializes only the migration workflow's prior-release source-network bootstrap with `--no-parallel-deploy`, because that step runs published `@hashgraph/solo@0.80.0` and cannot include this branch's orchestrator fix.

Observed failures addressed:

* Performance test failures in relay chart value preparation with `Cannot read properties of undefined (reading 'haProxyClusterIp')`.
* Performance test failures in mirror pinger enablement where the SDK node client was created from an empty consensus service map.
* Migration test failure during initial deployment of the prior Solo release before the PR build was used.

### Related Issues

* Closes #4922

### Pull request (PR) checklist

* [ ] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [x] Any technical debt has been documented as a separate issue and linked to this PR
* [x] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [ ] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [x] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* `npx mocha 'test/unit/commands/one-shot/orchestrator/orchestrator-pipeline-phase.test.ts' 'test/unit/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.test.ts'` - 53 passing
* `npx prettier --check src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts` - passed
* `npx eslint src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts` - passed with no errors
* `task build:compile` - passed
* `bash -n .github/workflows/script/launch_network.sh` - passed
* Verified `@hashgraph/solo@0.80.0` includes the `parallel-deploy` flag and documents `--no-parallel-deploy`.

The following CI status was observed after the latest push:

* Code style, CodeQL, DCO, and title checks were passing.
* Performance, migration, deploy/destroy, and other long-running workflow checks were still running or queued in GitHub Actions.

The following was not tested locally:

* The full performance E2E and migration workflows were not rerun locally because they require the CI runner environment.

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                       |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>