### PR TITLE
fix: enable pinger task hangs on one-shot deploy

### DIFF
--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {spawnSync} from 'node:child_process';
+import {rmSync} from 'node:fs';
 import {dirname, join} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
@@ -13,8 +14,17 @@ const soloNoCache = process.env.SOLO_NO_CACHE?.toLowerCase() === 'true';
 const isGlobalInstall = process.env.npm_config_global === 'true';
 
 if (!isGlobalInstall) {
-  console.log('Skipping Solo image cache population because this is not a global npm install.');
+  console.log('Skipping Solo home directory reset and image cache population because this is not a global npm install.');
   process.exit(0);
+}
+
+// For global installations remove the Solo home directory on global install so stale config, logs, keys, and other
+// per-deployment state do not carry over.
+const soloHomeDirectory = process.env.SOLO_HOME || join(process.env.HOME || process.env.USERPROFILE, '.solo');
+try {
+  rmSync(soloHomeDirectory, {recursive: true, force: true});
+} catch (error) {
+  console.warn(`Failed to remove Solo home directory ${soloHomeDirectory}: ${error.message}. Continuing install.`);
 }
 
 if (soloNoCache) {

--- a/scripts/postinstall.mjs
+++ b/scripts/postinstall.mjs
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import {spawnSync} from 'node:child_process';
-import {rmSync} from 'node:fs';
 import {dirname, join} from 'node:path';
 import {fileURLToPath} from 'node:url';
 
@@ -14,17 +13,8 @@ const soloNoCache = process.env.SOLO_NO_CACHE?.toLowerCase() === 'true';
 const isGlobalInstall = process.env.npm_config_global === 'true';
 
 if (!isGlobalInstall) {
-  console.log('Skipping Solo home directory reset and image cache population because this is not a global npm install.');
+  console.log('Skipping Solo image cache population because this is not a global npm install.');
   process.exit(0);
-}
-
-// For global installations remove the Solo home directory on global install so stale config, logs, keys, and other
-// per-deployment state do not carry over.
-const soloHomeDirectory = process.env.SOLO_HOME || join(process.env.HOME || process.env.USERPROFILE, '.solo');
-try {
-  rmSync(soloHomeDirectory, {recursive: true, force: true});
-} catch (error) {
-  console.warn(`Failed to remove Solo home directory ${soloHomeDirectory}: ${error.message}. Continuing install.`);
 }
 
 if (soloNoCache) {

--- a/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
+++ b/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
@@ -71,6 +71,7 @@ import {
 } from '../../../../core/helpers.js';
 import {Duration} from '../../../../core/time/duration.js';
 import {BlockNodeDeployedEvent} from '../../../../core/events/event-types/block-node-deployed-event.js';
+import {MirrorNodeDeployedEvent} from '../../../../core/events/event-types/mirror-node-deployed-event.js';
 import {ListrLock} from '../../../../core/lock/listr-lock.js';
 import {UserBreak} from '../../../../core/errors/user-break.js';
 import {ConfirmationRequiredSoloError} from '../../../../core/errors/classes/validation/confirmation-required-solo-error.js';
@@ -625,24 +626,18 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
         'Deploy Solo components',
         [
           new OrchestratorPipelinePhase('Deploy block node', {
-            asListrTask: (
-              getConfig: () => OneShotSingleDeployConfigClass,
-            ): SoloListrTask<OneShotSingleDeployContext> => {
-              const skipAndNotify: () => boolean = (): boolean => {
-                const shouldSkip: boolean = !DeployArgvBuilders.shouldDeployBlockNode(getConfig());
-                if (shouldSkip) {
-                  this.eventBus.emit(new BlockNodeDeployedEvent(getConfig().deployment));
-                }
-                return shouldSkip;
-              };
-              return invokeSoloCommand(
+            asListrTask: (getConfig: () => OneShotSingleDeployConfigClass): SoloListrTask<OneShotSingleDeployContext> =>
+              invokeSoloCommand(
                 `solo ${BlockCommandDefinition.ADD_COMMAND}`,
                 BlockCommandDefinition.ADD_COMMAND,
                 (): string[] => DeployArgvBuilders.buildBlockNodeArgv(getConfig()),
                 this.taskList,
-                skipAndNotify,
-              );
-            },
+                OrchestratorPipelinePhase.skipAndNotify(
+                  this.eventBus,
+                  (): boolean => !DeployArgvBuilders.shouldDeployBlockNode(getConfig()),
+                  [(): BlockNodeDeployedEvent => new BlockNodeDeployedEvent(getConfig().deployment)],
+                ),
+              ),
           }),
           OrchestratorPipelinePhase.composite('Deploy network node', [
             new OrchestratorPipelinePhase('Deploy consensus node', {
@@ -696,7 +691,9 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
                 MirrorCommandDefinition.ADD_COMMAND,
                 (): string[] => DeployArgvBuilders.buildMirrorNodeArgv(getConfig(), false),
                 this.taskList,
-                (): boolean => !getConfig().deployMirrorNode,
+                OrchestratorPipelinePhase.skipAndNotify(this.eventBus, (): boolean => !getConfig().deployMirrorNode, [
+                  (): MirrorNodeDeployedEvent => new MirrorNodeDeployedEvent(getConfig().deployment),
+                ]),
               ),
           }),
           new OrchestratorPipelinePhase('Enable mirror pinger', {

--- a/src/commands/one-shot/orchestrator/orchestrator-pipeline-phase.ts
+++ b/src/commands/one-shot/orchestrator/orchestrator-pipeline-phase.ts
@@ -64,6 +64,38 @@ export class OrchestratorPipelinePhase<TConfig extends {deployment: string}, TCo
     return this;
   }
 
+  /**
+   * Builds a skip callback that also emits one or more events when the skip condition is true.
+   *
+   * Use this for phases that other phases wait on via {@link withWaitCondition}: a skipped phase
+   * still has to notify downstream waiters, otherwise their {@link SoloEventBus.waitFor} blocks until
+   * it times out. This is the counterpart to {@link withWaitCondition} — one waits for events, the
+   * other emits them when there is no work to do.
+   *
+   * Events are supplied as factories because a phase's payload (for example the deployment name) is
+   * only known once the pipeline config is populated at run time, after the phases have been built.
+   *
+   * @param eventBus - the bus the events are emitted on
+   * @param skipCallback - returns true when the phase should be skipped
+   * @param eventsToEmit - event factories emitted, in order, when the phase is skipped
+   * @returns a skip callback that emits the events and returns the skip decision
+   */
+  public static skipAndNotify(
+    eventBus: SoloEventBus,
+    skipCallback: () => boolean,
+    eventsToEmit: Array<() => AnySoloEvent>,
+  ): () => boolean {
+    return (): boolean => {
+      const shouldSkip: boolean = skipCallback();
+      if (shouldSkip) {
+        for (const createEvent of eventsToEmit) {
+          eventBus.emit(createEvent());
+        }
+      }
+      return shouldSkip;
+    };
+  }
+
   public asListrTask(getConfig: () => TConfig, eventBus: SoloEventBus): SoloListrTask<TContext> {
     const shouldInjectFailure: boolean =
       (process.env.SOLO_FAIL_AFTER_STEP ?? '').replaceAll("'", '').replaceAll('"', '') === this.title;

--- a/src/core/errors/classes/component/one-shot-deploy-failed-solo-error.ts
+++ b/src/core/errors/classes/component/one-shot-deploy-failed-solo-error.ts
@@ -22,7 +22,9 @@ export class OneShotDeployFailedSoloError extends SoloError {
         troubleshootingSteps:
           'Check solo logs: tail -n 100 ~/.solo/logs/solo.log\n' +
           'If rollback was skipped, clean up partial resources: solo one-shot single destroy\n' +
-          'If nothing else works, remove the entire SOLO_HOME directory (~/.solo by default, or $SOLO_HOME if set)',
+          'If nothing else works, remove the SOLO_HOME directory and delete the cluster:\n +' +
+          'kind delete cluster --name solo-cluster\n' +
+          'rm -rf ~/.solo\n',
       },
       cause,
     );

--- a/src/core/errors/classes/component/one-shot-deploy-failed-solo-error.ts
+++ b/src/core/errors/classes/component/one-shot-deploy-failed-solo-error.ts
@@ -21,7 +21,8 @@ export class OneShotDeployFailedSoloError extends SoloError {
         code: ErrorCodeRegistry.ONE_SHOT_DEPLOY_FAILED,
         troubleshootingSteps:
           'Check solo logs: tail -n 100 ~/.solo/logs/solo.log\n' +
-          'If rollback was skipped, clean up partial resources: solo one-shot single destroy',
+          'If rollback was skipped, clean up partial resources: solo one-shot single destroy\n' +
+          'If nothing else works, remove the entire SOLO_HOME directory (~/.solo by default, or $SOLO_HOME if set)',
       },
       cause,
     );


### PR DESCRIPTION
## Description

The PR fixes a possible process hanging on the `Enable mirror pinger` step. This can happen when a `one-shot` deployment exists on the cluster, but the user has deleted their `local-config.yaml` file. 

The PR also adds new troubleshooting steps to the SOLO-3035 error, which suggest the user perform a complete cleanup of their environment. 

The immediate error described in the linked issue is resolved in [this PR](https://github.com/hiero-ledger/solo/pull/4894). The issue could be observed with solo v0.80.0 when the `local-config.yaml` file was present, but the deployment did not exist in the cluster, the opposite of the case that caused the hanging pinger issue.

### Related Issues

* Closes #4937
* Related to #

### Pull request (PR) checklist

* \[ ] This PR added tests (unit, integration, and/or end-to-end)
* \[ ] This PR updated documentation
* \[ ] This PR added no TODOs or commented out code
* \[ ] This PR has no breaking changes
* \[ ] Any technical debt has been documented as a separate issue and linked to this PR
* \[ ] Any `package.json` changes have been explained to and approved by a repository manager
* \[ ] All related issues have been linked to this PR
* \[ ] All changes in this PR are included in the description
* \[ ] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* \[ ] This PR added unit tests
* \[ ] This PR added integration/end-to-end tests
* \[ ] These changes required manual testing that is documented below
* \[ ] Anything not tested is documented

The following manual testing was done:

* TBD

The following was not tested:

* TBD

<details>
<summary>
Commit message guidelines
</summary>
We use 'Conventional Commits' to ensure that our commit messages are easy to read, follow a consistent format, and for automated release note generation. Please follow the guidelines below when writing your commit messages:

1. BREAKING CHANGE: a commit that has a footer BREAKING CHANGE:, or appends a ! after the type/scope, introduces a breaking API change (correlating with MAJOR in Semantic Versioning). A BREAKING CHANGE can be part of commits of any type.  NOTE: currently breaking changes will only bump the MAJOR version.
2. The title is prefixed with one of the following:

| Prefix    | Description                                         | Semantic Version Update | Captured in Release Notes |
|-----------|-----------------------------------------------------|-------------------------|---------------------------|
| feat:     | a new feature                                       | MINOR                   | Yes                       |
| fix:      | a bug fix                                           | PATCH                   | Yes                       |
| perf:     | performance                                         | PATCH                   | Yes                       |
| refactor: | code change that isn't feature or fix               | none                    | No                        |
| test:     | adding missing tests                                | none                    | No                        |
| docs:     | changes to documentation                            | none                    | Yes                        |
| build:    | changes to build process                            | none                    | No                        |
| ci:       | changes to CI configuration                         | none                    | No                        |
| style:    | formatting, missing semi-colons, etc                | none                    | No                        |
| chore:    | updating grunt tasks etc; no production code change | none                    | No                        |

</details>
