### PR TITLE
fix: wait for mirror node database schema before dependent readiness checks

### DIFF
--- a/resources/mirror-node-values-hedera.yaml
+++ b/resources/mirror-node-values-hedera.yaml
@@ -40,10 +40,11 @@ importer:
     initialDelaySeconds: 0
     periodSeconds: 1
     failureThreshold: 60
+  # Importer startup includes the first-run Flyway schema build; 300 matches mirror-node-values.yaml
   startupProbe:
     initialDelaySeconds: 0
     periodSeconds: 1
-    failureThreshold: 60
+    failureThreshold: 300
   envFrom:
     - secretRef:
         name: mirror-passwords

--- a/src/commands/mirror-node.ts
+++ b/src/commands/mirror-node.ts
@@ -1132,9 +1132,49 @@ export class MirrorNodeCommand extends BaseCommand {
                 await this.deployMirrorNode(context_, commandType);
               },
             },
+            this.waitForMirrorNodeSchemaTask(),
           ],
           constants.LISTR_DEFAULT_OPTIONS.DEFAULT,
         ),
+    };
+  }
+
+  /**
+   * Waits for the importer to become ready — and thus for its Flyway schema migrations to complete —
+   * before dependent components are health-checked. Without this gate, a slow first-run schema build
+   * lets REST/REST-Java/Web3/gRPC query a partially-migrated database and fail the deployment.
+   */
+  private waitForMirrorNodeSchemaTask(): SoloListrTask<AnyListrContext> {
+    return {
+      title: 'Wait for mirror node database schema',
+      task: async (context_): Promise<void> => {
+        const config: MirrorNodeDeployConfigClass | MirrorNodeUpgradeConfigClass = context_.config;
+        const importerLabels: string[] = [
+          'app.kubernetes.io/component=importer',
+          `app.kubernetes.io/instance=${config.releaseName}`,
+        ];
+        const pods: Pods = this.k8Factory.getK8(config.clusterContext).pods();
+
+        try {
+          await pods.waitForRunningPhase(
+            config.namespace,
+            importerLabels,
+            constants.MIRROR_NODE_IMPORTER_DETECT_MAX_ATTEMPTS,
+            constants.MIRROR_NODE_IMPORTER_DETECT_DELAY,
+          );
+        } catch {
+          // importer disabled via custom values — no schema build to wait for
+          this.logger.info(`No importer pod found for release ${config.releaseName}; skipping mirror node schema wait`);
+          return;
+        }
+
+        await pods.waitForReadyStatus(
+          config.namespace,
+          importerLabels,
+          constants.MIRROR_NODE_SCHEMA_READY_MAX_ATTEMPTS,
+          constants.MIRROR_NODE_SCHEMA_READY_DELAY,
+        );
+      },
     };
   }
 

--- a/src/core/constants.ts
+++ b/src/core/constants.ts
@@ -468,6 +468,13 @@ export const MIRROR_NODE_PINGER_PODS_READY_MAX_ATTEMPTS: number =
   +getEnvironmentVariable('MIRROR_NODE_PINGER_PODS_READY_MAX_ATTEMPTS') || 900;
 export const MIRROR_NODE_PINGER_PODS_READY_DELAY: number =
   +getEnvironmentVariable('MIRROR_NODE_PINGER_PODS_READY_DELAY') || 2000;
+export const MIRROR_NODE_SCHEMA_READY_MAX_ATTEMPTS: number =
+  +getEnvironmentVariable('MIRROR_NODE_SCHEMA_READY_MAX_ATTEMPTS') || 900;
+export const MIRROR_NODE_SCHEMA_READY_DELAY: number = +getEnvironmentVariable('MIRROR_NODE_SCHEMA_READY_DELAY') || 2000;
+export const MIRROR_NODE_IMPORTER_DETECT_MAX_ATTEMPTS: number =
+  +getEnvironmentVariable('MIRROR_NODE_IMPORTER_DETECT_MAX_ATTEMPTS') || 15;
+export const MIRROR_NODE_IMPORTER_DETECT_DELAY: number =
+  +getEnvironmentVariable('MIRROR_NODE_IMPORTER_DETECT_DELAY') || 2000;
 export const RELAY_PODS_RUNNING_MAX_ATTEMPTS: number =
   +getEnvironmentVariable('RELAY_PODS_RUNNING_MAX_ATTEMPTS') || 900;
 export const RELAY_PODS_RUNNING_DELAY: number =

