### PR TITLE
test(ci): fan out install validation across supported Linux distributions

### DIFF
--- a/.github/workflows/flow-install-validation.yaml
+++ b/.github/workflows/flow-install-validation.yaml
@@ -91,14 +91,24 @@ jobs:
             use_setup_node: true
           # Alpine is musl, so the glibc runtime actions/setup-node downloads cannot execute; the
           # apk-provided Node (22.x in 3.21) is used instead. GNU tar is required because busybox
-          # tar cannot serve the actions that unpack .tar.gz downloads.
+          # tar cannot serve the actions that unpack .tar.gz downloads. bash is absent from the base
+          # image (busybox provides only /bin/sh) and is required by every step after the bootstrap,
+          # which run under the workflow's default bash shell.
           - distro: alpine
             image: alpine:3.21
-            bootstrap: 'apk update && apk add git curl sudo ca-certificates tar nodejs npm'
+            bootstrap: 'apk update && apk add bash git curl sudo ca-certificates tar nodejs npm'
             use_setup_node: false
             podman_probe: 'apk search -x podman | grep -q podman'
     container:
       image: ${{ matrix.image }}
+      # Images that declare no PATH in their OCI config (quay.io/rockylinux/rockylinux:9 ships
+      # Env: ["container=oci"], opensuse/leap:16.0 ships Env: null) lose it entirely once an action
+      # prepends to GITHUB_PATH: the runner rebuilds the exec PATH from the container's declared
+      # PATH, so /usr/bin drops out and even bash stops resolving. Declaring the standard search
+      # path here gives every row something to prepend onto; all distributions in the matrix use
+      # these directories.
+      env:
+        PATH: '/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin'
     steps:
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -107,7 +117,11 @@ jobs:
 
       # The base distribution images ship none of git/curl/sudo. git and curl are needed for
       # checkout and the Node setup; sudo is needed because Solo elevates package installs via sudo.
+      # This is the only step that cannot use the workflow's default bash shell: on Alpine bash is
+      # one of the packages this very step installs, so requiring it here would be circular. Every
+      # distribution in the matrix ships /bin/sh, and every bootstrap command is plain POSIX sh.
       - name: Bootstrap Container
+        shell: sh
         run: ${{ matrix.bootstrap }}
 
       # Podman itself is installed through the Homebrew-on-Linux bootstrap (tracked separately by

--- a/.github/workflows/flow-install-validation.yaml
+++ b/.github/workflows/flow-install-validation.yaml
@@ -15,8 +15,9 @@
 ##
 
 # Validates Solo's real per-distribution system-dependency install (git, iptables) inside a
-# disposable distribution container. This foundation runs a single distro (Ubuntu); follow-up
-# work fans the matrix out across the remaining supported distributions.
+# disposable distribution container, one job per supported distribution: Ubuntu and Debian
+# (apt-get), Fedora, Rocky, AlmaLinux and Oracle Linux (dnf), openSUSE Leap (zypper), Arch
+# (pacman) and Alpine (apk).
 # Tracked by hiero-ledger/solo#4888.
 name: 'Install Validation'
 
@@ -40,29 +41,88 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # Follow-up work (hiero-ledger/solo#4888) appends the remaining supported distributions here.
+        # One row per supported distribution. `bootstrap` installs the tooling the base image lacks,
+        # `use_setup_node` is false only where actions/setup-node cannot serve a usable runtime, and
+        # `podman_probe` is set only where podman lives outside the default repositories.
+        # Image pins must be bumped as releases reach end of life; an EOL image loses its mirrors and
+        # the row fails on the package-index refresh rather than on Solo's install path.
         include:
           - distro: ubuntu
             image: ubuntu:24.04
