### PR TITLE
feat(mirror-node): add collect-jfr to capture JVM metrics during performance tests

### DIFF
--- a/resources/mirror-node-perf-values.yaml
+++ b/resources/mirror-node-perf-values.yaml
@@ -1,0 +1,25 @@
+# JFR-enabling overlay for the mirror node importer, used to capture JVM metrics during performance tests.
+# The importer runs with a read-only root filesystem, so the recording is written under its writable /tmp
+# emptyDir at constants.MIRROR_NODE_JFR_REPOSITORY_DIRECTORY ("/tmp/jfr"); enforced by mirror-node-values.test.ts.
+# maxchunksize is kept small so chunks rotate often under load, keeping each collection close to live.
+# settings=profile uses the JVM built-in JFR profile, so no .jfc file needs to be staged into the pod.
+# Apply with:
+#   npm run solo -- mirror node add --deployment one-shot --values-file <this file>
+# then collect the recording during or after the run with:
+#   npm run solo -- mirror node collect-jfr --deployment one-shot
+importer:
+  resources:
+    requests:
+      cpu: "1"
+      memory: 2Gi
+    limits:
+      cpu: "2"
+      memory: 2Gi
+  env:
+    JAVA_TOOL_OPTIONS: >-
+      -Xms256m
+      -Xmx1g
+      -XX:+HeapDumpOnOutOfMemoryError
+      -XX:HeapDumpPath=/tmp/dump.hprof
+      -XX:FlightRecorderOptions=repository=/tmp/jfr,maxchunksize=1m
+      -XX:StartFlightRecording=name=mirror-importer,settings=profile,disk=true,maxsize=100m,maxage=30m,dumponexit=true,filename=/tmp/jfr/recording.jfr

--- a/resources/mirror-node-perf-values.yaml
+++ b/resources/mirror-node-perf-values.yaml
@@ -1,12 +1,4 @@
-# JFR-enabling overlay for the mirror node importer, used to capture JVM metrics during performance tests.
-# The importer runs with a read-only root filesystem, so the recording is written under its writable /tmp
-# emptyDir at constants.MIRROR_NODE_JFR_REPOSITORY_DIRECTORY ("/tmp/jfr"); enforced by mirror-node-values.test.ts.
-# maxchunksize is kept small so chunks rotate often under load, keeping each collection close to live.
-# settings=profile uses the JVM built-in JFR profile, so no .jfc file needs to be staged into the pod.
-# Apply with:
-#   npm run solo -- mirror node add --deployment one-shot --values-file <this file>
-# then collect the recording during or after the run with:
-#   npm run solo -- mirror node collect-jfr --deployment one-shot
+# JFR overlay for the mirror node importer (perf tests); records to a dedicated disk volume, repository path enforced by mirror-node-values.test.ts.
 importer:
   resources:
     requests:
@@ -15,11 +7,17 @@ importer:
     limits:
       cpu: "2"
       memory: 2Gi
+  # Dedicated writable volume for JFR output (the importer's root filesystem is read-only), mirroring the block node output dir.
+  volumeMounts:
+    jfr:
+      mountPath: /opt/hiero/mirror-node/output/jfr
+  volumes:
+    jfr:
+      emptyDir:
+        sizeLimit: 1Gi
   env:
     JAVA_TOOL_OPTIONS: >-
       -Xms256m
       -Xmx1g
-      -XX:+HeapDumpOnOutOfMemoryError
-      -XX:HeapDumpPath=/tmp/dump.hprof
-      -XX:FlightRecorderOptions=repository=/tmp/jfr,maxchunksize=1m
-      -XX:StartFlightRecording=name=mirror-importer,settings=profile,disk=true,maxsize=100m,maxage=30m,dumponexit=true,filename=/tmp/jfr/recording.jfr
+      -XX:FlightRecorderOptions=repository=/opt/hiero/mirror-node/output/jfr,maxchunksize=1m
+      -XX:StartFlightRecording=name=mirror-importer,settings=profile,disk=true,maxsize=100m,maxage=30m,dumponexit=true,filename=/opt/hiero/mirror-node/output/jfr/recording.jfr

