### PR TITLE
fix: show usage help instead of internal SOLO-9007 error for invalid CLI arguments

### DIFF
--- a/src/argument-processor.ts
+++ b/src/argument-processor.ts
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-import {SoloErrors} from './core/errors/solo-errors.js';
 import {SilentBreak} from './core/errors/silent-break.js';
 import {Flags as flags} from './commands/flags.js';
 import {type Middlewares} from './core/middlewares.js';
@@ -59,35 +58,26 @@ export class ArgumentProcessor {
           throw new SilentBreak('Help displayed');
         }
 
-        if (
-          message.includes('Unknown argument') ||
-          message.includes('Missing required argument') ||
-          message.toLowerCase().includes('select')
-        ) {
-          if (message.toLowerCase().includes('select')) {
-            // Show what subcommands are available then exit normally
-            rootCmd.showHelp((output): void => {
-              helpRenderer.render(rootCmd, output);
-            });
-            // Use SilentBreak to exit cleanly without error display
-            throw new SilentBreak('No subcommand provided, help displayed');
-          }
-
-          // For unknown/missing arguments, show message and help
-          logger.showUser(message);
+        if (message.toLowerCase().includes('select')) {
+          // Show what subcommands are available then exit normally
           rootCmd.showHelp((output): void => {
             helpRenderer.render(rootCmd, output);
           });
+          // Use SilentBreak to exit cleanly without error display
+          throw new SilentBreak('No subcommand provided, help displayed');
+        }
 
-          // Throw error to propagate through async call chains if given unknown argument
-          if (!rootCmd.parsed.argv.help) {
-            // Set exit code but don't exit immediately - allows I/O buffers to flush
-            process.exitCode = 1;
-            throw new SoloErrors.internal.commandReturnedFalse('argument-processor', message);
-          }
-        } else {
-          logger.showUserError(new SoloErrors.internal.commandReturnedFalse('argument-processor', message));
-          throw new SoloErrors.internal.commandReturnedFalse('argument-processor', message);
+        // Any other yargs failure is a CLI usage error: show it with the usage help, without an internal error report
+        logger.showUser(message);
+        rootCmd.showHelp((output): void => {
+          helpRenderer.render(rootCmd, output);
+        });
+
+        // Throw to propagate through async call chains when given an invalid argument
+        if (!rootCmd.parsed.argv.help) {
+          // Set exit code but don't exit immediately - allows I/O buffers to flush
+          process.exitCode = 1;
+          throw new SilentBreak(message);
         }
       }
     });

--- a/test/unit/core/argument-processor.test.ts
+++ b/test/unit/core/argument-processor.test.ts
@@ -194,6 +194,22 @@ describe('ArgumentProcessor', (): void => {
       expect(output).to.include('Missing required argument: deployment');
       expect(process.exitCode).to.equal(1);
     });
+
+    it('should throw SilentBreak for a missing required argument so no internal error is displayed', async (): Promise<void> => {
+      const argv: string[] = ['node', 'solo.ts', 'consensus', 'network', 'destroy'];
+      process.exitCode = undefined;
+
+      try {
+        await ArgumentProcessor.process(argv);
+        expect.fail('Expected SilentBreak to be thrown');
+      } catch (error: unknown) {
+        expect((error as Error).constructor.name).to.equal('SilentBreak');
+      }
+
+      const output: string = consoleOutput.join('\n');
+      expect(output).to.not.include('SOLO-9007');
+      expect(process.exitCode).to.equal(1);
+    });
   });
 
   describe('Unknown Arguments', (): void => {
@@ -218,6 +234,49 @@ describe('ArgumentProcessor', (): void => {
 
       const output: string = consoleOutput.join('\n');
       expect(output).to.include('Unknown');
+    });
+
+    it('should treat an unknown short flag as a usage error without an internal error report', async (): Promise<void> => {
+      // Repro from https://github.com/hiero-ledger/solo/issues/5062
+      const argv: string[] = ['node', 'solo.ts', 'deployment', 'config', 'list', '-d', 'one-shot'];
+      process.exitCode = undefined;
+
+      try {
+        await ArgumentProcessor.process(argv);
+        expect.fail('Expected SilentBreak to be thrown');
+      } catch (error: unknown) {
+        expect((error as Error).constructor.name).to.equal('SilentBreak');
+        expect((error as Error).message).to.include('Unknown argument');
+      }
+
+      const output: string = consoleOutput.join('\n');
+      expect(output).to.include('Unknown argument');
+      expect(output).to.not.include('SOLO-9007');
+      expect(output).to.not.include('File a bug report');
+      expect(process.exitCode).to.equal(1);
+    });
+
+    it('should throw SilentBreak for an unknown flag so no internal error is displayed', async (): Promise<void> => {
+      const argv: string[] = [
+        'node',
+        'solo.ts',
+        'consensus',
+        'network',
+        'deploy',
+        '--deployment',
+        'test',
+        '--unknown-flag',
+      ];
+      process.exitCode = undefined;
+
+      try {
+        await ArgumentProcessor.process(argv);
+        expect.fail('Expected SilentBreak to be thrown');
+      } catch (error: unknown) {
+        expect((error as Error).constructor.name).to.equal('SilentBreak');
+      }
+
+      expect(process.exitCode).to.equal(1);
     });
   });
 


### PR DESCRIPTION
## Description

This pull request changes the following:

* Treats every failure message reported by yargs (unknown argument, missing required argument, invalid values, ...) as a CLI usage error: solo now shows the message together with the command usage help, sets exit code 1, and unwinds with `SilentBreak` so no internal error report is displayed.
* Previously, an invalid argument such as `solo deployment config list -d one-shot` was wrapped in `SoloErrors.internal.commandReturnedFalse`, so the top-level error handler rendered an internal-error report — the `SOLO-9007` box, "This is an internal Solo error. File a bug report", an unrelated troubleshooting link, and the diagnostics tips — for a plain user typo. Non-argument validation messages additionally rendered the internal error box twice (once inside the yargs `fail()` handler and once in the top-level handler).
* `SOLO-9007` (`commandReturnedFalse`) keeps its real meaning and its other call sites (command returning `false`, uncaught exceptions); only its misuse for CLI usage errors is removed.

### Related Issues

* Closes #5062

### Pull request (PR) checklist

* [x] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [ ] Any technical debt has been documented as a separate issue and linked to this PR
* [ ] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [x] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [x] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* Reproduced the issue command `solo deployment config list -d one-shot` (via `npm run solo-test`): it now prints `Unknown argument: d` followed by the command usage help and exits with code 1 — no `SOLO-9007` box, no "file a bug report" guidance, no diagnostics tips.
* `npx mocha 'test/unit/core/argument-processor.test.ts'` — 28 passing (3 new tests: the issue repro asserting no internal error output and exit code 1, plus `SilentBreak` propagation for unknown flags and missing required arguments; all pre-existing assertions unchanged and passing).
* `npx eslint`, `npx prettier --check` on the changed files and `npx tsc --noEmit` — clean.

The following was not tested:

* Interactive TTY rendering differences of the help output (help renderer is unchanged by this PR).
