### PR TITLE
feat: allow passing ports to consensus node service endpoints

### DIFF
--- a/src/commands/flags.ts
+++ b/src/commands/flags.ts
@@ -2995,6 +2995,32 @@ export class Flags {
     prompt: undefined,
   };
 
+  public static readonly gossipEndpointPort: CommandFlag = {
+    constName: 'gossipEndpointPort',
+    name: 'gossip-endpoint-port',
+    definition: {
+      describe:
+        'Port used when building the consensus node gossip endpoints published to the network' +
+        `\n(Default port: ${constants.HEDERA_NODE_EXTERNAL_GOSSIP_PORT})` +
+        '\n[Format: <port> to apply the same port to every node, or <alias>=<port>[,<alias>=<port>] per node]',
+      type: 'string',
+    },
+    prompt: undefined,
+  };
+
+  public static readonly serviceEndpointPort: CommandFlag = {
+    constName: 'serviceEndpointPort',
+    name: 'service-endpoint-port',
+    definition: {
+      describe:
+        'Port used when building the consensus node gRPC service endpoints published to the network' +
+        `\n(Default port: ${constants.GRPC_PORT})` +
+        '\n[Format: <port> to apply the same port to every node, or <alias>=<port>[,<alias>=<port>] per node]',
+      type: 'string',
+    },
+    prompt: undefined,
+  };
+
   public static readonly realm: CommandFlag = {
     constName: 'realm',
     name: 'realm',
@@ -3355,6 +3381,8 @@ export class Flags {
     Flags.dnsConsensusNodePattern,
     Flags.domainName,
     Flags.domainNames,
+    Flags.gossipEndpointPort,
+    Flags.serviceEndpointPort,
     Flags.blockNodeChartVersion,
     Flags.blockNodeVersion,
     Flags.blockNodeTssOverlay,

--- a/src/commands/network-deploy-config-class.ts
+++ b/src/commands/network-deploy-config-class.ts
@@ -2,7 +2,7 @@
 
 import {type NamespaceName} from '../types/namespace/namespace-name.js';
 import {type NodeAlias, type NodeAliases, type IP} from '../types/aliases.js';
-import {type ClusterReferenceName, type ClusterReferences} from '../types/index.js';
+import {type ClusterReferenceName, type ClusterReferences, type EndpointPortMapping} from '../types/index.js';
 import {type HelmChartValues} from '../integration/helm/model/values.js';
 import {type StorageType} from '../core/constants.js';
 import {type ConsensusNode} from '../core/model/consensus-node.js';
@@ -61,6 +61,10 @@ export interface NetworkDeployConfigClass {
   clusterRefs: ClusterReferences;
   domainNames?: string;
   domainNamesMapping?: Record<NodeAlias, string>;
+  gossipEndpointPort?: string;
+  gossipEndpointPortMapping?: EndpointPortMapping;
+  serviceEndpointPort?: string;
+  serviceEndpointPortMapping?: EndpointPortMapping;
   blockNodeComponents: BlockNodeStateSchema[];
   debugNodeAlias: NodeAlias;
   app: string;

--- a/src/commands/network.ts
+++ b/src/commands/network.ts
@@ -166,6 +166,8 @@ export class NetworkCommand extends BaseCommand {
       flags.backupRegion,
       flags.backupProvider,
       flags.domainNames,
+      flags.gossipEndpointPort,
+      flags.serviceEndpointPort,
       flags.serviceMonitor,
       flags.podLog,
       flags.enableMonitoringSupport,
@@ -904,6 +906,8 @@ export class NetworkCommand extends BaseCommand {
       flags.gcsBucketPrefix,
       flags.nodeAliasesUnparsed,
       flags.domainNames,
+      flags.gossipEndpointPort,
+      flags.serviceEndpointPort,
     ];
 
     // disable the prompts that we don't want to prompt the user for
@@ -959,6 +963,9 @@ export class NetworkCommand extends BaseCommand {
     if (config.domainNames) {
       config.domainNamesMapping = Templates.parseNodeAliasToDomainNameMapping(config.domainNames);
     }
+
+    config.gossipEndpointPortMapping = Templates.parseNodeAliasToPortMapping(config.gossipEndpointPort);
+    config.serviceEndpointPortMapping = Templates.parseNodeAliasToPortMapping(config.serviceEndpointPort);
 
     // compute other config parameters
     config.keysDir = PathEx.join(config.cacheDir, 'keys');

--- a/src/commands/node/config-interfaces/node-add-config-class.ts
+++ b/src/commands/node/config-interfaces/node-add-config-class.ts
@@ -5,7 +5,7 @@ import {type PrivateKey} from '@hiero-ledger/sdk';
 import {type CheckedNodesConfigClass} from './checked-nodes-config-class.js';
 import {type NodeCommonConfigWithNodeAlias} from './node-common-config-with-node-alias.js';
 import {type Client} from '@hiero-ledger/sdk';
-import {type ClusterReferenceName} from '../../../types/index.js';
+import {type ClusterReferenceName, type EndpointPortMapping} from '../../../types/index.js';
 
 export interface NodeAddConfigClass extends NodeCommonConfigWithNodeAlias, CheckedNodesConfigClass {
   app: string;
@@ -42,5 +42,9 @@ export interface NodeAddConfigClass extends NodeCommonConfigWithNodeAlias, Check
   clusterRef: ClusterReferenceName;
   domainNames: string;
   domainNamesMapping: Record<NodeAlias, string>;
+  gossipEndpointPort: string;
+  gossipEndpointPortMapping: EndpointPortMapping;
+  serviceEndpointPort: string;
+  serviceEndpointPortMapping: EndpointPortMapping;
   nodeAliasesUnparsed?: string;
 }

--- a/src/commands/node/config-interfaces/node-destroy-config-class.ts
+++ b/src/commands/node/config-interfaces/node-destroy-config-class.ts
@@ -6,6 +6,7 @@ import {type CheckedNodesConfigClass} from './checked-nodes-config-class.js';
 import {type NodeCommonConfigWithNodeAlias} from './node-common-config-with-node-alias.js';
 import {type Client} from '@hiero-ledger/sdk';
 import {type ConsensusNode} from '../../../core/model/consensus-node.js';
+import {type EndpointPortMapping} from '../../../types/index.js';
 
 export interface NodeDestroyConfigClass extends NodeCommonConfigWithNodeAlias, CheckedNodesConfigClass {
   app: string;
@@ -29,5 +30,9 @@ export interface NodeDestroyConfigClass extends NodeCommonConfigWithNodeAlias, C
   refreshedConsensusNodes: ConsensusNode[];
   domainNames: string;
   domainNamesMapping: Record<NodeAlias, string>;
+  gossipEndpointPort: string;
+  gossipEndpointPortMapping: EndpointPortMapping;
+  serviceEndpointPort: string;
+  serviceEndpointPortMapping: EndpointPortMapping;
   nodeAliasesUnparsed?: string;
 }

--- a/src/commands/node/config-interfaces/node-refresh-config-class.ts
+++ b/src/commands/node/config-interfaces/node-refresh-config-class.ts
@@ -3,6 +3,7 @@
 import {type NodeAlias, type NodeAliases} from '../../../types/aliases.js';
 import {type PodReference} from '../../../integration/kube/resources/pod/pod-reference.js';
 import {type NodeCommonConfigWithNodeAliases} from './node-common-config-with-node-aliases.js';
+import {type EndpointPortMapping} from '../../../types/index.js';
 
 export interface NodeRefreshConfigClass extends NodeCommonConfigWithNodeAliases {
   app: string;
@@ -14,4 +15,8 @@ export interface NodeRefreshConfigClass extends NodeCommonConfigWithNodeAliases 
   domainNames: string;
   nodeAliases: NodeAliases;
   domainNamesMapping: Record<NodeAlias, string>;
+  gossipEndpointPort: string;
+  gossipEndpointPortMapping: EndpointPortMapping;
+  serviceEndpointPort: string;
+  serviceEndpointPortMapping: EndpointPortMapping;
 }

--- a/src/commands/node/config-interfaces/node-setup-config-class.ts
+++ b/src/commands/node/config-interfaces/node-setup-config-class.ts
@@ -3,6 +3,7 @@
 import {type NodeAlias} from '../../../types/aliases.js';
 import {type PodReference} from '../../../integration/kube/resources/pod/pod-reference.js';
 import {type NodeCommonConfigWithNodeAliases} from './node-common-config-with-node-aliases.js';
+import {type EndpointPortMapping} from '../../../types/index.js';
 
 export interface NodeSetupConfigClass extends NodeCommonConfigWithNodeAliases {
   app: string;
@@ -19,4 +20,8 @@ export interface NodeSetupConfigClass extends NodeCommonConfigWithNodeAliases {
   getUnusedConfigs: () => string[];
   domainNames: string;
   domainNamesMapping: Record<NodeAlias, string>;
+  gossipEndpointPort: string;
+  gossipEndpointPortMapping: EndpointPortMapping;
+  serviceEndpointPort: string;
+  serviceEndpointPortMapping: EndpointPortMapping;
 }

--- a/src/commands/node/config-interfaces/node-update-config-class.ts
+++ b/src/commands/node/config-interfaces/node-update-config-class.ts
@@ -5,6 +5,7 @@ import {type PrivateKey} from '@hiero-ledger/sdk';
 import {type CheckedNodesConfigClass} from './checked-nodes-config-class.js';
 import {type NodeCommonConfigWithNodeAlias} from './node-common-config-with-node-alias.js';
 import {type Client} from '@hiero-ledger/sdk';
+import {type EndpointPortMapping} from '../../../types/index.js';
 
 export interface NodeUpdateConfigClass extends NodeCommonConfigWithNodeAlias, CheckedNodesConfigClass {
   app: string;
@@ -36,4 +37,8 @@ export interface NodeUpdateConfigClass extends NodeCommonConfigWithNodeAlias, Ch
   curDate: Date;
   domainNames: string;
   domainNamesMapping: Record<NodeAlias, string>;
+  gossipEndpointPort: string;
+  gossipEndpointPortMapping: EndpointPortMapping;
+  serviceEndpointPort: string;
+  serviceEndpointPortMapping: EndpointPortMapping;
 }

--- a/src/commands/node/configs.ts
+++ b/src/commands/node/configs.ts
@@ -219,7 +219,7 @@ export class NodeCommandConfigs {
     task: SoloListrTaskWrapper<NodeUpdateContext>,
     shouldLoadNodeClient: boolean = true,
   ): Promise<NodeUpdateConfigClass> {
-    context_.config = this.configManager.getConfig(UPDATE_CONFIGS_NAME, argv.flags, [
+    const config: NodeUpdateConfigClass = this.configManager.getConfig(UPDATE_CONFIGS_NAME, argv.flags, [
       'allNodeAliases',
       'existingNodeAliases',
       'freezeAdminPrivateKey',
@@ -234,46 +234,47 @@ export class NodeCommandConfigs {
       'contexts',
     ]) as NodeUpdateConfigClass;
 
-    context_.config.namespace = await resolveNamespaceFromDeployment(this.localConfig, this.configManager, task);
-    context_.config.curDate = new Date();
-    context_.config.existingNodeAliases = [];
+    context_.config = config;
 
-    await this.initializeSetup(context_.config, this.k8Factory);
+    config.namespace = await resolveNamespaceFromDeployment(this.localConfig, this.configManager, task);
+    config.curDate = new Date();
+    config.existingNodeAliases = [];
+
+    await this.initializeSetup(config, this.k8Factory);
 
     if (shouldLoadNodeClient) {
-      context_.config.nodeClient = await this.accountManager.loadNodeClient(
-        context_.config.namespace,
+      config.nodeClient = await this.accountManager.loadNodeClient(
+        config.namespace,
         this.remoteConfig.getClusterRefs(),
-        context_.config.deployment,
+        config.deployment,
       );
     }
 
     // check consensus releaseTag to make sure it is a valid semantic version string starting with 'v'
-    context_.config.releaseTag = SemanticVersion.getValidSemanticVersion(
-      context_.config.releaseTag,
-      true,
-      'Consensus release tag',
-    );
+    config.releaseTag = SemanticVersion.getValidSemanticVersion(config.releaseTag, true, 'Consensus release tag');
 
-    const freezeAdminAccountId: AccountId = this.accountManager.getFreezeAccountId(context_.config.deployment);
+    const freezeAdminAccountId: AccountId = this.accountManager.getFreezeAccountId(config.deployment);
     const accountKeys: AccountIdWithKeyPairObject = await this.accountManager.getAccountKeysFromSecret(
       freezeAdminAccountId.toString(),
-      context_.config.namespace,
+      config.namespace,
     );
-    context_.config.freezeAdminPrivateKey = accountKeys.privateKey;
+    config.freezeAdminPrivateKey = accountKeys.privateKey;
 
     const treasuryAccount: AccountIdWithKeyPairObject = await this.accountManager.getTreasuryAccountKeys(
-      context_.config.namespace,
-      context_.config.deployment,
+      config.namespace,
+      config.deployment,
     );
     const treasuryAccountPrivateKey: string = treasuryAccount.privateKey;
-    context_.config.treasuryKey = PrivateKey.fromStringED25519(treasuryAccountPrivateKey);
+    config.treasuryKey = PrivateKey.fromStringED25519(treasuryAccountPrivateKey);
 
-    if (context_.config.domainNames) {
-      context_.config.domainNamesMapping = Templates.parseNodeAliasToDomainNameMapping(context_.config.domainNames);
+    if (config.domainNames) {
+      config.domainNamesMapping = Templates.parseNodeAliasToDomainNameMapping(config.domainNames);
     }
 
-    return context_.config;
+    config.gossipEndpointPortMapping = Templates.parseNodeAliasToPortMapping(config.gossipEndpointPort);
+    config.serviceEndpointPortMapping = Templates.parseNodeAliasToPortMapping(config.serviceEndpointPort);
+
+    return config;
   }
 
   public async destroyConfigBuilder(
@@ -282,7 +283,7 @@ export class NodeCommandConfigs {
     task: SoloListrTaskWrapper<NodeDestroyContext>,
     shouldLoadNodeClient: boolean = true,
   ): Promise<NodeDestroyConfigClass> {
-    context_.config = this.configManager.getConfig(DESTROY_CONFIGS_NAME, argv.flags, [
+    const config: NodeDestroyConfigClass = this.configManager.getConfig(DESTROY_CONFIGS_NAME, argv.flags, [
       'adminKey',
       'allNodeAliases',
       'existingNodeAliases',
@@ -298,39 +299,44 @@ export class NodeCommandConfigs {
       'contexts',
     ]) as NodeDestroyConfigClass;
 
-    context_.config.curDate = new Date();
-    context_.config.existingNodeAliases = [];
-    context_.config.namespace = await resolveNamespaceFromDeployment(this.localConfig, this.configManager, task);
+    context_.config = config;
 
-    await this.initializeSetup(context_.config, this.k8Factory);
+    config.curDate = new Date();
+    config.existingNodeAliases = [];
+    config.namespace = await resolveNamespaceFromDeployment(this.localConfig, this.configManager, task);
+
+    await this.initializeSetup(config, this.k8Factory);
 
     if (shouldLoadNodeClient) {
-      context_.config.nodeClient = await this.accountManager.loadNodeClient(
-        context_.config.namespace,
+      config.nodeClient = await this.accountManager.loadNodeClient(
+        config.namespace,
         this.remoteConfig.getClusterRefs(),
-        context_.config.deployment,
+        config.deployment,
       );
     }
 
-    const freezeAdminAccountId: AccountId = this.accountManager.getFreezeAccountId(context_.config.deployment);
+    const freezeAdminAccountId: AccountId = this.accountManager.getFreezeAccountId(config.deployment);
     const accountKeys: AccountIdWithKeyPairObject = await this.accountManager.getAccountKeysFromSecret(
       freezeAdminAccountId.toString(),
-      context_.config.namespace,
+      config.namespace,
     );
-    context_.config.freezeAdminPrivateKey = accountKeys.privateKey;
+    config.freezeAdminPrivateKey = accountKeys.privateKey;
 
     const treasuryAccount: AccountIdWithKeyPairObject = await this.accountManager.getTreasuryAccountKeys(
-      context_.config.namespace,
-      context_.config.deployment,
+      config.namespace,
+      config.deployment,
     );
     const treasuryAccountPrivateKey: string = treasuryAccount.privateKey;
-    context_.config.treasuryKey = PrivateKey.fromStringED25519(treasuryAccountPrivateKey);
+    config.treasuryKey = PrivateKey.fromStringED25519(treasuryAccountPrivateKey);
 
-    if (context_.config.domainNames) {
-      context_.config.domainNamesMapping = Templates.parseNodeAliasToDomainNameMapping(context_.config.domainNames);
+    if (config.domainNames) {
+      config.domainNamesMapping = Templates.parseNodeAliasToDomainNameMapping(config.domainNames);
     }
 
-    return context_.config;
+    config.gossipEndpointPortMapping = Templates.parseNodeAliasToPortMapping(config.gossipEndpointPort);
+    config.serviceEndpointPortMapping = Templates.parseNodeAliasToPortMapping(config.serviceEndpointPort);
+
+    return config;
   }
 
   public async addConfigBuilder(
@@ -339,7 +345,7 @@ export class NodeCommandConfigs {
     task: SoloListrTaskWrapper<NodeAddContext>,
     shouldLoadNodeClient: boolean = true,
   ): Promise<NodeAddConfigClass> {
-    context_.config = this.configManager.getConfig(ADD_CONFIGS_NAME, argv.flags, [
+    const config: NodeAddConfigClass = this.configManager.getConfig(ADD_CONFIGS_NAME, argv.flags, [
       'allNodeAliases',
       'newNodeAliases',
       'curDate',
@@ -357,59 +363,64 @@ export class NodeCommandConfigs {
       'contexts',
     ]) as NodeAddConfigClass;
 
+    context_.config = config;
+
     context_.adminKey = argv[flags.adminKey?.name]
       ? PrivateKey.fromStringED25519(argv[flags.adminKey?.name])
       : PrivateKey.fromStringED25519(constants.GENESIS_KEY);
 
-    context_.config.namespace = await resolveNamespaceFromDeployment(this.localConfig, this.configManager, task);
-    context_.config.curDate = new Date();
-    context_.config.existingNodeAliases = [];
+    config.namespace = await resolveNamespaceFromDeployment(this.localConfig, this.configManager, task);
+    config.curDate = new Date();
+    config.existingNodeAliases = [];
 
-    await this.initializeSetup(context_.config, this.k8Factory);
+    await this.initializeSetup(config, this.k8Factory);
 
     if (shouldLoadNodeClient) {
-      context_.config.nodeClient = await this.accountManager.loadNodeClient(
-        context_.config.namespace,
+      config.nodeClient = await this.accountManager.loadNodeClient(
+        config.namespace,
         this.remoteConfig.getClusterRefs(),
-        context_.config.deployment,
+        config.deployment,
       );
     }
 
-    const freezeAdminAccountId: AccountId = this.accountManager.getFreezeAccountId(context_.config.deployment);
+    const freezeAdminAccountId: AccountId = this.accountManager.getFreezeAccountId(config.deployment);
     const accountKeys: AccountIdWithKeyPairObject = await this.accountManager.getAccountKeysFromSecret(
       freezeAdminAccountId.toString(),
-      context_.config.namespace,
+      config.namespace,
     );
-    context_.config.freezeAdminPrivateKey = accountKeys.privateKey;
+    config.freezeAdminPrivateKey = accountKeys.privateKey;
 
     const treasuryAccount: AccountIdWithKeyPairObject = await this.accountManager.getTreasuryAccountKeys(
-      context_.config.namespace,
-      context_.config.deployment,
+      config.namespace,
+      config.deployment,
     );
     const treasuryAccountPrivateKey: string = treasuryAccount.privateKey;
-    context_.config.treasuryKey = PrivateKey.fromStringED25519(treasuryAccountPrivateKey);
+    config.treasuryKey = PrivateKey.fromStringED25519(treasuryAccountPrivateKey);
 
-    context_.config.serviceMap = await this.accountManager.getNodeServiceMap(
-      context_.config.namespace,
+    config.serviceMap = await this.accountManager.getNodeServiceMap(
+      config.namespace,
       this.remoteConfig.getClusterRefs(),
-      context_.config.deployment,
+      config.deployment,
     );
 
-    context_.config.consensusNodes = this.remoteConfig.getConsensusNodes();
-    context_.config.contexts = this.remoteConfig.getContexts();
+    config.consensusNodes = this.remoteConfig.getConsensusNodes();
+    config.contexts = this.remoteConfig.getContexts();
 
-    if (!context_.config.clusterRef) {
-      context_.config.clusterRef = this.remoteConfig.getClusterRefs()?.entries()?.next()?.value[0];
-      if (!context_.config.clusterRef) {
+    if (!config.clusterRef) {
+      config.clusterRef = this.remoteConfig.getClusterRefs()?.entries()?.next()?.value[0];
+      if (!config.clusterRef) {
         throw new SoloErrors.system.clusterReferenceUndetermined();
       }
     }
 
-    if (context_.config.domainNames) {
-      context_.config.domainNamesMapping = Templates.parseNodeAliasToDomainNameMapping(context_.config.domainNames);
+    if (config.domainNames) {
+      config.domainNamesMapping = Templates.parseNodeAliasToDomainNameMapping(config.domainNames);
     }
 
-    return context_.config;
+    config.gossipEndpointPortMapping = Templates.parseNodeAliasToPortMapping(config.gossipEndpointPort);
+    config.serviceEndpointPortMapping = Templates.parseNodeAliasToPortMapping(config.serviceEndpointPort);
+
+    return config;
   }
 
   public async logsConfigBuilder(
@@ -478,7 +489,7 @@ export class NodeCommandConfigs {
     context_: NodeRefreshContext,
     task: SoloListrTaskWrapper<NodeRefreshContext>,
   ): Promise<NodeRefreshConfigClass> {
-    context_.config = this.configManager.getConfig(REFRESH_CONFIGS_NAME, argv.flags, [
+    const config: NodeRefreshConfigClass = this.configManager.getConfig(REFRESH_CONFIGS_NAME, argv.flags, [
       'nodeAliases',
       'podRefs',
       'namespace',
@@ -486,20 +497,25 @@ export class NodeCommandConfigs {
       'contexts',
     ]) as NodeRefreshConfigClass;
 
-    context_.config.namespace = await resolveNamespaceFromDeployment(this.localConfig, this.configManager, task);
-    context_.config.nodeAliases = parseNodeAliases(
-      context_.config.nodeAliasesUnparsed,
+    context_.config = config;
+
+    config.namespace = await resolveNamespaceFromDeployment(this.localConfig, this.configManager, task);
+    config.nodeAliases = parseNodeAliases(
+      config.nodeAliasesUnparsed,
       this.remoteConfig.getConsensusNodes(),
       this.configManager,
     );
 
-    await this.initializeSetup(context_.config, this.k8Factory);
+    await this.initializeSetup(config, this.k8Factory);
 
-    if (context_.config.domainNames) {
-      context_.config.domainNamesMapping = Templates.parseNodeAliasToDomainNameMapping(context_.config.domainNames);
+    if (config.domainNames) {
+      config.domainNamesMapping = Templates.parseNodeAliasToDomainNameMapping(config.domainNames);
     }
 
-    return context_.config;
+    config.gossipEndpointPortMapping = Templates.parseNodeAliasToPortMapping(config.gossipEndpointPort);
+    config.serviceEndpointPortMapping = Templates.parseNodeAliasToPortMapping(config.serviceEndpointPort);
+
+    return config;
   }
 
   public async keysConfigBuilder(argv: ArgvStruct, context_: NodeKeysContext): Promise<NodeKeysConfigClass> {
@@ -644,13 +660,15 @@ export class NodeCommandConfigs {
     context_: NodeSetupContext,
     task: SoloListrTaskWrapper<NodeSetupContext>,
   ): Promise<NodeSetupConfigClass> {
-    context_.config = this.configManager.getConfig(SETUP_CONFIGS_NAME, argv.flags, [
+    const config: NodeSetupConfigClass = this.configManager.getConfig(SETUP_CONFIGS_NAME, argv.flags, [
       'nodeAliases',
       'podRefs',
       'namespace',
       'consensusNodes',
       'contexts',
     ]) as NodeSetupConfigClass;
+
+    context_.config = config;
 
     // Only enforce the saved-version match when there is at least one consensus node that has actually
     // progressed past REQUESTED. On a fresh deployment the remote-config version may have been
@@ -662,26 +680,25 @@ export class NodeCommandConfigs {
     );
     if (
       hasDeployedConsensusNode &&
-      !savedVersion.equals(context_.config.releaseTag) && // allow different versions only for local builds
-      !context_.config.localBuildPath
+      !savedVersion.equals(config.releaseTag) && // allow different versions only for local builds
+      !config.localBuildPath
     ) {
-      throw new SoloErrors.validation.nodeVersionMismatch(savedVersion.toString(), context_.config.releaseTag);
+      throw new SoloErrors.validation.nodeVersionMismatch(savedVersion.toString(), config.releaseTag);
     }
 
-    context_.config.namespace = await resolveNamespaceFromDeployment(this.localConfig, this.configManager, task);
-    context_.config.consensusNodes = this.remoteConfig.getConsensusNodes();
-    context_.config.nodeAliases = parseNodeAliases(
-      context_.config.nodeAliasesUnparsed,
-      context_.config.consensusNodes,
-      this.configManager,
-    );
+    config.namespace = await resolveNamespaceFromDeployment(this.localConfig, this.configManager, task);
+    config.consensusNodes = this.remoteConfig.getConsensusNodes();
+    config.nodeAliases = parseNodeAliases(config.nodeAliasesUnparsed, config.consensusNodes, this.configManager);
 
-    await this.initializeSetup(context_.config, this.k8Factory);
+    await this.initializeSetup(config, this.k8Factory);
 
-    if (context_.config.domainNames) {
-      context_.config.domainNamesMapping = Templates.parseNodeAliasToDomainNameMapping(context_.config.domainNames);
+    if (config.domainNames) {
+      config.domainNamesMapping = Templates.parseNodeAliasToDomainNameMapping(config.domainNames);
     }
 
-    return context_.config;
+    config.gossipEndpointPortMapping = Templates.parseNodeAliasToPortMapping(config.gossipEndpointPort);
+    config.serviceEndpointPortMapping = Templates.parseNodeAliasToPortMapping(config.serviceEndpointPort);
+
+    return config;
   }
 }

--- a/src/commands/node/flags.ts
+++ b/src/commands/node/flags.ts
@@ -48,6 +48,8 @@ const COMMON_UPDATE_FLAGS_OPTIONAL_FLAGS: CommandFlag[] = [
   flags.gossipEndpoints,
   flags.grpcEndpoints,
   flags.domainNames,
+  flags.gossipEndpointPort,
+  flags.serviceEndpointPort,
   // Keep deprecated legacy flag accepted for backward compatibility.
   flags.releaseTag,
   flags.consensusNodeVersion,
@@ -140,6 +142,8 @@ const COMMON_DESTROY_OPTIONAL_FLAGS: CommandFlag[] = [
   flags.quiet,
   flags.chartDirectory,
   flags.domainNames,
+  flags.gossipEndpointPort,
+  flags.serviceEndpointPort,
   // Keep deprecated legacy flag accepted for backward compatibility.
   flags.releaseTag,
   flags.consensusNodeVersion,
@@ -167,6 +171,8 @@ const COMMON_ADD_OPTIONAL_FLAGS: CommandFlag[] = [
   flags.chartDirectory,
   flags.quiet,
   flags.domainNames,
+  flags.gossipEndpointPort,
+  flags.serviceEndpointPort,
   flags.cacheDir,
   flags.endpointType,
   flags.generateGossipKeys,
@@ -254,6 +260,8 @@ export const REFRESH_FLAGS: CommandFlags = {
     flags.consensusNodeVersion,
     flags.cacheDir,
     flags.domainNames,
+    flags.gossipEndpointPort,
+    flags.serviceEndpointPort,
   ],
 };
 
@@ -321,6 +329,8 @@ export const SETUP_FLAGS: CommandFlags = {
     flags.localBuildPath,
     flags.adminPublicKeys,
     flags.domainNames,
+    flags.gossipEndpointPort,
+    flags.serviceEndpointPort,
   ],
 };
 

--- a/src/commands/node/tasks.ts
+++ b/src/commands/node/tasks.ts
@@ -108,6 +108,7 @@ import {
   type ComponentId,
   type Context,
   type DeploymentName,
+  type EndpointPortMapping,
   type NodeAliasToAddressMapping,
   type Optional,
   type PriorityMapping,
@@ -1694,6 +1695,8 @@ export class NodeCommandTasks {
             config.consensusNodes,
             config.stagingDir,
             config.domainNamesMapping,
+            config.gossipEndpointPortMapping,
+            config.serviceEndpointPortMapping,
           );
         }
 
@@ -1964,12 +1967,16 @@ export class NodeCommandTasks {
    * @param keysDirectory - keys directory
    * @param stagingDirectory - staging directory
    * @param domainNamesMapping
+   * @param gossipEndpointPortMapping - port overrides for the gossip endpoints
+   * @param serviceEndpointPortMapping - port overrides for the gRPC service endpoints
    */
   private async generateGenesisNetworkJson(
     namespace: NamespaceName,
     consensusNodes: ConsensusNode[],
     stagingDirectory: string,
     domainNamesMapping?: Record<NodeAlias, string>,
+    gossipEndpointPortMapping?: EndpointPortMapping,
+    serviceEndpointPortMapping?: EndpointPortMapping,
   ): Promise<void> {
     const deploymentName: string = this.configManager.getFlag<DeploymentName>(flags.deployment);
     const networkNodeServiceMap: Map<NodeAlias, NetworkNodeServices> = await this.accountManager.getNodeServiceMap(
@@ -1991,6 +1998,8 @@ export class NodeCommandTasks {
       networkNodeServiceMap,
       adminPublicKeys,
       domainNamesMapping,
+      gossipEndpointPortMapping,
+      serviceEndpointPortMapping,
     );
 
     const genesisNetworkJson: string = PathEx.join(stagingDirectory, 'genesis-network.json');
@@ -3299,7 +3308,11 @@ export class NodeCommandTasks {
               [],
             ),
             k8,
-            +constants.HEDERA_NODE_EXTERNAL_GOSSIP_PORT,
+            Templates.resolveEndpointPort(
+              config.gossipEndpointPortMapping,
+              config.nodeAlias,
+              +constants.HEDERA_NODE_EXTERNAL_GOSSIP_PORT,
+            ),
             gossipFqdnRestricted,
           );
 
@@ -3349,6 +3362,12 @@ export class NodeCommandTasks {
       task: (context_): void => {
         const config: NodeAddConfigClass = context_.config;
         let endpoints: string[] = [];
+        // without an override the gRPC service endpoint keeps using the external gossip port, as it always has
+        const servicePort: number = Templates.resolveEndpointPort(
+          config.serviceEndpointPortMapping,
+          config.nodeAlias,
+          +constants.HEDERA_NODE_EXTERNAL_GOSSIP_PORT,
+        );
 
         if (config.grpcEndpoints) {
           endpoints = splitFlagInput(config.grpcEndpoints);
@@ -3358,15 +3377,11 @@ export class NodeCommandTasks {
           }
 
           endpoints = [
-            `${Templates.renderFullyQualifiedNetworkSvcName(config.namespace, config.nodeAlias)}:${constants.HEDERA_NODE_EXTERNAL_GOSSIP_PORT}`,
+            `${Templates.renderFullyQualifiedNetworkSvcName(config.namespace, config.nodeAlias)}:${servicePort}`,
           ];
         }
 
-        context_.grpcServiceEndpoints = prepareEndpoints(
-          config.endpointType,
-          endpoints,
-          constants.HEDERA_NODE_EXTERNAL_GOSSIP_PORT,
-        );
+        context_.grpcServiceEndpoints = prepareEndpoints(config.endpointType, endpoints, servicePort);
       },
     };
   }

--- a/src/core/genesis-network-models/genesis-network-data-constructor.ts
+++ b/src/core/genesis-network-models/genesis-network-data-constructor.ts
@@ -5,11 +5,12 @@ import {GenesisNetworkNodeDataWrapper} from './genesis-network-node-data-wrapper
 import * as constants from '../constants.js';
 
 import {type KeyManager} from '../key-manager.js';
-import {type ToJSON} from '../../types/index.js';
+import {type EndpointPortMapping, type ToJSON} from '../../types/index.js';
 import {type JsonString, type NodeAlias} from '../../types/aliases.js';
 import {GenesisNetworkRosterEntryDataWrapper} from './genesis-network-roster-entry-data-wrapper.js';
 import {SoloErrors} from '../errors/solo-errors.js';
 import {Flags as flags} from '../../commands/flags.js';
+import {Templates} from '../templates.js';
 import {type AccountManager} from '../account-manager.js';
 import {type ConsensusNode} from '../model/consensus-node.js';
 import {type NodeServiceMapping} from '../../types/mappings/node-service-mapping.js';
@@ -31,6 +32,8 @@ export class GenesisNetworkDataConstructor implements ToJSON {
     public networkNodeServiceMap: NodeServiceMapping,
     public adminPublicKeyMap: Map<NodeAlias, string>,
     public domainNamesMapping?: Record<NodeAlias, string>,
+    public gossipEndpointPortMapping?: EndpointPortMapping,
+    public serviceEndpointPortMapping?: EndpointPortMapping,
   ) {
     this.initializationPromise = (async (): Promise<void> => {
       for (const consensusNode of consensusNodes) {
@@ -75,15 +78,24 @@ export class GenesisNetworkDataConstructor implements ToJSON {
           this.rosters[consensusNode.name] = rosterDataWrapper;
           rosterDataWrapper.weight = this.nodes[consensusNode.name].weight = constants.HEDERA_NODE_DEFAULT_STAKE_AMOUNT;
 
-          const externalPort: number = +constants.HEDERA_NODE_EXTERNAL_GOSSIP_PORT;
+          const externalPort: number = Templates.resolveEndpointPort(
+            gossipEndpointPortMapping,
+            consensusNode.name,
+            +constants.HEDERA_NODE_EXTERNAL_GOSSIP_PORT,
+          );
           // Add gossip endpoints
           nodeDataWrapper.addGossipEndpoint(networkNodeService.externalAddress, externalPort);
           rosterDataWrapper.addGossipEndpoint(networkNodeService.externalAddress, externalPort);
 
           const domainName: string = domainNamesMapping?.[consensusNode.name];
+          const servicePort: number = Templates.resolveEndpointPort(
+            serviceEndpointPortMapping,
+            consensusNode.name,
+            constants.GRPC_PORT,
+          );
 
           // Add service endpoints
-          nodeDataWrapper.addServiceEndpoint(domainName ?? networkNodeService.externalAddress, constants.GRPC_PORT);
+          nodeDataWrapper.addServiceEndpoint(domainName ?? networkNodeService.externalAddress, servicePort);
         } catch (error) {
           throw new SoloErrors.component.genesisDataGenerationFailed(error);
         }
@@ -98,6 +110,8 @@ export class GenesisNetworkDataConstructor implements ToJSON {
     networkNodeServiceMap: NodeServiceMapping,
     adminPublicKeys: string[],
     domainNamesMapping?: Record<NodeAlias, string>,
+    gossipEndpointPortMapping?: EndpointPortMapping,
+    serviceEndpointPortMapping?: EndpointPortMapping,
   ): Promise<GenesisNetworkDataConstructor> {
     const adminPublicKeyMap: Map<NodeAlias, string> = new Map();
 
@@ -126,6 +140,8 @@ export class GenesisNetworkDataConstructor implements ToJSON {
       networkNodeServiceMap,
       adminPublicKeyMap,
       domainNamesMapping,
+      gossipEndpointPortMapping,
+      serviceEndpointPortMapping,
     );
 
     await instance.load();

--- a/src/core/templates.ts
+++ b/src/core/templates.ts
@@ -11,6 +11,7 @@ import {type NamespaceName} from '../types/namespace/namespace-name.js';
 import {
   type ClusterReferenceName,
   type ComponentId,
+  type EndpointPortMapping,
   type NamespaceNameAsString,
   type NodeAliasToAddressMapping,
   type PriorityMapping,
@@ -359,6 +360,74 @@ export class Templates {
     }
 
     return mapping;
+  }
+
+  /**
+   * Parses a port override used when building the consensus node endpoints written to the genesis network.
+   *
+   * Supported forms:
+   *
+   * 1) A single port applied to every consensus node
+   *    Example: "50211"
+   *
+   * 2) Explicit alias → port pairs, with multiple nodes comma separated
+   *    Example: "node1=50211,node2=50212"
+   *
+   * The two forms can be combined, in which case the alias-less port acts as the default for the nodes that were not
+   * listed explicitly. Example: "50211,node2=50212"
+   *
+   * @param unparsed - input string describing the port override, may be undefined when the flag was not supplied
+   * @returns the default port and the per node alias overrides
+   * @throws SoloError if an alias cannot be parsed or a port is not an integer between 1 and 65535
+   */
+  public static parseNodeAliasToPortMapping(unparsed?: string): EndpointPortMapping {
+    const mapping: EndpointPortMapping = {nodeAliasToPort: {}};
+
+    if (!unparsed || typeof unparsed !== 'string') {
+      return mapping;
+    }
+
+    for (const data of unparsed.split(',')) {
+      if (data.includes('=')) {
+        const [nodeAlias, port] = data.split('=') as [NodeAlias, string];
+
+        if (!nodeAlias) {
+          throw new SoloErrors.validation.nodeAliasParseFailed(data);
+        }
+
+        mapping.nodeAliasToPort[nodeAlias] = Templates.parsePort(port);
+      } else {
+        mapping.defaultPort = Templates.parsePort(data);
+      }
+    }
+
+    return mapping;
+  }
+
+  /**
+   * Resolves the port to use for a consensus node endpoint, preferring the per node override, then the port that the
+   * user supplied for every node, and finally the built in default.
+   *
+   * @param portMapping - the parsed port override, undefined when the flag was not supplied
+   * @param nodeAlias - the consensus node the endpoint is built for
+   * @param defaultPort - the port to use when the user did not override it
+   */
+  public static resolveEndpointPort(
+    portMapping: EndpointPortMapping | undefined,
+    nodeAlias: NodeAlias,
+    defaultPort: number,
+  ): number {
+    return portMapping?.nodeAliasToPort?.[nodeAlias] ?? portMapping?.defaultPort ?? defaultPort;
+  }
+
+  private static parsePort(unparsed: string): number {
+    const port: number = Number(unparsed.trim());
+
+    if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+      throw new SoloErrors.validation.invalidPortNumber(unparsed);
+    }
+
+    return port;
   }
 
   public static parseNodeAliasToDomainNameMapping(unparsed: string): Record<NodeAlias, string> {

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -74,3 +74,8 @@ export type ClusterReferenceName = string;
 export type ClusterReferences = Map<ClusterReferenceName, Context>;
 export type PriorityMapping = [blockNodeId: ComponentId, priority: number];
 export type NodeAliasToAddressMapping = Record<NodeAlias, {address: string; port: number}>;
+/**
+ * A port override for a consensus node endpoint. `defaultPort` applies to every consensus node that has no entry in
+ * `nodeAliasToPort`; both are undefined/empty when the user did not supply an override.
+ */
+export type EndpointPortMapping = {defaultPort?: number; nodeAliasToPort: Record<NodeAlias, number>};

--- a/test/unit/commands/network.test.ts
+++ b/test/unit/commands/network.test.ts
@@ -243,7 +243,8 @@ describe('NetworkCommand unit tests', (): void => {
       options.leaseManager = container.resolve<LockManager>(InjectTokens.LockManager);
       options.leaseManager.currentNamespace = sinon.stub().returns(testName);
 
-      GenesisNetworkDataConstructor.initialize = sinon.stub().resolves();
+      // stub through sinon so that afterEach's restore puts the real method back for other test files
+      sinon.stub(GenesisNetworkDataConstructor, 'initialize').resolves();
     });
 
     afterEach((): void => {

--- a/test/unit/core/genesis-network-data-constructor.test.ts
+++ b/test/unit/core/genesis-network-data-constructor.test.ts
@@ -1,0 +1,105 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {expect} from 'chai';
+import {describe, it} from 'mocha';
+import {GenesisNetworkDataConstructor} from '../../../src/core/genesis-network-models/genesis-network-data-constructor.js';
+import {type AccountManager} from '../../../src/core/account-manager.js';
+import {type KeyManager} from '../../../src/core/key-manager.js';
+import {ConsensusNode} from '../../../src/core/model/consensus-node.js';
+import {type NetworkNodeServices} from '../../../src/core/network-node-services.js';
+import {NamespaceName} from '../../../src/types/namespace/namespace-name.js';
+import {type NodeAlias} from '../../../src/types/aliases.js';
+import {type EndpointPortMapping, type ServiceEndpoint} from '../../../src/types/index.js';
+import {type NodeServiceMapping} from '../../../src/types/mappings/node-service-mapping.js';
+import * as constants from '../../../src/core/constants.js';
+
+describe('core/genesis-network-data-constructor', (): void => {
+  const nodeAliases: NodeAlias[] = ['node1', 'node2'];
+
+  const consensusNodes: ConsensusNode[] = nodeAliases.map(
+    (nodeAlias: NodeAlias, index: number): ConsensusNode =>
+      new ConsensusNode(nodeAlias, index, 'solo', 'solo-cluster', 'solo-cluster', 'cluster.local', '', '', [], []),
+  );
+
+  function networkNodeServiceMap(): NodeServiceMapping {
+    const serviceMap: NodeServiceMapping = new Map();
+
+    for (const [index, nodeAlias] of nodeAliases.entries()) {
+      serviceMap.set(nodeAlias, {
+        nodeId: index,
+        accountId: `0.0.${index + 3}`,
+        namespace: NamespaceName.of('solo'),
+        externalAddress: `network-${nodeAlias}-svc.solo.svc.cluster.local`,
+      } as unknown as NetworkNodeServices);
+    }
+
+    return serviceMap;
+  }
+
+  const keyManager: KeyManager = {
+    getDerFromPem: (): Uint8Array => new Uint8Array([1, 2, 3]),
+  } as unknown as KeyManager;
+
+  const accountManager: AccountManager = {
+    getGossipPublicKeyPem: async (): Promise<string> => 'gossip-public-key-pem',
+    createOrReplaceAccountKeySecret: async (): Promise<void> => {},
+  } as unknown as AccountManager;
+
+  async function buildGenesisNetworkData(
+    gossipEndpointPortMapping?: EndpointPortMapping,
+    serviceEndpointPortMapping?: EndpointPortMapping,
+  ): Promise<GenesisNetworkDataConstructor> {
+    return await GenesisNetworkDataConstructor.initialize(
+      consensusNodes,
+      keyManager,
+      accountManager,
+      networkNodeServiceMap(),
+      [],
+      undefined,
+      gossipEndpointPortMapping,
+      serviceEndpointPortMapping,
+    );
+  }
+
+  function gossipPorts(genesisNetworkData: GenesisNetworkDataConstructor): number[] {
+    return nodeAliases.flatMap((nodeAlias: NodeAlias): number[] => [
+      ...genesisNetworkData.nodes[nodeAlias].gossipEndpoint.map((endpoint: ServiceEndpoint): number => endpoint.port),
+      ...genesisNetworkData.rosters[nodeAlias].gossipEndpoint.map((endpoint: ServiceEndpoint): number => endpoint.port),
+    ]);
+  }
+
+  function servicePorts(genesisNetworkData: GenesisNetworkDataConstructor): number[] {
+    return nodeAliases.flatMap((nodeAlias: NodeAlias): number[] =>
+      genesisNetworkData.nodes[nodeAlias].serviceEndpoint.map((endpoint: ServiceEndpoint): number => endpoint.port),
+    );
+  }
+
+  it('should use the default ports when no port override was supplied', async (): Promise<void> => {
+    const genesisNetworkData: GenesisNetworkDataConstructor = await buildGenesisNetworkData();
+
+    expect(gossipPorts(genesisNetworkData)).to.deep.equal(
+      Array.from({length: 4}, (): number => +constants.HEDERA_NODE_EXTERNAL_GOSSIP_PORT),
+    );
+    expect(servicePorts(genesisNetworkData)).to.deep.equal(Array.from({length: 2}, (): number => constants.GRPC_PORT));
+  });
+
+  it('should apply the default port of the override to every consensus node', async (): Promise<void> => {
+    const genesisNetworkData: GenesisNetworkDataConstructor = await buildGenesisNetworkData(
+      {defaultPort: 40_111, nodeAliasToPort: {}},
+      {defaultPort: 40_211, nodeAliasToPort: {}},
+    );
+
+    expect(gossipPorts(genesisNetworkData)).to.deep.equal([40_111, 40_111, 40_111, 40_111]);
+    expect(servicePorts(genesisNetworkData)).to.deep.equal([40_211, 40_211]);
+  });
+
+  it('should prefer the per node alias port over the default port', async (): Promise<void> => {
+    const genesisNetworkData: GenesisNetworkDataConstructor = await buildGenesisNetworkData(
+      {defaultPort: 40_111, nodeAliasToPort: {node2: 40_112}},
+      {nodeAliasToPort: {node2: 40_212}},
+    );
+
+    expect(gossipPorts(genesisNetworkData)).to.deep.equal([40_111, 40_111, 40_112, 40_112]);
+    expect(servicePorts(genesisNetworkData)).to.deep.equal([constants.GRPC_PORT, 40_212]);
+  });
+});

--- a/test/unit/core/templates.test.ts
+++ b/test/unit/core/templates.test.ts
@@ -61,4 +61,47 @@ describe('core/templates', (): void => {
       'http://mirror-1-web3.solo.svc.cluster.local',
     );
   });
+
+  describe('parseNodeAliasToPortMapping', (): void => {
+    it('should return an empty mapping when no port was supplied', (): void => {
+      expect(Templates.parseNodeAliasToPortMapping()).to.deep.equal({nodeAliasToPort: {}});
+      expect(Templates.parseNodeAliasToPortMapping('')).to.deep.equal({nodeAliasToPort: {}});
+    });
+
+    it('should apply a single port to every consensus node', (): void => {
+      expect(Templates.parseNodeAliasToPortMapping('50211')).to.deep.equal({
+        defaultPort: 50_211,
+        nodeAliasToPort: {},
+      });
+    });
+
+    it('should parse per node alias ports', (): void => {
+      expect(Templates.parseNodeAliasToPortMapping('node1=50211,node2=50212')).to.deep.equal({
+        nodeAliasToPort: {node1: 50_211, node2: 50_212},
+      });
+    });
+
+    it('should combine a default port with per node alias ports', (): void => {
+      expect(Templates.parseNodeAliasToPortMapping('50211,node2=50212')).to.deep.equal({
+        defaultPort: 50_211,
+        nodeAliasToPort: {node2: 50_212},
+      });
+    });
+
+    it('should throw when a port is not a valid port number', (): void => {
+      const invalidPorts: string[] = ['abc', '0', '65536', '50211.5', '-1', 'node1=abc', 'node1='];
+
+      for (const invalidPort of invalidPorts) {
+        expect((): void => {
+          Templates.parseNodeAliasToPortMapping(invalidPort);
+        }, invalidPort).to.throw(/Invalid port number/);
+      }
+    });
+
+    it('should throw when the node alias is missing', (): void => {
+      expect((): void => {
+        Templates.parseNodeAliasToPortMapping('=50211');
+      }).to.throw(/Cannot parse node alias/);
+    });
+  });
 });


### PR DESCRIPTION
## Description

* Adds two optional flags that override the ports used when building the consensus node
  endpoints it publishes to the network:
  * `--gossip-endpoint-port` — port for the gossip endpoints (default: `50111`, from
    `SOLO_NODE_EXTERNAL_GOSSIP_PORT`)
  * `--service-endpoint-port` — port for the gRPC service endpoints (default: `50211`, from
    `GRPC_PORT`)
* Each flag accepts either a single port applied to every node, per-node `alias=port` pairs, or a
  combination where the alias-less port is the default for nodes not listed explicitly:

  ```bash
  --gossip-endpoint-port 50111
  --service-endpoint-port node1=50211,node2=50212
  --service-endpoint-port 50211,node2=50212
  ```

### Related Issues

* Closes # https://github.com/hiero-ledger/solo/issues/3306