--- a/src/commands/command-definitions/mirror-command-definition.ts
+++ b/src/commands/command-definitions/mirror-command-definition.ts
@@ -33,6 +33,7 @@ export class MirrorCommandDefinition extends BaseCommandDefinition {
   public static readonly NODE_ADD: string = 'add';
   public static readonly NODE_DESTROY: string = 'destroy';
   public static readonly NODE_UPGRADE: string = 'upgrade';
+  public static readonly NODE_COLLECT_JFR: string = 'collect-jfr';
 
   public static readonly ADD_COMMAND: string =
     `${MirrorCommandDefinition.COMMAND_NAME} ${MirrorCommandDefinition.NODE_SUBCOMMAND_NAME} ${MirrorCommandDefinition.NODE_ADD}` as const;
@@ -42,6 +43,9 @@ export class MirrorCommandDefinition extends BaseCommandDefinition {
 
   public static readonly UPGRADE_COMMAND: string =
     `${MirrorCommandDefinition.COMMAND_NAME} ${MirrorCommandDefinition.NODE_SUBCOMMAND_NAME} ${MirrorCommandDefinition.NODE_UPGRADE}` as const;
+
+  public static readonly COLLECT_JFR_COMMAND: string =
+    `${MirrorCommandDefinition.COMMAND_NAME} ${MirrorCommandDefinition.NODE_SUBCOMMAND_NAME} ${MirrorCommandDefinition.NODE_COLLECT_JFR}` as const;
 
   public getCommandDefinition(): CommandDefinition {
     return new CommandBuilder(MirrorCommandDefinition.COMMAND_NAME, MirrorCommandDefinition.DESCRIPTION, this.logger)
@@ -77,6 +81,18 @@ export class MirrorCommandDefinition extends BaseCommandDefinition {
               this.mirrorNodeCommand,
               this.mirrorNodeCommand.upgrade,
               MirrorNodeCommand.UPGRADE_FLAGS_LIST,
+              [...constants.BASE_DEPENDENCIES],
+            ),
+          )
+          .addSubcommand(
+            new Subcommand(
+              MirrorCommandDefinition.NODE_COLLECT_JFR,
+              'Downloads the Java Flight Recorder recording from a mirror node importer instance in the ' +
+                'specified deployment to the local solo logs directory. Requires the mirror node to have been ' +
+                'deployed with Java Flight Recorder enabled.',
+              this.mirrorNodeCommand,
+              this.mirrorNodeCommand.collectJfr,
+              MirrorNodeCommand.COLLECT_JFR_FLAGS_LIST,
               [...constants.BASE_DEPENDENCIES],
             ),
           ),

--- a/src/commands/mirror-node.ts
+++ b/src/commands/mirror-node.ts
@@ -2164,7 +2164,8 @@ export class MirrorNodeCommand extends BaseCommand {
     return {
       title: 'Download Java Flight Recorder logs from mirror node importer pod',
       task: async ({config}, task): Promise<void> => {
-        const labels: string[] = Templates.renderMirrorNodeLabels(config.id);
+        // Select the importer by name+component only so both modern (mirror-<id>) and legacy (mirror) release names match.
+        const labels: string[] = [constants.SOLO_MIRROR_IMPORTER_NAME_LABEL, 'app.kubernetes.io/component=importer'];
         const importerPods: Pod[] = await this.k8Factory
           .getK8(config.clusterContext)
           .pods()

--- a/src/commands/mirror-node.ts
+++ b/src/commands/mirror-node.ts
@@ -2187,9 +2187,7 @@ export class MirrorNodeCommand extends BaseCommand {
         const repositoryDirectory: string = constants.MIRROR_NODE_JFR_REPOSITORY_DIRECTORY;
         const collectedRecordingPath: string = `${repositoryDirectory}/collected-recording.jfr`;
 
-        // The importer is a JRE image without `jcmd`, so JFR runs as a continuous on-disk recording that
-        // rotates chunk files. Concatenate every finalized chunk (all but the still-open last one) into a
-        // single readable recording. This is non-destructive and can be run repeatedly during a test.
+        // Concatenate every finalized JFR chunk (all but the still-open last one) into a single readable recording.
         const consolidateScript: string =
           'set -e; ' +
           `finalized=$(ls -1 ${repositoryDirectory}/*/*.jfr 2>/dev/null | sort | sed '$d'); ` +

--- a/src/commands/mirror-node.ts
+++ b/src/commands/mirror-node.ts
@@ -33,6 +33,8 @@ import {type NamespaceName} from '../types/namespace/namespace-name.js';
 import {PodReference} from '../integration/kube/resources/pod/pod-reference.js';
 import {Pod} from '../integration/kube/resources/pod/pod.js';
 import {type Pods} from '../integration/kube/resources/pod/pods.js';
+import {ContainerReference} from '../integration/kube/resources/container/container-reference.js';
+import {type Container} from '../integration/kube/resources/container/container.js';
 import chalk from 'chalk';
 import {type CommandFlag, type CommandFlags} from '../types/flag-types.js';
 import {PvcReference} from '../integration/kube/resources/pvc/pvc-reference.js';
@@ -185,6 +187,20 @@ interface MirrorNodeDestroyContext {
   config: MirrorNodeDestroyConfigClass;
 }
 
+interface MirrorNodeCollectJfrConfigClass {
+  namespace: NamespaceName;
+  clusterContext: Context;
+  clusterReference: ClusterReferenceName;
+  deployment: DeploymentName;
+  devMode: boolean;
+  quiet: boolean;
+  id: ComponentId;
+}
+
+interface MirrorNodeCollectJfrContext {
+  config: MirrorNodeCollectJfrConfigClass;
+}
+
 interface InferredData {
   id: ComponentId;
   releaseName: string;
@@ -228,6 +244,11 @@ export class MirrorNodeCommand extends BaseCommand {
   private static readonly DEPLOY_CONFIGS_NAME: string = 'deployConfigs';
 
   private static readonly UPGRADE_CONFIGS_NAME: string = 'upgradeConfigs';
+
+  private static readonly COLLECT_JFR_CONFIGS_NAME: string = 'collectJfrConfigs';
+
+  // Sentinel printed by the in-pod consolidation script when no JFR recording is present.
+  private static readonly NO_JFR_MARKER: string = 'SOLO_NO_JFR_RECORDING';
 
   public static readonly DEPLOY_FLAGS_LIST: CommandFlags = {
     required: [flags.deployment],
@@ -310,6 +331,11 @@ export class MirrorNodeCommand extends BaseCommand {
   public static readonly DESTROY_FLAGS_LIST: CommandFlags = {
     required: [flags.deployment],
     optional: [flags.chartDirectory, flags.clusterRef, flags.force, flags.quiet, flags.devMode, flags.id],
+  };
+
+  public static readonly COLLECT_JFR_FLAGS_LIST: CommandFlags = {
+    required: [flags.deployment],
+    optional: [flags.clusterRef, flags.devMode, flags.quiet, flags.id],
   };
 
   private prepareBlockNodeIntegrationValues(
@@ -2125,6 +2151,141 @@ export class MirrorNodeCommand extends BaseCommand {
     } else {
       this.taskList.registerCloseFunction(async (): Promise<void> => {
         await this.accountManager?.close().catch();
+        if (!this.oneShotState.isActive()) {
+          await lease?.release();
+        }
+      });
+    }
+
+    return true;
+  }
+
+  private downloadMirrorNodeJavaFlightRecorderLogs(): SoloListrTask<MirrorNodeCollectJfrContext> {
+    return {
+      title: 'Download Java Flight Recorder logs from mirror node importer pod',
+      task: async ({config}, task): Promise<void> => {
+        const labels: string[] = Templates.renderMirrorNodeLabels(config.id);
+        const importerPods: Pod[] = await this.k8Factory
+          .getK8(config.clusterContext)
+          .pods()
+          .list(config.namespace, labels);
+
+        if (importerPods.length === 0) {
+          throw new SoloErrors.system.mirrorNodePodsNotFound(this.renderReleaseName(config.id), config.namespace.name);
+        }
+
+        const podReference: PodReference = importerPods[0].podReference;
+        const containerReference: ContainerReference = ContainerReference.of(
+          podReference,
+          constants.MIRROR_NODE_IMPORTER_CONTAINER_NAME,
+        );
+        const k8Container: Container = this.k8Factory
+          .getK8(config.clusterContext)
+          .containers()
+          .readByRef(containerReference);
+
+        const repositoryDirectory: string = constants.MIRROR_NODE_JFR_REPOSITORY_DIRECTORY;
+        const collectedRecordingPath: string = `${repositoryDirectory}/collected-recording.jfr`;
+
+        // The importer is a JRE image without `jcmd`, so JFR runs as a continuous on-disk recording that
+        // rotates chunk files. Concatenate every finalized chunk (all but the still-open last one) into a
+        // single readable recording. This is non-destructive and can be run repeatedly during a test.
+        const consolidateScript: string =
+          'set -e; ' +
+          `finalized=$(ls -1 ${repositoryDirectory}/*/*.jfr 2>/dev/null | sort | sed '$d'); ` +
+          `if [ -z "$finalized" ]; then echo "${MirrorNodeCommand.NO_JFR_MARKER}"; exit 0; fi; ` +
+          `cat $finalized > ${collectedRecordingPath}`;
+
+        let consolidateResult: string;
+        try {
+          consolidateResult = await k8Container.execContainer(['bash', '-c', consolidateScript]);
+        } catch (error) {
+          throw new SoloErrors.component.mirrorNodeJfrCollectionFailed(error);
+        }
+
+        if (consolidateResult.includes(MirrorNodeCommand.NO_JFR_MARKER)) {
+          const reason: string = `no finalized Java Flight Recorder chunk found in ${repositoryDirectory} on mirror node importer pod ${podReference.name}; the mirror node may not have been deployed with Java Flight Recorder enabled, or the recording is still shorter than one chunk`;
+          this.logger.warn(reason);
+          task.skip(`${task.title} ${chalk.yellow('[SKIPPING]')} ${chalk.grey(reason)}`);
+          return;
+        }
+
+        const localJfrLogsDirectory: string = PathEx.join(constants.SOLO_LOGS_DIR, config.deployment);
+        fs.mkdirSync(localJfrLogsDirectory, {recursive: true});
+
+        await k8Container.copyFrom(collectedRecordingPath, localJfrLogsDirectory);
+
+        const downloadedRecordingPath: string = PathEx.join(localJfrLogsDirectory, 'collected-recording.jfr');
+        this.logger.showUser(`Downloaded Java Flight Recorder recording to ${downloadedRecordingPath}`);
+      },
+    };
+  }
+
+  public async collectJfr(argv: ArgvStruct): Promise<boolean> {
+    let lease: Lock;
+
+    const tasks: SoloListr<MirrorNodeCollectJfrContext> = this.taskList.newTaskList<MirrorNodeCollectJfrContext>(
+      [
+        {
+          title: 'Initialize',
+          task: async (context_, task): Promise<Listr<AnyListrContext>> => {
+            await this.localConfig.load();
+            await this.remoteConfig.loadAndValidate(argv);
+            if (!this.oneShotState.isActive()) {
+              lease = await this.leaseManager.create();
+            }
+
+            this.configManager.update(argv);
+
+            flags.disablePrompts(MirrorNodeCommand.COLLECT_JFR_FLAGS_LIST.optional);
+
+            const allFlags: CommandFlag[] = [
+              ...MirrorNodeCommand.COLLECT_JFR_FLAGS_LIST.required,
+              ...MirrorNodeCommand.COLLECT_JFR_FLAGS_LIST.optional,
+            ];
+
+            await this.configManager.executePrompt(task, allFlags);
+
+            const config: MirrorNodeCollectJfrConfigClass = this.configManager.getConfig(
+              MirrorNodeCommand.COLLECT_JFR_CONFIGS_NAME,
+              allFlags,
+            ) as MirrorNodeCollectJfrConfigClass;
+
+            context_.config = config;
+
+            config.namespace = await this.getNamespace(task);
+            config.clusterReference = this.getClusterReference();
+            config.clusterContext = this.getClusterContext(config.clusterReference);
+
+            config.id = this.inferMirrorNodeId();
+
+            await this.throwIfNamespaceIsMissing(config.clusterContext, config.namespace);
+
+            if (!this.oneShotState.isActive()) {
+              return ListrLock.newAcquireLockTask(lease, task);
+            }
+            return ListrLock.newSkippedLockTask(task);
+          },
+        },
+        this.downloadMirrorNodeJavaFlightRecorderLogs(),
+      ],
+      constants.LISTR_DEFAULT_OPTIONS.DEFAULT,
+      undefined,
+      'mirror node collect-jfr',
+    );
+
+    if (tasks.isRoot()) {
+      try {
+        await tasks.run();
+      } catch (error) {
+        throw new SoloErrors.component.mirrorNodeJfrCollectionFailed(error);
+      } finally {
+        if (!this.oneShotState.isActive()) {
+          await lease?.release();
+        }
+      }
+    } else {
+      this.taskList.registerCloseFunction(async (): Promise<void> => {
         if (!this.oneShotState.isActive()) {
           await lease?.release();
         }

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -143,6 +143,15 @@ export const MIRROR_NODE_CHART_URL: string =
 export const MIRROR_NODE_CHART: string = 'hedera-mirror';
 export const MIRROR_NODE_RELEASE_NAME: string = 'mirror';
 export const MIRROR_NODE_PINGER_TPS: number = +getEnvironmentVariable('MIRROR_NODE_PINGER_TPS') || 5;
+
+// Container name of the mirror node importer pod (the importer subchart's `.Chart.Name`), which
+// `solo mirror node collect-jfr` execs into to consolidate Java Flight Recorder chunks.
+export const MIRROR_NODE_IMPORTER_CONTAINER_NAME: ContainerName = ContainerName.of('hedera-mirror-importer');
+
+// In-pod JFR disk-repository path `solo mirror node collect-jfr` reads from. The importer runs with a
+// read-only root filesystem, so JFR must write under its writable `/tmp` emptyDir. The repository path in
+// resources/mirror-node-perf-values.yaml is kept in sync with this constant by mirror-node-values.test.ts.
+export const MIRROR_NODE_JFR_REPOSITORY_DIRECTORY: string = '/tmp/jfr';
 export const PROMETHEUS_STACK_CHART_URL: string =
   getEnvironmentVariable('PROMETHEUS_STACK_CHART_URL') ?? 'https://prometheus-community.github.io/helm-charts';
 export const PROMETHEUS_STACK_CHART: string = 'kube-prometheus-stack';

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -144,14 +144,11 @@ export const MIRROR_NODE_CHART: string = 'hedera-mirror';
 export const MIRROR_NODE_RELEASE_NAME: string = 'mirror';
 export const MIRROR_NODE_PINGER_TPS: number = +getEnvironmentVariable('MIRROR_NODE_PINGER_TPS') || 5;
 
-// Container name of the mirror node importer pod (the importer subchart's `.Chart.Name`), which
-// `solo mirror node collect-jfr` execs into to consolidate Java Flight Recorder chunks.
+// Importer container name (the importer subchart's `.Chart.Name`) that `mirror node collect-jfr` execs into.
 export const MIRROR_NODE_IMPORTER_CONTAINER_NAME: ContainerName = ContainerName.of('hedera-mirror-importer');
 
-// In-pod JFR disk-repository path `solo mirror node collect-jfr` reads from. The importer runs with a
-// read-only root filesystem, so JFR must write under its writable `/tmp` emptyDir. The repository path in
-// resources/mirror-node-perf-values.yaml is kept in sync with this constant by mirror-node-values.test.ts.
-export const MIRROR_NODE_JFR_REPOSITORY_DIRECTORY: string = '/tmp/jfr';
+// In-pod JFR repository path `mirror node collect-jfr` reads from (a dedicated volume, mirrors the block node output dir); enforced by mirror-node-values.test.ts.
+export const MIRROR_NODE_JFR_REPOSITORY_DIRECTORY: string = '/opt/hiero/mirror-node/output/jfr';
 export const PROMETHEUS_STACK_CHART_URL: string =
   getEnvironmentVariable('PROMETHEUS_STACK_CHART_URL') ?? 'https://prometheus-community.github.io/helm-charts';
 export const PROMETHEUS_STACK_CHART: string = 'kube-prometheus-stack';

--- a/src/core/errors/classes/component/mirror-node-jfr-collection-failed-solo-error.ts
+++ b/src/core/errors/classes/component/mirror-node-jfr-collection-failed-solo-error.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {SoloError} from '../../solo-error.js';
+import {ErrorOwnership} from '../../error-ownership.js';
+import {ErrorCodeRegistry} from '../../error-code-registry.js';
+
+/**
+ * @description Thrown when `solo mirror node collect-jfr` cannot collect the Java Flight Recorder recording from the
+ * mirror node importer; the underlying failure is wrapped in `cause`. Retryable, since a transient pod or
+ * cluster-API problem often clears on a later attempt.
+ */
+export class MirrorNodeJfrCollectionFailedSoloError extends SoloError {
+  protected override readonly retryable: boolean = true;
+  protected override readonly ownership: ErrorOwnership = ErrorOwnership.Infrastructure;
+
+  public constructor(cause: Error) {
+    super(
+      {
+        message: `Error collecting Java Flight Recorder recording from mirror node: ${cause.message}`,
+        code: ErrorCodeRegistry.MIRROR_NODE_JFR_COLLECTION_FAILED,
+        troubleshootingSteps:
+          'Check solo logs: tail -n 100 ~/.solo/logs/solo.log\n' +
+          'Inspect mirror node importer pods: kubectl get pods -A -l app.kubernetes.io/component=importer\n' +
+          'Verify the mirror node importer was deployed with Java Flight Recorder enabled\n' +
+          'Verify the cluster is reachable: kubectl cluster-info --context <context>',
+      },
+      cause,
+    );
+  }
+}

--- a/src/core/errors/classes/component/mirror-node-jfr-collection-failed-solo-error.ts
+++ b/src/core/errors/classes/component/mirror-node-jfr-collection-failed-solo-error.ts
@@ -4,11 +4,7 @@ import {SoloError} from '../../solo-error.js';
 import {ErrorOwnership} from '../../error-ownership.js';
 import {ErrorCodeRegistry} from '../../error-code-registry.js';
 
-/**
- * @description Thrown when `solo mirror node collect-jfr` cannot collect the Java Flight Recorder recording from the
- * mirror node importer; the underlying failure is wrapped in `cause`. Retryable, since a transient pod or
- * cluster-API problem often clears on a later attempt.
- */
+/** Thrown when `mirror node collect-jfr` cannot collect the Java Flight Recorder recording from the importer (cause wrapped). */
 export class MirrorNodeJfrCollectionFailedSoloError extends SoloError {
   protected override readonly retryable: boolean = true;
   protected override readonly ownership: ErrorOwnership = ErrorOwnership.Infrastructure;

--- a/src/core/errors/error-code-registry.ts
+++ b/src/core/errors/error-code-registry.ts
@@ -129,6 +129,7 @@ export const ErrorCodeRegistry: Record<string, string> = {
   FILE_CONTENT_MISMATCH: 'SOLO-3088',
   NODE_SERVICE_NOT_FOUND: 'SOLO-3089',
   BLOCK_NODE_JFR_COLLECTION_FAILED: 'SOLO-3090',
+  MIRROR_NODE_JFR_COLLECTION_FAILED: 'SOLO-3091',
 
   // 4xxx - Validation: User input, flags, IDs, formatting
   MISSING_ARGUMENT: 'SOLO-4001',

--- a/src/core/errors/solo-errors.ts
+++ b/src/core/errors/solo-errors.ts
@@ -109,6 +109,7 @@ import {RelayOperatorKeyRetrievalFailedSoloError} from './classes/component/rela
 import {MirrorNodeDeployFailedSoloError} from './classes/component/mirror-node-deploy-failed-solo-error.js';
 import {MirrorNodeUpgradeFailedSoloError} from './classes/component/mirror-node-upgrade-failed-solo-error.js';
 import {MirrorNodeDestroyFailedSoloError} from './classes/component/mirror-node-destroy-failed-solo-error.js';
+import {MirrorNodeJfrCollectionFailedSoloError} from './classes/component/mirror-node-jfr-collection-failed-solo-error.js';
 import {MirrorNodeOperatorKeyRetrievalFailedSoloError} from './classes/component/mirror-node-operator-key-retrieval-failed-solo-error.js';
 import {OneShotDeployFailedSoloError} from './classes/component/one-shot-deploy-failed-solo-error.js';
 import {OneShotDestroyFailedSoloError} from './classes/component/one-shot-destroy-failed-solo-error.js';
@@ -415,6 +416,7 @@ export class SoloErrors {
     readonly mirrorNodeDeployFailed: typeof MirrorNodeDeployFailedSoloError;
     readonly mirrorNodeUpgradeFailed: typeof MirrorNodeUpgradeFailedSoloError;
     readonly mirrorNodeDestroyFailed: typeof MirrorNodeDestroyFailedSoloError;
+    readonly mirrorNodeJfrCollectionFailed: typeof MirrorNodeJfrCollectionFailedSoloError;
     readonly mirrorNodeOperatorKeyRetrievalFailed: typeof MirrorNodeOperatorKeyRetrievalFailedSoloError;
     readonly oneShotDeployFailed: typeof OneShotDeployFailedSoloError;
     readonly oneShotDestroyFailed: typeof OneShotDestroyFailedSoloError;
@@ -504,6 +506,7 @@ export class SoloErrors {
     mirrorNodeDeployFailed: MirrorNodeDeployFailedSoloError,
     mirrorNodeUpgradeFailed: MirrorNodeUpgradeFailedSoloError,
     mirrorNodeDestroyFailed: MirrorNodeDestroyFailedSoloError,
+    mirrorNodeJfrCollectionFailed: MirrorNodeJfrCollectionFailedSoloError,
     mirrorNodeOperatorKeyRetrievalFailed: MirrorNodeOperatorKeyRetrievalFailedSoloError,
     oneShotDeployFailed: OneShotDeployFailedSoloError,
     oneShotDestroyFailed: OneShotDestroyFailedSoloError,

--- a/test/e2e/commands/performance.test.ts
+++ b/test/e2e/commands/performance.test.ts
@@ -114,8 +114,7 @@ const endToEndTestSuite: EndToEndTestSuite = new EndToEndTestSuiteBuilder()
             testLogger.info(`${testName}: finished ${testName}: block node deploy`);
           }
 
-          // Opt-in: re-deploy the mirror node importer with JFR enabled (one-shot already added it without JFR)
-          // so its JVM metrics are recorded and collected at teardown.
+          // Opt-in: re-deploy the mirror node importer with JFR enabled so its JVM metrics are collected at teardown.
           if (process.env.PERFORMANCE_TEST_WITH_MIRROR_NODE_JFR === 'true') {
             testLogger.info(`${testName}: beginning ${testName}: mirror node upgrade (JFR enabled)`);
             await main(soloMirrorNodeJfrUpgrade(testName, deployment));

--- a/test/e2e/commands/performance.test.ts
+++ b/test/e2e/commands/performance.test.ts
@@ -18,6 +18,7 @@ import {main} from '../../../src/index.js';
 import {BaseCommandTest} from './tests/base-command-test.js';
 import {OneShotCommandDefinition} from '../../../src/commands/command-definitions/one-shot-command-definition.js';
 import {BlockCommandDefinition} from '../../../src/commands/command-definitions/block-command-definition.js';
+import {MirrorCommandDefinition} from '../../../src/commands/command-definitions/mirror-command-definition.js';
 import {MetricsServerImpl} from '../../../src/business/runtime-state/services/metrics-server-impl.js';
 import * as constants from '../../../src/core/constants.js';
 import {sleep} from '../../../src/core/helpers.js';
@@ -111,6 +112,14 @@ const endToEndTestSuite: EndToEndTestSuite = new EndToEndTestSuiteBuilder()
             testLogger.info(`${testName}: beginning ${testName}: block node deploy (JFR enabled)`);
             await main(soloBlockNodeJfrDeploy(testName, deployment));
             testLogger.info(`${testName}: finished ${testName}: block node deploy`);
+          }
+
+          // Opt-in: re-deploy the mirror node importer with JFR enabled (one-shot already added it without JFR)
+          // so its JVM metrics are recorded and collected at teardown.
+          if (process.env.PERFORMANCE_TEST_WITH_MIRROR_NODE_JFR === 'true') {
+            testLogger.info(`${testName}: beginning ${testName}: mirror node upgrade (JFR enabled)`);
+            await main(soloMirrorNodeJfrUpgrade(testName, deployment));
+            testLogger.info(`${testName}: finished ${testName}: mirror node upgrade`);
           }
 
           startTime = new Date();
@@ -351,6 +360,25 @@ export function soloBlockNodeJfrDeploy(testName: string, deployment: string): st
     deployment,
     optionFromFlag(Flags.valuesFile),
     PathEx.joinWithRealPath(constants.RESOURCES_DIR, 'block-node-perf-values.yaml'),
+  );
+  return argv;
+}
+
+export function soloMirrorNodeJfrUpgrade(testName: string, deployment: string): string[] {
+  const {newArgv, argvPushGlobalFlags, optionFromFlag} = BaseCommandTest;
+
+  const argv: string[] = newArgv();
+  argv.push(
+    MirrorCommandDefinition.COMMAND_NAME,
+    MirrorCommandDefinition.NODE_SUBCOMMAND_NAME,
+    MirrorCommandDefinition.NODE_UPGRADE,
+  );
+  argvPushGlobalFlags(argv, testName);
+  argv.push(
+    optionFromFlag(Flags.deployment),
+    deployment,
+    optionFromFlag(Flags.valuesFile),
+    PathEx.joinWithRealPath(constants.RESOURCES_DIR, 'mirror-node-perf-values.yaml'),
   );
   return argv;
 }

--- a/test/e2e/commands/tests/base-command-test.ts
+++ b/test/e2e/commands/tests/base-command-test.ts
@@ -15,6 +15,8 @@ import {getEnvironmentVariable} from '../../../../src/core/constants.js';
 import {ConsensusCommandDefinition} from '../../../../src/commands/command-definitions/consensus-command-definition.js';
 import {BlockCommandDefinition} from '../../../../src/commands/command-definitions/block-command-definition.js';
 import type BlockNodeCommand from '../../../../src/commands/block-node.js';
+import {MirrorCommandDefinition} from '../../../../src/commands/command-definitions/mirror-command-definition.js';
+import {type MirrorNodeCommand} from '../../../../src/commands/mirror-node.js';
 import {Templates} from '../../../../src/core/templates.js';
 import {type NodeAlias} from '../../../../src/types/aliases.js';
 import {PathEx} from '../../../../src/business/utils/path-ex.js';
@@ -143,6 +145,35 @@ export class BaseCommandTest {
     }
   }
 
+  public static async collectMirrorNodeJavaFlightRecorderLogs(
+    testName: string,
+    testLogger: SoloLogger,
+    deployment: string,
+  ): Promise<void> {
+    try {
+      testLogger.info(`${testName}: Collecting mirror node jfr logs...`);
+
+      const argv: Argv = Argv.getDefaultArgv(NamespaceName.of(testName), testName);
+      argv.setArg(Flags.deployment, deployment);
+      argv.setCommand(
+        MirrorCommandDefinition.COMMAND_NAME,
+        MirrorCommandDefinition.NODE_SUBCOMMAND_NAME,
+        MirrorCommandDefinition.NODE_COLLECT_JFR,
+      );
+
+      const mirrorNodeCommand: MirrorNodeCommand = container.resolve<MirrorNodeCommand>(InjectTokens.MirrorNodeCommand);
+      await mirrorNodeCommand.collectJfr(argv.build());
+
+      testLogger.info(`${testName}: Mirror node Java Flight Recorder logs collected successfully`);
+    } catch (error: unknown) {
+      // Best-effort: a run without a JFR-enabled mirror node should not fail teardown.
+      testLogger.error(`${testName}: Error collecting mirror node Java Flight Recorder logs: ${error}`);
+      if (error instanceof Error && error.stack) {
+        testLogger.error(`${testName}: Stack trace:\n${error.stack}`);
+      }
+    }
+  }
+
   /**
    * Sets up an after() hook for diagnostic log collection in E2E tests.
    * Call this within your test suite describe block.
@@ -167,6 +198,10 @@ export class BaseCommandTest {
 
     if (process.env.PERFORMANCE_TEST_WITH_BLOCK_NODE === 'true') {
       await BaseCommandTest.collectBlockNodeJavaFlightRecorderLogs(testName, testLogger, deployment);
+    }
+
+    if (process.env.PERFORMANCE_TEST_WITH_MIRROR_NODE_JFR === 'true') {
+      await BaseCommandTest.collectMirrorNodeJavaFlightRecorderLogs(testName, testLogger, deployment);
     }
   }
 

--- a/test/unit/commands/mirror-node-values.test.ts
+++ b/test/unit/commands/mirror-node-values.test.ts
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {expect} from 'chai';
+import {describe, it} from 'mocha';
+import fs from 'node:fs';
+import yaml from 'yaml';
+import * as constants from '../../../src/core/constants.js';
+import {PathEx} from '../../../src/business/utils/path-ex.js';
+
+interface MirrorNodePerformanceValuesConfig {
+  importer?: {
+    env?: {
+      JAVA_TOOL_OPTIONS?: string;
+    };
+  };
+}
+
+describe('Mirror node performance (JFR) values', (): void => {
+  const performanceValuesFile: string = PathEx.joinWithRealPath(
+    constants.RESOURCES_DIR,
+    'mirror-node-perf-values.yaml',
+  );
+
+  it('should enable a continuous on-disk Java Flight Recording on the importer', (): void => {
+    const valuesContent: string = fs.readFileSync(performanceValuesFile, 'utf8');
+    const parsedValues: MirrorNodePerformanceValuesConfig = yaml.parse(
+      valuesContent,
+    ) as MirrorNodePerformanceValuesConfig;
+    const javaToolOptions: string | undefined = parsedValues.importer?.env?.JAVA_TOOL_OPTIONS;
+
+    expect(javaToolOptions, 'importer.env.JAVA_TOOL_OPTIONS should be defined').to.be.a('string');
+    expect(javaToolOptions, 'JAVA_TOOL_OPTIONS should start a flight recording').to.include(
+      '-XX:StartFlightRecording=',
+    );
+    expect(javaToolOptions, 'recording should stream to disk').to.include('disk=true');
+    expect(javaToolOptions, 'recording should dump on JVM exit').to.include('dumponexit=true');
+    expect(javaToolOptions, 'recording should use the built-in profile settings').to.include('settings=profile');
+    expect(javaToolOptions, 'chunks should rotate at a bounded size').to.include('maxchunksize=');
+  });
+
+  it('should point the JFR repository at constants.MIRROR_NODE_JFR_REPOSITORY_DIRECTORY', (): void => {
+    const valuesContent: string = fs.readFileSync(performanceValuesFile, 'utf8');
+    const parsedValues: MirrorNodePerformanceValuesConfig = yaml.parse(
+      valuesContent,
+    ) as MirrorNodePerformanceValuesConfig;
+    const javaToolOptions: string | undefined = parsedValues.importer?.env?.JAVA_TOOL_OPTIONS;
+
+    // `solo mirror node collect-jfr` reads chunks from constants.MIRROR_NODE_JFR_REPOSITORY_DIRECTORY, so the
+    // repository configured in this overlay must match it exactly.
+    expect(
+      javaToolOptions,
+      'FlightRecorderOptions repository must match the constant collect-jfr reads from',
+    ).to.include(`repository=${constants.MIRROR_NODE_JFR_REPOSITORY_DIRECTORY}`);
+  });
+});

--- a/test/unit/commands/mirror-node-values.test.ts
+++ b/test/unit/commands/mirror-node-values.test.ts
@@ -12,6 +12,11 @@ interface MirrorNodePerformanceValuesConfig {
     env?: {
       JAVA_TOOL_OPTIONS?: string;
     };
+    volumeMounts?: {
+      jfr?: {
+        mountPath?: string;
+      };
+    };
   };
 }
 
@@ -45,11 +50,23 @@ describe('Mirror node performance (JFR) values', (): void => {
     ) as MirrorNodePerformanceValuesConfig;
     const javaToolOptions: string | undefined = parsedValues.importer?.env?.JAVA_TOOL_OPTIONS;
 
-    // `solo mirror node collect-jfr` reads chunks from constants.MIRROR_NODE_JFR_REPOSITORY_DIRECTORY, so the
-    // repository configured in this overlay must match it exactly.
+    // The overlay's repository must match the path `mirror node collect-jfr` reads from.
     expect(
       javaToolOptions,
       'FlightRecorderOptions repository must match the constant collect-jfr reads from',
     ).to.include(`repository=${constants.MIRROR_NODE_JFR_REPOSITORY_DIRECTORY}`);
+  });
+
+  it('should mount a dedicated writable volume at the JFR repository path', (): void => {
+    const valuesContent: string = fs.readFileSync(performanceValuesFile, 'utf8');
+    const parsedValues: MirrorNodePerformanceValuesConfig = yaml.parse(
+      valuesContent,
+    ) as MirrorNodePerformanceValuesConfig;
+    const jfrMountPath: string | undefined = parsedValues.importer?.volumeMounts?.jfr?.mountPath;
+
+    // The importer's root filesystem is read-only, so JFR must write into a mounted volume at the repository path.
+    expect(jfrMountPath, 'JFR volume must be mounted at the repository collect-jfr reads from').to.equal(
+      constants.MIRROR_NODE_JFR_REPOSITORY_DIRECTORY,
+    );
   });
 });


### PR DESCRIPTION
## Description

This pull request adds the ability to capture **JVM metrics for the Mirror Node importer** (heap, GC, threads, allocations) via Java Flight Recorder (JFR), mirroring the existing block-node JFR collection (#3512 / #4778) and adapting it to the Mirror Node importer's constraints.

The Mirror Node importer is a Spring Boot **JRE** image (no `jcmd` to dump a recording on demand) that runs with a **read-only root filesystem** and a writable `/tmp` `emptyDir`. So, exactly like the block node:

* A new values overlay, `resources/mirror-node-perf-values.yaml`, enables JFR on the importer JVM via `importer.env.JAVA_TOOL_OPTIONS` — a continuous on-disk recording using the JVM built-in `profile` settings, writing timestamped chunk files under the importer's writable `/tmp/jfr` with a small `maxchunksize` so chunks rotate frequently under load. The overlay also raises the importer's resource limits for the recording.
* A new command, `solo mirror node collect-jfr --deployment <name>`, consolidates the **finalized** chunks (excluding the still-open active chunk) into a single readable `.jfr` and downloads it to `~/.solo/logs/<deployment>/collected-recording.jfr`. It is **non-destructive** and can be run **repeatedly during** a performance test.
* The e2e performance test can optionally re-deploy the importer with JFR enabled (`mirror node upgrade --values-file`) and collects its recording automatically at teardown alongside the consensus-node and block-node JFR collection. Both the deploy and the teardown collection are opt-in via the `PERFORMANCE_TEST_WITH_MIRROR_NODE_JFR=true` env var, so default performance runs (and the CI memory budget) are unchanged; the teardown collection is best-effort and no-ops when JFR was not enabled.
* No CI workflow change is needed — the existing `~/.solo/logs/**/*.jfr` artifact glob (`solo-performance-test-jfr`, added in #4778) already captures the collected mirror-node recording.

Changes:

* `src/commands/mirror-node.ts` — `collect-jfr` command, config/context, flags list, and the chunk-consolidation download task.
* `src/commands/command-definitions/mirror-command-definition.ts` — registers the `mirror node collect-jfr` subcommand.
* `src/core/constants.ts` — `MIRROR_NODE_JFR_REPOSITORY_DIRECTORY` (in-pod JFR repository path under the writable `/tmp`) and `MIRROR_NODE_IMPORTER_CONTAINER_NAME`.
* `resources/mirror-node-perf-values.yaml` — JFR-enabling values overlay (new).
* `src/core/errors/**` — new `mirrorNodeJfrCollectionFailed` error factory (class + registry code + wiring); reuses the existing `mirrorNodePodsNotFound` system error for the missing-pod case.
* `test/unit/commands/mirror-node-values.test.ts` — unit tests for the JFR overlay (recording enabled + repository path matches the constant `collect-jfr` reads from).
* `test/e2e/commands/tests/base-command-test.ts` — collects the Mirror Node JFR recording during performance-test teardown (opt-in).
* `test/e2e/commands/performance.test.ts` — optionally enables JFR on the importer (opt-in via `PERFORMANCE_TEST_WITH_MIRROR_NODE_JFR`).

### Related Issues

* Closes #3511

### Pull request (PR) checklist

* [x] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [x] Any technical debt has been documented as a separate issue and linked to this PR
* [x] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [x] This PR added unit tests
* [x] This PR added integration/end-to-end tests
* [x] These changes required manual testing that is documented below
* [x] Anything not tested is documented

Automated tests added:

* Unit tests (`test/unit/commands/mirror-node-values.test.ts`) asserting the JFR overlay enables a continuous on-disk recording and that its repository path matches `constants.MIRROR_NODE_JFR_REPOSITORY_DIRECTORY` (the path `collect-jfr` reads from).
* E2E performance-test teardown now invokes Mirror Node JFR collection (`test/e2e/commands/tests/base-command-test.ts`), gated behind `PERFORMANCE_TEST_WITH_MIRROR_NODE_JFR`.

Verification performed:

* `task build:compile` compiles cleanly; ESLint is clean on all changed files.
* New unit tests pass (2/2); existing `mirror-node.test.ts` still passes (14/14).
* `solo mirror node collect-jfr --help` renders the expected command and flags.