--- a/test/unit/commands/mirror-node.test.ts
+++ b/test/unit/commands/mirror-node.test.ts
@@ -45,6 +45,8 @@ interface MirrorNodeCommandInternal {
   addMirrorNodeImageTagOverrides: (chartValues: HelmChartValues, mirrorNodeVersion: string) => void;
   initializeSharedPostgresDatabaseTask: () => SoloListrTask<MirrorNodeDatabaseTaskContext>;
   primePostgresSecretTask: () => SoloListrTask<MirrorNodeDatabaseTaskContext>;
+  waitForMirrorNodeSchemaTask: () => SoloListrTask<MirrorNodeSchemaWaitTaskContext>;
+  k8Factory: {getK8: (context: string) => {pods: () => MirrorNodeSchemaWaitPodsStub}};
   prepareBlockNodeIntegrationValues: (config: {
     cacheDir: string;
     clusterReference: string;
@@ -65,11 +67,37 @@ interface MirrorNodeDatabaseTaskContext {
   };
 }
 
+interface MirrorNodeSchemaWaitTaskContext {
+  config: {
+    releaseName: string;
+    clusterContext: string;
+    namespace: {name: string};
+  };
+}
+
+interface MirrorNodeSchemaWaitPodsStub {
+  waitForRunningPhase: sinon.SinonStub;
+  waitForReadyStatus: sinon.SinonStub;
+}
+
 type MirrorNodeDatabaseSkip = (context: MirrorNodeDatabaseTaskContext) => boolean;
 
 function getSkipFunction(task: SoloListrTask<MirrorNodeDatabaseTaskContext>): MirrorNodeDatabaseSkip {
   expect(task.skip).to.be.a('function');
   return task.skip as MirrorNodeDatabaseSkip;
+}
+
+function stubImporterPods(
+  command: MirrorNodeCommand,
+  podsStub: MirrorNodeSchemaWaitPodsStub,
+): MirrorNodeCommandInternal {
+  const mirrorNodeCommandInternal: MirrorNodeCommandInternal = command as unknown as MirrorNodeCommandInternal;
+  mirrorNodeCommandInternal.k8Factory = {
+    getK8: (): {pods: () => MirrorNodeSchemaWaitPodsStub} => ({
+      pods: (): MirrorNodeSchemaWaitPodsStub => podsStub,
+    }),
+  };
+  return mirrorNodeCommandInternal;
 }
 
 interface MirrorNodeIntegrationValues {
@@ -421,5 +449,48 @@ describe('MirrorNodeCommand unit tests', (): void => {
     } finally {
       fs.rmSync(cacheDirection, {recursive: true, force: true});
     }
+  });
+
+  describe('waitForMirrorNodeSchemaTask', (): void => {
+    const schemaWaitContext: MirrorNodeSchemaWaitTaskContext = {
+      config: {
+        releaseName: 'mirror-1',
+        clusterContext: 'kind-a',
+        namespace: {name: 'solo'},
+      },
+    };
+
+    it('should wait for importer readiness with the schema budget once the importer pod is running', async (): Promise<void> => {
+      const podsStub: MirrorNodeSchemaWaitPodsStub = {
+        waitForRunningPhase: sinon.stub().resolves([{}]),
+        waitForReadyStatus: sinon.stub().resolves([{}]),
+      };
+      const mirrorNodeCommandInternal: MirrorNodeCommandInternal = stubImporterPods(mirrorNodeCommand, podsStub);
+
+      const task: SoloListrTask<MirrorNodeSchemaWaitTaskContext> =
+        mirrorNodeCommandInternal.waitForMirrorNodeSchemaTask();
+      await (task.task as (context: MirrorNodeSchemaWaitTaskContext) => Promise<void>)(schemaWaitContext);
+
+      const expectedLabels: string[] = ['app.kubernetes.io/component=importer', 'app.kubernetes.io/instance=mirror-1'];
+      expect(podsStub.waitForRunningPhase.calledOnce).to.equal(true);
+      expect(podsStub.waitForReadyStatus.calledOnce).to.equal(true);
+      expect(podsStub.waitForReadyStatus.firstCall.args[1]).to.deep.equal(expectedLabels);
+      expect(podsStub.waitForReadyStatus.firstCall.args[2]).to.equal(constants.MIRROR_NODE_SCHEMA_READY_MAX_ATTEMPTS);
+      expect(podsStub.waitForReadyStatus.firstCall.args[3]).to.equal(constants.MIRROR_NODE_SCHEMA_READY_DELAY);
+    });
+
+    it('should skip the schema wait when no importer pod appears', async (): Promise<void> => {
+      const podsStub: MirrorNodeSchemaWaitPodsStub = {
+        waitForRunningPhase: sinon.stub().rejects(new Error('no pods found')),
+        waitForReadyStatus: sinon.stub().resolves([{}]),
+      };
+      const mirrorNodeCommandInternal: MirrorNodeCommandInternal = stubImporterPods(mirrorNodeCommand, podsStub);
+
+      const task: SoloListrTask<MirrorNodeSchemaWaitTaskContext> =
+        mirrorNodeCommandInternal.waitForMirrorNodeSchemaTask();
+      await (task.task as (context: MirrorNodeSchemaWaitTaskContext) => Promise<void>)(schemaWaitContext);
+
+      expect(podsStub.waitForReadyStatus.called).to.equal(false);
+    });
   });
 });


