### PR TITLE
fix(test): stop the kind-client suite timeout from clobbering per-test timeouts

### DIFF
--- a/test/e2e/integration/core/kind/kind-client.test.ts
+++ b/test/e2e/integration/core/kind/kind-client.test.ts
@@ -29,7 +29,12 @@ import {type SemanticVersion} from '../../../../../src/business/utils/semantic-v
 const execAsync: (command: string, options?: Parameters<typeof exec>[1]) => Promise<{stdout: string; stderr: string}> =
   promisify(exec);
 
-describe('KindClient Integration Tests', (): void => {
+describe('KindClient Integration Tests', function (this: Mocha.Suite): void {
+  // Must be set here rather than chained onto the closing `});`: since mocha 11.7.6 a suite-level
+  // `.timeout()` propagates to already-registered tests and would clobber their own timeouts.
+  // eslint-disable-next-line unicorn/no-this-outside-of-class
+  this.timeout(Duration.ofMinutes(1).toMillis());
+
   let kindClient: KindClient;
   let kindPath: string;
   const testClusterName: string = 'test-kind-client';
@@ -215,4 +220,4 @@ describe('KindClient Integration Tests', (): void => {
     const deletedCluster: KindCluster = clusters.find((c: KindCluster): boolean => c.name === testClusterName);
     expect(deletedCluster).to.be.undefined;
   });
-}).timeout(Duration.ofMinutes(1).toMillis());
+});


### PR DESCRIPTION
## Description

This pull request changes the following:

* Moves the kind-client integration suite's 1-minute timeout from a chained `.timeout()` on the suite's closing brace to a `this.timeout()` call as the first statement inside the `describe` callback (`test/e2e/integration/core/kind/kind-client.test.ts`).
* Root cause: since mocha 11.7.6 (the fix for mochajs/mocha#5422), `Suite.prototype.timeout()` propagates to every already-registered test and nested suite. The chained form runs after all `it()` registrations, so the suite's 1-minute value overwrote the per-test timeouts — `should create a cluster` declares 4 minutes but was effectively running with 60 seconds while performing up to three delete-and-create rounds against a real kind cluster.
* Effect: per-test and per-hook timeouts take effect again, fixing the intermittent `Timeout of 60000ms exceeded` failures in the `E2E Tests (Integration)` job that have been hitting open PRs since mocha 11.7.6 landed on 2026-07-15.

### Related Issues

* Related to the intermittent `E2E Tests (Integration) / Integration` failures on open PRs (e.g. #5144, #5315)

### Pull request (PR) checklist

- [ ] This PR added tests (unit, integration, and/or end-to-end)
- [ ] This PR updated documentation
- [x] This PR added no TODOs or commented out code
- [x] This PR has no breaking changes
- [ ] Any technical debt has been documented as a separate issue and linked to this PR
- [ ] Any `package.json` changes have been explained to and approved by a repository manager
- [x] All related issues have been linked to this PR
- [x] All changes in this PR are included in the description
- [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

- [ ] This PR added unit tests
- [ ] This PR added integration/end-to-end tests
- [x] These changes required manual testing that is documented below
- [ ] Anything not tested is documented

The following manual testing was done:

* Verified the mocha behavior with a scratch spec against this repo's installed mocha (11.7.6): the chained `.timeout()` shape reports an effective timeout of 60000 ms for a test declaring 240000 ms; the corrected `this.timeout()` shape reports 240000 ms.

The following was not tested:

* The full `E2E Tests (Integration)` job was not run locally — this PR's own CI run exercises the affected suite.