### PR TITLE
feat: add load-balancer switch to relay and explorer

### DIFF
--- a/src/commands/explorer.ts
+++ b/src/commands/explorer.ts
@@ -59,6 +59,7 @@ interface ExplorerDeployConfigClass {
   explorerStaticIp: string | '';
   explorerVersion: string;
   componentImage: Optional<string>;
+  loadBalancerEnabled: boolean;
   namespace: NamespaceName;
   tlsClusterIssuerType: string;
   valuesFile: string;
@@ -99,6 +100,7 @@ interface ExplorerUpgradeConfigClass {
   explorerStaticIp: string | '';
   explorerVersion: string;
   componentImage: Optional<string>;
+  loadBalancerEnabled: boolean;
   namespace: NamespaceName;
   tlsClusterIssuerType: string;
   valuesFile: string;
@@ -179,6 +181,7 @@ export class ExplorerCommand extends BaseCommand {
       flags.explorerStaticIp,
       flags.explorerVersion,
       flags.componentImage,
+      flags.loadBalancerEnabled,
       flags.namespace,
       flags.quiet,
       flags.soloChartVersion,
@@ -210,6 +213,7 @@ export class ExplorerCommand extends BaseCommand {
       flags.explorerStaticIp,
       flags.explorerVersion,
       flags.componentImage,
+      flags.loadBalancerEnabled,
       flags.namespace,
       flags.quiet,
       flags.soloChartVersion,
@@ -239,6 +243,10 @@ export class ExplorerCommand extends BaseCommand {
 
     if (config.enableIngress) {
       chartValues.set('ingress.enabled', true).setLiteral('ingressClassName', config.ingressReleaseName);
+    }
+
+    if (config.loadBalancerEnabled) {
+      chartValues.set('service.type', 'LoadBalancer');
     }
     chartValues.setLiteral('fullnameOverride', `${config.releaseName}-${config.namespace.name}`);
 

--- a/src/commands/explorer.ts
+++ b/src/commands/explorer.ts
@@ -562,6 +562,28 @@ export class ExplorerCommand extends BaseCommand {
     };
   }
 
+  private checkLoadBalancerIsAssignedTask(): SoloListrTask<AnyListrContext> {
+    return {
+      title: 'Check load balancer is assigned',
+      skip: ({config}: ExplorerDeployContext | ExplorerUpgradeContext): boolean => !config.loadBalancerEnabled,
+      task: async ({config}: ExplorerDeployContext | ExplorerUpgradeContext): Promise<void> => {
+        try {
+          await this.k8Factory
+            .getK8(config.clusterContext)
+            .services()
+            .waitForLoadBalancerAddress(
+              config.namespace,
+              [`app.kubernetes.io/instance=${config.releaseName}`],
+              constants.LOAD_BALANCER_CHECK_MAX_ATTEMPTS,
+              Duration.ofSeconds(constants.LOAD_BALANCER_CHECK_DELAY_SECS).toMillis(),
+            );
+        } catch (error) {
+          throw new SoloErrors.system.loadBalancerNotFound(error);
+        }
+      },
+    };
+  }
+
   private enablePortForwardingTask(): SoloListrTask<AnyListrContext> {
     return {
       title: 'Enable port forwarding for explorer',
@@ -740,6 +762,7 @@ export class ExplorerCommand extends BaseCommand {
         this.installExplorerIngressControllerTask(),
         this.checkExplorerPodIsReadyTask(),
         this.checkExplorerIngressControllerPodIsReadyTask(),
+        this.checkLoadBalancerIsAssignedTask(),
         this.enablePortForwardingTask(),
         {
           title: 'Show user messages',
@@ -853,6 +876,7 @@ export class ExplorerCommand extends BaseCommand {
         this.installExplorerIngressControllerTask(),
         this.checkExplorerPodIsReadyTask(),
         this.checkExplorerIngressControllerPodIsReadyTask(),
+        this.checkLoadBalancerIsAssignedTask(),
         this.enablePortForwardingTask(),
       ],
       constants.LISTR_DEFAULT_OPTIONS.DEFAULT,

--- a/src/commands/flags.ts
+++ b/src/commands/flags.ts
@@ -2888,7 +2888,7 @@ export class Flags {
     constName: 'loadBalancerEnabled',
     name: 'load-balancer',
     definition: {
-      describe: 'Enable load balancer for network node proxies',
+      describe: 'Expose the deployed services via a LoadBalancer service type',
       defaultValue: false,
       type: 'boolean',
     },

--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -55,8 +55,6 @@ import {patchInject} from '../core/dependency-injection/container-helper.js';
 import {type CommandFlag, type CommandFlags} from '../types/flag-types.js';
 import {type K8} from '../integration/kube/k8.js';
 import {type Lock} from '../core/lock/lock.js';
-import {type LoadBalancerIngress} from '../integration/kube/resources/load-balancer-ingress.js';
-import {type Service} from '../integration/kube/resources/service/service.js';
 import {type Container} from '../integration/kube/resources/container/container.js';
 import {DeploymentPhase} from '../data/schema/model/remote/deployment-phase.js';
 import {ComponentTypes} from '../core/config/remote/enumerations/component-types.js';
@@ -1615,7 +1613,6 @@ export class NetworkCommand extends BaseCommand {
             }
           },
         },
-        // TODO: Move the check for load balancer logic to a utility method or class
         {
           title: 'Check for load balancer',
           skip: ({config: {loadBalancerEnabled}}): boolean => loadBalancerEnabled === false,
@@ -1627,34 +1624,19 @@ export class NetworkCommand extends BaseCommand {
               subTasks.push({
                 title: `Load balancer is assigned for: ${chalk.yellow(consensusNode.name)}, cluster: ${chalk.yellow(consensusNode.cluster)}`,
                 task: async (): Promise<void> => {
-                  let attempts: number = 0;
-                  let svc: Service[];
-
-                  while (attempts < constants.LOAD_BALANCER_CHECK_MAX_ATTEMPTS) {
-                    svc = await this.k8Factory
+                  try {
+                    await this.k8Factory
                       .getK8(consensusNode.context)
                       .services()
-                      .list(namespace, Templates.renderNodeSvcLabelsFromNodeId(consensusNode.nodeId));
-
-                    if (svc && svc.length > 0 && svc[0].status?.loadBalancer?.ingress?.length > 0) {
-                      let shouldContinue: boolean = false;
-                      for (let index: number = 0; index < svc[0].status.loadBalancer.ingress.length; index++) {
-                        const ingress: LoadBalancerIngress = svc[0].status.loadBalancer.ingress[index];
-                        if (!ingress.hostname && !ingress.ip) {
-                          shouldContinue = true; // try again if there is neither a hostname nor an ip
-                          break;
-                        }
-                      }
-                      if (shouldContinue) {
-                        continue;
-                      }
-                      return;
-                    }
-
-                    attempts++;
-                    await sleep(Duration.ofSeconds(constants.LOAD_BALANCER_CHECK_DELAY_SECS));
+                      .waitForLoadBalancerAddress(
+                        namespace,
+                        Templates.renderNodeSvcLabelsFromNodeId(consensusNode.nodeId),
+                        constants.LOAD_BALANCER_CHECK_MAX_ATTEMPTS,
+                        Duration.ofSeconds(constants.LOAD_BALANCER_CHECK_DELAY_SECS).toMillis(),
+                      );
+                  } catch (error) {
+                    throw new SoloErrors.system.loadBalancerNotFound(error);
                   }
-                  throw new SoloErrors.system.loadBalancerNotFound();
                 },
               });
             }

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -76,6 +76,7 @@ interface RelayDeployConfigClass {
   relayReleaseTag: string;
   componentImage: string;
   replicaCount: number;
+  loadBalancerEnabled: boolean;
   valuesFile: string;
   isChartInstalled: boolean;
   nodeAliases: NodeAliases;
@@ -113,6 +114,7 @@ interface RelayUpgradeConfigClass {
   relayReleaseTag: string;
   componentImage: string;
   replicaCount: number;
+  loadBalancerEnabled: boolean;
   valuesFile: string;
   isChartInstalled: boolean;
   nodeAliases: NodeAliases;
@@ -179,6 +181,7 @@ export class RelayCommand extends BaseCommand {
       flags.relayVersion,
       flags.componentImage,
       flags.replicaCount,
+      flags.loadBalancerEnabled,
       flags.valuesFile,
       flags.domainName,
       flags.forcePortForward,
@@ -209,6 +212,7 @@ export class RelayCommand extends BaseCommand {
       flags.relayVersion,
       flags.componentImage,
       flags.replicaCount,
+      flags.loadBalancerEnabled,
       flags.valuesFile,
       flags.domainName,
       flags.forcePortForward,
@@ -243,6 +247,7 @@ export class RelayCommand extends BaseCommand {
     relayReleaseTag,
     componentImage,
     replicaCount,
+    loadBalancerEnabled,
     operatorId,
     operatorKey,
     namespace,
@@ -291,6 +296,10 @@ export class RelayCommand extends BaseCommand {
 
     if (replicaCount) {
       chartValues.set('relay.replicaCount', replicaCount).set('ws.replicaCount', replicaCount);
+    }
+
+    if (loadBalancerEnabled) {
+      chartValues.set('relay.service.type', 'LoadBalancer').set('ws.service.type', 'LoadBalancer');
     }
 
     const operatorIdUsing: string = operatorId || this.accountManager.getOperatorAccountId(deployment).toString();

--- a/src/commands/relay.ts
+++ b/src/commands/relay.ts
@@ -547,6 +547,28 @@ export class RelayCommand extends BaseCommand {
     };
   }
 
+  private checkLoadBalancerIsAssignedTask(): SoloListrTask<AnyListrContext> {
+    return {
+      title: 'Check load balancer is assigned',
+      skip: ({config}: RelayDeployContext | RelayUpgradeContext): boolean => !config.loadBalancerEnabled,
+      task: async ({config}: RelayDeployContext | RelayUpgradeContext): Promise<void> => {
+        try {
+          await this.k8Factory
+            .getK8(config.context)
+            .services()
+            .waitForLoadBalancerAddress(
+              config.namespace,
+              [`app.kubernetes.io/instance=${config.releaseName}`],
+              constants.LOAD_BALANCER_CHECK_MAX_ATTEMPTS,
+              Duration.ofSeconds(constants.LOAD_BALANCER_CHECK_DELAY_SECS).toMillis(),
+            );
+        } catch (error) {
+          throw new SoloErrors.system.loadBalancerNotFound(error);
+        }
+      },
+    };
+  }
+
   private enablePortForwardingTask(): SoloListrTask<AnyListrContext> {
     return {
       title: 'Enable port forwarding for relay node',
@@ -690,6 +712,7 @@ export class RelayCommand extends BaseCommand {
         this.deployJsonRpcRelayTask(RelayCommandType.ADD),
         this.checkRelayIsRunningTask(),
         this.checkRelayIsReadyTask(),
+        this.checkLoadBalancerIsAssignedTask(),
         this.enablePortForwardingTask(),
         {
           title: 'Show user messages',
@@ -815,6 +838,7 @@ export class RelayCommand extends BaseCommand {
         this.deployJsonRpcRelayTask(RelayCommandType.UPGRADE),
         this.checkRelayIsRunningTask(),
         this.checkRelayIsReadyTask(),
+        this.checkLoadBalancerIsAssignedTask(),
         this.enablePortForwardingTask(),
       ],
       constants.LISTR_DEFAULT_OPTIONS.DEFAULT,

--- a/src/core/errors/classes/system/load-balancer-not-found-solo-error.ts
+++ b/src/core/errors/classes/system/load-balancer-not-found-solo-error.ts
@@ -14,14 +14,17 @@ export class LoadBalancerNotFoundSoloError extends SoloError {
   protected override readonly retryable: boolean = true;
   protected override readonly ownership: ErrorOwnership = ErrorOwnership.Infrastructure;
 
-  public constructor() {
-    super({
-      message: 'Load balancer not found',
-      code: ErrorCodeRegistry.LOAD_BALANCER_NOT_FOUND,
-      troubleshootingSteps:
-        'Check load balancer service status: kubectl get svc -n <namespace> -l solo.hedera.com/type=network-node\n' +
-        'Ensure your cloud provider supports LoadBalancer services\n' +
-        'Review cloud provisioning logs for LB assignment delays',
-    });
+  public constructor(cause?: Error) {
+    super(
+      {
+        message: 'Load balancer not found',
+        code: ErrorCodeRegistry.LOAD_BALANCER_NOT_FOUND,
+        troubleshootingSteps:
+          'Check load balancer service status: kubectl get svc -n <namespace>\n' +
+          'Ensure your cloud provider supports LoadBalancer services\n' +
+          'Review cloud provisioning logs for LB assignment delays',
+      },
+      cause,
+    );
   }
 }

--- a/src/integration/kube/errors/kube-service-load-balancer-timeout-error.ts
+++ b/src/integration/kube/errors/kube-service-load-balancer-timeout-error.ts
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {KubeError} from './kube-error.js';
+
+export class KubeServiceLoadBalancerTimeoutError extends KubeError {
+  public readonly namespace: string;
+  public readonly labels: string[];
+
+  public constructor(namespace: string, labels: string[]) {
+    super(
+      `Timed out waiting for a load balancer address to be assigned in namespace ${namespace} for labels [${labels.join(', ')}]`,
+      undefined,
+      {namespace, labels},
+    );
+    this.namespace = namespace;
+    this.labels = labels;
+  }
+}

--- a/src/integration/kube/k8-client/resources/service/k8-client-services.ts
+++ b/src/integration/kube/k8-client/resources/service/k8-client-services.ts
@@ -19,6 +19,10 @@ import {type ServiceReference} from '../../../resources/service/service-referenc
 import {KubeApiResponse} from '../../../kube-api-response.js';
 import {ResourceOperation} from '../../../resources/resource-operation.js';
 import {ResourceType} from '../../../resources/resource-type.js';
+import {KubeServiceLoadBalancerTimeoutError} from '../../../errors/kube-service-load-balancer-timeout-error.js';
+import {type LoadBalancerIngress} from '../../../resources/load-balancer-ingress.js';
+import {Duration} from '../../../../../core/time/duration.js';
+import {sleep} from '../../../../../core/helpers.js';
 
 export class K8ClientServices extends K8ClientBase implements Services {
   public constructor(private readonly kubeClient: CoreV1Api) {
@@ -39,6 +43,42 @@ export class K8ClientServices extends K8ClientBase implements Services {
     return serviceList.items.map((svc: V1Service): Service => {
       return this.wrapService(namespace, svc);
     });
+  }
+
+  public async waitForLoadBalancerAddress(
+    namespace: NamespaceName,
+    labels: string[],
+    maxAttempts: number,
+    delay: number,
+  ): Promise<Service[]> {
+    for (let attempt: number = 1; attempt <= maxAttempts; attempt++) {
+      const services: Service[] = await this.list(namespace, labels);
+      const loadBalancerServices: Service[] = services.filter(
+        (service: Service): boolean => service.spec?.type === 'LoadBalancer',
+      );
+
+      if (
+        loadBalancerServices.length > 0 &&
+        loadBalancerServices.every((service: Service): boolean => K8ClientServices.hasLoadBalancerAddress(service))
+      ) {
+        return loadBalancerServices;
+      }
+
+      if (attempt < maxAttempts) {
+        await sleep(Duration.ofMillis(delay));
+      }
+    }
+
+    throw new KubeServiceLoadBalancerTimeoutError(namespace.name, labels);
+  }
+
+  private static hasLoadBalancerAddress(service: Service): boolean {
+    const ingresses: LoadBalancerIngress[] = service.status?.loadBalancer?.ingress ?? [];
+
+    return (
+      ingresses.length > 0 &&
+      ingresses.every((ingress: LoadBalancerIngress): boolean => Boolean(ingress.ip || ingress.hostname))
+    );
   }
 
   public async read(namespace: NamespaceName, name: string): Promise<Service> {

--- a/src/integration/kube/resources/service/services.ts
+++ b/src/integration/kube/resources/service/services.ts
@@ -20,6 +20,22 @@ export interface Services {
   list(namespace: NamespaceName, labels?: string[]): Promise<Service[]>;
 
   /**
+   * Wait until every LoadBalancer-typed service matching the labels has an external address assigned.
+   * @param namespace - namespace
+   * @param labels - service labels
+   * @param maxAttempts - maximum attempts to check
+   * @param delay - delay between checks in milliseconds
+   * @returns the matching LoadBalancer services
+   * @throws {KubeServiceLoadBalancerTimeoutError} if no address is assigned within the allotted attempts
+   */
+  waitForLoadBalancerAddress(
+    namespace: NamespaceName,
+    labels: string[],
+    maxAttempts: number,
+    delay: number,
+  ): Promise<Service[]>;
+
+  /**
    * Create a service
    * @param serviceReference - service reference
    * @param labels - the labels for the service

--- a/test/unit/commands/explorer.test.ts
+++ b/test/unit/commands/explorer.test.ts
@@ -406,6 +406,24 @@ describe('ExplorerCommand unit tests', (): void => {
     expect(chartValues.toArguments()).to.include('proxyPass./api=http://mirror-1-rest.mirror-ns.svc.cluster.local');
   });
 
+  it('should set explorer service type to LoadBalancer only when load balancer is enabled', async (): Promise<void> => {
+    resetForTest();
+    const command: ExplorerCommandInternal = container.resolve(ExplorerCommand) as unknown as ExplorerCommandInternal;
+
+    const defaultChartValues: HelmChartValues = await command.prepareHederaExplorerChartValues(
+      createDeployConfig('explorer'),
+    );
+
+    expect(defaultChartValues.toArguments()).to.not.include('service.type=LoadBalancer');
+
+    const loadBalancerChartValues: HelmChartValues = await command.prepareHederaExplorerChartValues({
+      ...createDeployConfig('explorer'),
+      loadBalancerEnabled: true,
+    });
+
+    expect(loadBalancerChartValues.toArguments()).to.include('service.type=LoadBalancer');
+  });
+
   it('add builds the expected task flow and updates explorer state after successful install', async (): Promise<void> => {
     const harness: ExplorerHarness = await createHarness(sandbox);
     const deployConfig: Record<string, unknown> = createDeployConfig('explorer-add');

--- a/test/unit/commands/explorer.test.ts
+++ b/test/unit/commands/explorer.test.ts
@@ -453,6 +453,7 @@ describe('ExplorerCommand unit tests', (): void => {
       'Install explorer ingress controller',
       'Check explorer pod is ready',
       'Check haproxy ingress controller pod is ready',
+      'Check load balancer is assigned',
       'Enable port forwarding for explorer',
       'Show user messages',
     ]);
@@ -549,6 +550,7 @@ describe('ExplorerCommand unit tests', (): void => {
       'Install explorer ingress controller',
       'Check explorer pod is ready',
       'Check haproxy ingress controller pod is ready',
+      'Check load balancer is assigned',
       'Enable port forwarding for explorer',
     ]);
 

--- a/test/unit/commands/relay.test.ts
+++ b/test/unit/commands/relay.test.ts
@@ -144,6 +144,33 @@ describe('RelayCommand unit tests', (): void => {
     expect(valueArguments).to.include('ws.image.tag=7');
   });
 
+  it('should set relay and ws service type to LoadBalancer when load balancer is enabled', async (): Promise<void> => {
+    const relayCommandInternal: RelayCommandInternal = relayCommand as unknown as RelayCommandInternal;
+
+    sinon.stub(relayCommandInternal, 'prepareNetworkJsonString').resolves('{"127.0.0.1:50211":"0.0.3"}');
+
+    const valueArguments: string[] = await prepareRelayValueArguments(
+      relayCommandInternal,
+      createRelayConfig({
+        [flags.loadBalancerEnabled.constName]: true,
+      }),
+    );
+
+    expect(valueArguments).to.include('relay.service.type=LoadBalancer');
+    expect(valueArguments).to.include('ws.service.type=LoadBalancer');
+  });
+
+  it('should not override service types when load balancer is disabled', async (): Promise<void> => {
+    const relayCommandInternal: RelayCommandInternal = relayCommand as unknown as RelayCommandInternal;
+
+    sinon.stub(relayCommandInternal, 'prepareNetworkJsonString').resolves('{"127.0.0.1:50211":"0.0.3"}');
+
+    const valueArguments: string[] = await prepareRelayValueArguments(relayCommandInternal, createRelayConfig());
+
+    expect(valueArguments).to.not.include('relay.service.type=LoadBalancer');
+    expect(valueArguments).to.not.include('ws.service.type=LoadBalancer');
+  });
+
   it('should reject plain tag value for componentImage', async (): Promise<void> => {
     const relayCommandInternal: RelayCommandInternal = relayCommand as unknown as RelayCommandInternal;
 

--- a/test/unit/integration/kube/k8-client-services.test.ts
+++ b/test/unit/integration/kube/k8-client-services.test.ts
@@ -1,0 +1,80 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {expect} from 'chai';
+import {before, describe, it} from 'mocha';
+import sinon, {type SinonStub} from 'sinon';
+import {K8ClientServices} from '../../../../src/integration/kube/k8-client/resources/service/k8-client-services.js';
+import {KubeServiceLoadBalancerTimeoutError} from '../../../../src/integration/kube/errors/kube-service-load-balancer-timeout-error.js';
+import {NamespaceName} from '../../../../src/types/namespace/namespace-name.js';
+import {type Service} from '../../../../src/integration/kube/resources/service/service.js';
+import {resetForTest} from '../../../test-container.js';
+
+interface ServiceItemOptions {
+  type: string;
+  ingress?: Array<{ip?: string; hostname?: string}>;
+}
+
+function buildServiceItem({type, ingress}: ServiceItemOptions): object {
+  return {
+    metadata: {name: 'relay-1'},
+    spec: {type},
+    status: ingress ? {loadBalancer: {ingress}} : {},
+  };
+}
+
+function buildServices(listStub: SinonStub): K8ClientServices {
+  return new K8ClientServices({
+    listNamespacedService: listStub,
+  } as never);
+}
+
+describe('K8ClientServices waitForLoadBalancerAddress', (): void => {
+  const namespace: NamespaceName = NamespaceName.of('solo-e2e');
+  const labels: string[] = ['app.kubernetes.io/instance=relay-1'];
+
+  before((): void => {
+    resetForTest();
+  });
+
+  it('resolves once every LoadBalancer service has an address', async (): Promise<void> => {
+    const listStub: SinonStub = sinon.stub();
+    listStub.onFirstCall().resolves({items: [buildServiceItem({type: 'LoadBalancer', ingress: [{}]})]});
+    listStub.onSecondCall().resolves({items: [buildServiceItem({type: 'LoadBalancer', ingress: [{ip: '10.0.0.1'}]})]});
+    const services: K8ClientServices = buildServices(listStub);
+
+    const result: Service[] = await services.waitForLoadBalancerAddress(namespace, labels, 3, 0);
+
+    expect(result).to.have.lengthOf(1);
+    expect(listStub).to.have.callCount(2);
+  });
+
+  it('ignores non-LoadBalancer services when checking for addresses', async (): Promise<void> => {
+    const listStub: SinonStub = sinon.stub().resolves({
+      items: [
+        buildServiceItem({type: 'ClusterIP'}),
+        buildServiceItem({type: 'LoadBalancer', ingress: [{hostname: 'lb.example.test'}]}),
+      ],
+    });
+    const services: K8ClientServices = buildServices(listStub);
+
+    const result: Service[] = await services.waitForLoadBalancerAddress(namespace, labels, 3, 0);
+
+    expect(result).to.have.lengthOf(1);
+    expect(result[0].spec.type).to.equal('LoadBalancer');
+  });
+
+  it('throws when no address is assigned within the allotted attempts', async (): Promise<void> => {
+    const listStub: SinonStub = sinon.stub().resolves({
+      items: [buildServiceItem({type: 'LoadBalancer'})],
+    });
+    const services: K8ClientServices = buildServices(listStub);
+
+    try {
+      await services.waitForLoadBalancerAddress(namespace, labels, 2, 0);
+      expect.fail('expected waitForLoadBalancerAddress to reject');
+    } catch (error: Error | unknown) {
+      expect(error).to.be.instanceOf(KubeServiceLoadBalancerTimeoutError);
+      expect(listStub).to.have.callCount(2);
+    }
+  });
+});


### PR DESCRIPTION
## Description

Adds the `--load-balancer` switch to the relay and explorer `deploy`/`upgrade` commands, so exposing them externally no longer requires a values-file override, and makes the commands wait until the load balancer address is actually provisioned.

Design notes:

* Reuses the existing `Flags.loadBalancerEnabled` flag (previously used only by `network deploy`) rather than introducing a new one; its description is generalized since it now applies to three commands.
* When set, relay flips `relay.service.type` and `ws.service.type` to `LoadBalancer` (both default to `ClusterIP` in the `hedera-json-rpc` chart), and explorer flips the chart's root `service.type` (also `ClusterIP` by default).
* The explorer ingress-controller path needs no change: the haproxy-ingress chart already defaults `controller.service.type` to `LoadBalancer`, and `--explorer-static-ip` already targets it.
* A new `Services.waitForLoadBalancerAddress` method on the K8 client wrapper polls until every LoadBalancer-typed service matching the label selector has an ingress IP or hostname. Relay and explorer run a `Check load balancer is assigned` task (skipped unless `--load-balancer`), so the command only succeeds once the address is up. The `network deploy` load-balancer check is refactored onto the same method, resolving the inline TODO there and fixing a tight retry loop that skipped both the attempt counter and the delay when an ingress entry had no address yet.
* `LoadBalancerNotFoundSoloError` now accepts an optional cause, and its troubleshooting hint no longer assumes the network-node label since the error is raised for relay and explorer too.

Unit tests cover the enabled and disabled chart-value paths for relay and explorer, the new wait method (address assigned late, non-LB services ignored, timeout), and the updated explorer task flows. Verified the flag surfaces on all four subcommands via `--help`.

### Related Issues

* Fixes #3311