### PR DESCRIPTION
## Description

This pull request changes the following:

* Adds a `Wait for mirror node database schema` task after the mirror chart install (deploy and upgrade paths). The importer builds the mirror node schema via Flyway during startup, and its readiness implies the migrations are complete — so the schema build now gets its own timeout budget instead of sharing the readiness budget of the dependent components.
* Adds env-tunable constants for the schema wait (`MIRROR_NODE_SCHEMA_READY_MAX_ATTEMPTS`, `MIRROR_NODE_SCHEMA_READY_DELAY`) and for importer pod detection (`MIRROR_NODE_IMPORTER_DETECT_MAX_ATTEMPTS`, `MIRROR_NODE_IMPORTER_DETECT_DELAY`). When no importer pod exists (disabled via custom values), the wait is skipped.
* Aligns the importer `startupProbe.failureThreshold` in `mirror-node-values-hedera.yaml` (60s → 300s) with `mirror-node-values.yaml`, so a first-run schema build is not killed mid-flight by the startup probe.

Root cause: on a first clean deploy, REST/REST-Java/Web3/gRPC start concurrently with the importer and query a partially-migrated database (`relation/column "..." does not exist`). On a slow machine the schema build consumes the shared readiness budget and the deployment fails; the pinger bootstrap against REST-Java (`/api/v1/network/nodes` returning 500 `column "account_id" does not exist`) then crash-loops. Destroy + redeploy succeeds because warm caches shrink the race window.

### Related Issues

* Closes #4967

### Pull request (PR) checklist

* [x] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [ ] Any technical debt has been documented as a separate issue and linked to this PR
* [ ] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [x] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [x] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* Reproduced the reported failure mechanism on solo v0.81.0 with a clean-state `one-shot single deploy` plus a CPU-throttled importer (stretched Flyway window): captured `500 column "account_id" does not exist` from REST-Java's `/api/v1/network/nodes` mid-migration and 3 pinger crash-loop restarts.
* Verified the fix with a full `one-shot single deploy` (fresh cluster and database, importer throttled to 100m CPU): `Wait for mirror node database schema` gated the deploy for the full 40s schema build on the deploy path and was an instant no-op on the upgrade path; all component checks passed afterwards, every pod finished with 0 restarts, and `GET /api/v1/network/nodes` returned HTTP 200 with node data. Deploy exit code 0.
* `npx mocha 'test/unit/commands/mirror-node.test.ts'` (16 passing, including 2 new tests)
* `npx eslint` / `npx prettier --check` / `npx tsc --noEmit` on the changed files

The following was not tested:

* `--use-external-database` deployments (the wait applies there too; importer readiness semantics are identical)
