### PR TITLE
fix: declare reflect-metadata as a runtime dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,7 @@
         "listr2": "11.0.0",
         "pino": "10.3.1",
         "pino-pretty": "13.1.3",
+        "reflect-metadata": "0.2.2",
         "rotating-file-stream": "3.2.9",
         "selfsigned": "5.5.0",
         "shell-quote": "1.10.0",
@@ -1423,6 +1424,7 @@
       "resolved": "https://registry.npmjs.org/@inquirer/prompts/-/prompts-8.5.2.tgz",
       "integrity": "sha512-IYR/3C/paEVVQYQvdDlFZVjRCJVYHHON0XXMH91KO9GSxs0TdKYWlUdvfQl2EfAHDxUaN3IBffkE/BDTh5nJ6g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@inquirer/checkbox": "^5.2.1",
         "@inquirer/confirm": "^6.1.1",
@@ -2886,6 +2888,7 @@
       "integrity": "sha512-promo4eFwuiW+TfGxhi+0x3czqTYJkG8qB17ZUJiVF10Xm7NLVRSLUsfRTU/6h1e24VvRnXCx+hG7li58lkzog==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/linkify-it": "^5",
         "@types/mdurl": "^2"
@@ -3293,6 +3296,7 @@
       "integrity": "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3371,6 +3375,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
       "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3383,6 +3388,7 @@
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
       "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -3809,6 +3815,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.42",
         "caniuse-lite": "^1.0.30001803",
@@ -4056,6 +4063,7 @@
       "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -4566,6 +4574,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -5240,6 +5249,7 @@
       "integrity": "sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5316,6 +5326,7 @@
       "integrity": "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "eslint-config-prettier": "bin/cli.js"
       },
@@ -7893,6 +7904,7 @@
       "resolved": "https://registry.npmjs.org/jsep/-/jsep-1.4.0.tgz",
       "integrity": "sha512-B7qPcEVE3NVkmSJbaYxvv4cHkVW7DQsZz13pUMrfS8z8Q/BuShN+gcTXrUlPiGqM2/t/EEaI030bpxMqY8gMlw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 10.16.0"
       }
@@ -8060,6 +8072,7 @@
       "resolved": "https://registry.npmjs.org/listr2/-/listr2-11.0.0.tgz",
       "integrity": "sha512-8K88S0aSrcSXdJfiZtEy5BQMnR+TyjrCGLcgAvQs6ta0NEnIm0RJ72/Pv67Jvg07cfBhDbuN74V81lSSVYEFEw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "cli-truncate": "^6.1.1",
         "log-update": "^8.0.0",
@@ -8299,6 +8312,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "argparse": "^2.0.1",
         "entities": "^4.5.0",
@@ -9201,6 +9215,7 @@
       "integrity": "sha512-nS9xOGbw2I3cjCpxwZAEJ9xK9lmJ08vEkQvLtz4du9ZrF9UrjRpeJGiIgl2Z+Qs++pmB4ecDe48Fwsh+j+j7xA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "browser-stdout": "^1.3.1",
         "chokidar": "^4.0.1",
@@ -10271,6 +10286,7 @@
       "integrity": "sha512-OpN0zzVdiaiAhxpuuj5efpIS4sY9j7bY6uR5mnj5yPzGkdkjNKSJeUThPb60Jw29QuAZgA4o+/iB49kFiaBX6g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "prettier": "bin/prettier.cjs"
       },
@@ -10346,6 +10362,7 @@
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-8.7.1.tgz",
       "integrity": "sha512-agdGHrXNTv0IrYscJPDou/PlEJk1c/hBZ9o/B5NH2i/nSPtPqacNxzgwf1CebXxFMjMrZH5sqv9uQuw96aGt/A==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "long": "^5.3.2"
       },
@@ -12124,6 +12141,7 @@
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.1.2.tgz",
       "integrity": "sha512-gmBGslpoQJtgnMAvOVqGZpEz9dyoKTCzy2nfz/n8aIFhN/jCE/rCmcxabB6jOOHV+0WNnylOxaxBQPSvcWklhA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^6.0.1"
       },
@@ -12494,6 +12512,7 @@
       "integrity": "sha512-RvwwcruNjI1ncT5xRakeyS9Lf8lcItv34KD+aif+VH9kduAyfYBipGh12274xtenIPZ119/R9BdTBa8gAwSh0A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12817,6 +12836,7 @@
       "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -12909,6 +12929,7 @@
       "integrity": "sha512-CZ4nMxWwgu1HEEFNkeaCptra9QCtkmKdgf3sWh1rl1trIhmxLilgTV4cwcbQ4wemnT4sWQN8CaKOmdYx+g2gMA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.65.0",
         "@typescript-eslint/types": "8.65.0",
@@ -13952,6 +13973,7 @@
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.1.tgz",
       "integrity": "sha512-+0NTnW77fFN/DjQi6k/Sq/Yvk4Sgajw7urW8V+asjXnRgDs9gyGkdb7EzgfhA4goXsRIZKE28fzIXBHEzhuiWw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "listr2": "11.0.0",
     "pino": "10.3.1",
     "pino-pretty": "13.1.3",
+    "reflect-metadata": "0.2.2",
     "rotating-file-stream": "3.2.9",
     "selfsigned": "5.5.0",
     "shell-quote": "1.10.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,6 @@
 
 import chalk from 'chalk';
 import 'dotenv/config';
-// eslint-disable-next-line n/no-extraneous-import
 import 'reflect-metadata';
 import {container} from 'tsyringe-neo';
 import {ListrLogger} from 'listr2';

--- a/test/setup.ts
+++ b/test/setup.ts
@@ -1,6 +1,5 @@
 // SPDX-License-Identifier: Apache-2.0
 
-// eslint-disable-next-line n/no-extraneous-import
 import 'reflect-metadata';
 import * as chai from 'chai';
 import chaiAsPromised from 'chai-as-promised';


### PR DESCRIPTION
## Description

`src/index.ts` starts with a bare `import 'reflect-metadata'` (required for tsyringe's decorator metadata), but nothing in solo's dependency tree declares the package: `tsyringe-neo@5.1.0` carries it only in `devDependencies`, and the only copy in the tree arrives transitively via `selfsigned → @peculiar/x509@1.x`. On npm/yarn's hoisted layouts the bare import resolves by accident; under pnpm with strict isolation it fails on **every** solo command with `ERR_MODULE_NOT_FOUND: Cannot find package 'reflect-metadata'`.

This PR adds `"reflect-metadata": "0.2.2"` to `dependencies` — the exact version already resolved in the tree, so there is zero runtime change; the import just becomes legitimate.

Two notes for reviewers:

* This is more urgent than "pnpm only": solo's **direct** `@peculiar/x509@2.0.0` dependency no longer ships `reflect-metadata`, so the accidental resolution survives solely through the old `1.x` copy nested under `selfsigned`. The moment `selfsigned` upgrades its `@peculiar/x509`, every package manager would hit this crash.
* Reproducing on pnpm ≥10 needs `hoist=false` in addition to the issue's `node-linker=isolated` — default hoisting places transitives in `.pnpm/node_modules`, which shadows the bug.

Verified end-to-end: `npm pack` of this branch installed into a pnpm project with `node-linker=isolated` + `hoist=false` imports cleanly (`IMPORT OK`), while published `@hiero-ledger/solo@0.83.0` fails in the same sandbox with the exact error from the issue. `npm run solo-test -- --version` also confirmed the CLI still runs.

The `package.json` change is a single dependency addition (per the checklist, flagging it here for repository-manager approval).

### Related Issues

* Fixes #5313