+            bootstrap: 'apt-get update && apt-get install -y git curl sudo ca-certificates'
+            use_setup_node: true
+          - distro: debian
+            image: debian:12
+            bootstrap: 'apt-get update && apt-get install -y git curl sudo ca-certificates'
+            use_setup_node: true
+          # The dnf rows also cover DnfPackageManager's iptables -> iptables-nft mapping, which is
+          # the only package name Solo rewrites per distribution.
+          - distro: fedora
+            image: fedora:44
+            bootstrap: 'dnf install -y --allowerasing git curl sudo ca-certificates tar gzip'
+            use_setup_node: true
+          - distro: rocky
+            image: quay.io/rockylinux/rockylinux:9
+            bootstrap: 'dnf install -y --allowerasing git curl sudo ca-certificates tar gzip'
+            use_setup_node: true
+          - distro: alma
+            image: almalinux:9
+            bootstrap: 'dnf install -y --allowerasing git curl sudo ca-certificates tar gzip'
+            use_setup_node: true
+          # Oracle Linux stands in for the CentOS 7 row hiero-ledger/solo#4909 originally asked for:
+          # CentOS 7 is EOL with its mirrors moved to vault, and its glibc 2.17 cannot run Node >= 22
+          # (required by package.json engines), so the Node-based harness cannot start in that
+          # container at all. Note that Oracle Linux reports ID_LIKE=fedora, so OsPackageManager
+          # resolves it to dnf; no released distribution currently routes to YumPackageManager.
+          - distro: oraclelinux
+            image: oraclelinux:9
+            bootstrap: 'dnf install -y --allowerasing git curl sudo ca-certificates tar gzip'
+            use_setup_node: true
+            podman_probe: 'dnf info podman'
+          - distro: opensuse
+            image: opensuse/leap:16.0
+            bootstrap: 'zypper --non-interactive install git curl sudo ca-certificates tar gzip'
+            use_setup_node: true
+          # Arch is rolling, so the tag cannot be pinned to a release; -Syu keeps the freshly
+          # refreshed package index and the installed system from drifting apart.
+          - distro: arch
+            image: archlinux:latest
+            bootstrap: 'pacman -Syu --noconfirm --needed git curl sudo ca-certificates'
+            use_setup_node: true
+          # Alpine is musl, so the glibc runtime actions/setup-node downloads cannot execute; the
+          # apk-provided Node (22.x in 3.21) is used instead. GNU tar is required because busybox
+          # tar cannot serve the actions that unpack .tar.gz downloads.
+          - distro: alpine
+            image: alpine:3.21
+            bootstrap: 'apk update && apk add git curl sudo ca-certificates tar nodejs npm'
+            use_setup_node: false
+            podman_probe: 'apk search -x podman | grep -q podman'
     container:
       image: ${{ matrix.image }}
     steps:
-      # The base distribution image ships none of git/curl/sudo. git and curl are needed for
-      # checkout and the Node setup; sudo is needed because Solo elevates package installs via sudo.
       - name: Harden the runner (Audit all outbound calls)
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
 
+      # The base distribution images ship none of git/curl/sudo. git and curl are needed for
+      # checkout and the Node setup; sudo is needed because Solo elevates package installs via sudo.
       - name: Bootstrap Container
-        run: |
-          apt-get update
-          apt-get install -y git curl sudo ca-certificates
+        run: ${{ matrix.bootstrap }}
+
+      # Podman itself is installed through the Homebrew-on-Linux bootstrap (tracked separately by
+      # hiero-ledger/solo#4910). This step only asserts that the repository carrying podman is
+      # enabled on the distributions where it is not in the default channel, so it queries the
+      # package index and never installs.
+      - name: Probe Podman Repository Availability
+        if: matrix.podman_probe != ''
+        run: ${{ matrix.podman_probe }}
 
       - name: Checkout Code
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node
+        if: matrix.use_setup_node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: 22


### PR DESCRIPTION
## Description

This pull request changes the following:

* Expands `.github/workflows/flow-install-validation.yaml` from the single Ubuntu foundation row
  (#4908) to one job per supported distribution, so every native package-manager path Solo ships is
  exercised by a real install rather than by mocked selection unit tests.
* Each row runs Solo's actual install path — `OsPackageManager` → the distribution's
  `PackageManager` → `update()` + `installPackages(['git', 'iptables'])` — and asserts both binaries
  land on the system. The dnf rows also cover the only package name Solo rewrites per distribution,
  `iptables` → `iptables-nft`.
* Rows carry their own `bootstrap` command (the base images ship none of git/curl/sudo), a
  `use_setup_node` flag that is false only where `actions/setup-node` cannot serve a usable runtime,
  and an optional `podman_probe` that asserts the repository carrying podman is enabled — querying
  the package index, never installing.
* No changes to the mocha harness, to `Taskfile.tests.yml`, or to any TypeScript. Matrix rows only,
  as scoped in the issue. No new actions: the four existing SHA pins are reused as-is.

| distro | image | package manager | setup-node | podman probe |
|---|---|---|---|---|
| ubuntu | `ubuntu:24.04` | apt-get | yes | — |
| debian | `debian:12` | apt-get | yes | — |
| fedora | `fedora:44` | dnf | yes | — |
| rocky | `quay.io/rockylinux/rockylinux:9` | dnf | yes | — |
| alma | `almalinux:9` | dnf | yes | — |
| oraclelinux | `oraclelinux:9` | dnf | yes | `dnf info podman` |
| opensuse | `opensuse/leap:16.0` | zypper | yes | — |
| arch | `archlinux:latest` | pacman | yes | — |
| alpine | `alpine:3.21` | apk | no (musl) | `apk search -x podman \| grep -q podman` |

**Three image pins deviate from the versions named in the issue.** Each of the originals would have
been a permanently red row that fails on the package-index refresh, before Solo's code runs:

* `fedora:41` → `fedora:44` — F41 and F42 are both EOL, and an EOL Fedora's mirrorlist returns
  nothing. F44 has the longest support runway.
* `opensuse/leap:15.6` → `opensuse/leap:16.0` — Leap 15.6 is EOL and there is no Leap 15.7. 16.0 is
  the only supported Leap.
* `oraclelinux:8` → `oraclelinux:9` — EL8 has no package named `iptables-nft`, so
  `DnfPackageManager.resolveDependencies()` would have died on `No match for argument: iptables-nft`.

**CentOS 7 is deliberately not a row.** It is EOL with its mirrors moved to vault, and its glibc 2.17
cannot run Node >= 22 as required by `package.json` engines — the harness cannot start in that
container at all.

**The yum path ends up covered by no row, and cannot be covered by one today.**
`OsPackageManager.DISTRIBUTION_PACKAGE_MANAGERS` maps `centos` and `rhel` to dnf, and Oracle Linux
reports `ID_LIKE=fedora`, which also resolves to dnf. `YumPackageManager` is reachable only through
`FALLBACK_PROBE_ORDER`, which requires os-release to match nothing in the map — so no released
distribution currently routes to it. The originally-requested CentOS 7 row would therefore have
failed on `dnf makecache` with dnf absent, not merely on glibc. This is flagged in a comment on the
Oracle Linux row and needs a source fix rather than a CI row. Filed as #5355.

### Related Issues

* Closes #4909
* Related to #4888
* Follows #4908 (foundation workflow, #4911)
* Surfaced #5355 (`YumPackageManager` is unreachable — source bug found by this work)

### Pull request (PR) checklist

- [x] This PR added tests (unit, integration, and/or end-to-end)
- [ ] This PR updated documentation
- [x] This PR added no TODOs or commented out code
- [x] This PR has no breaking changes
- [x] Any technical debt has been documented as a separate issue and linked to this PR
- [x] Any `package.json` changes have been explained to and approved by a repository manager
- [x] All related issues have been linked to this PR
- [x] All changes in this PR are included in the description
- [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

- [ ] This PR added unit tests
- [x] This PR added integration/end-to-end tests
- [x] These changes required manual testing that is documented below
- [x] Anything not tested is documented

The following manual testing was done:

* Confirmed the harness stays inert on a developer machine with `SOLO_OS_INSTALL_VALIDATION` unset:
  `npx mocha 'test/e2e/integration/core/package-managers/os-package-manager-install.test.ts'` reports
  0 passing / 1 pending / 0 failing and mutates nothing.
* `npx prettier --check` on the workflow; every image pin and package name checked against the
  distribution's current upstream package index and support lifecycle.

The following was not tested:

* No row was executed in a container locally — no container engine was available on the authoring
  machine. Every row is correct-by-inspection; the matrix run on this PR is the actual validation.
* Alpine is the row most likely to fail first, and for reasons outside Solo: the Actions runner has
  to supply a musl Node to run the JS actions inside the container, and `checkout@v7` runs on node24.
  A failure there happens at the first action, not at Solo's install path. Alpine 3.21 ships
  nodejs 22.23.0 in `main`, so the runtime side itself is sound.
* `archlinux:latest` is rolling and cannot be pinned, so upstream churn can break that row on an
  unrelated PR. Pinned images also age into EOL — alpine 3.21 (Nov 2026) is the next one due.
* Flipping this workflow from non-blocking to required is GitHub branch-protection configuration,
  not a repo file — a maintainer follow-up once the matrix is green.
