### PR TITLE
fix: make file storage writes atomic

### DIFF
--- a/src/data/backend/impl/file-storage-backend.ts
+++ b/src/data/backend/impl/file-storage-backend.ts
@@ -3,7 +3,7 @@
 import {SoloErrors} from '../../../core/errors/solo-errors.js';
 import {type StorageBackend} from '../api/storage-backend.js';
 import {StorageOperation} from '../api/storage-operation.js';
-import {type Stats, statSync, lstatSync, readdirSync, writeFileSync, unlinkSync} from 'node:fs';
+import {type Stats, lstatSync, readdirSync, renameSync, statSync, unlinkSync, writeFileSync} from 'node:fs';
 import {StorageBackendError} from '../api/storage-backend-error.js';
 import {readFileSync} from 'node:fs';
 import {PathEx} from '../../../business/utils/path-ex.js';
@@ -91,11 +91,25 @@ export class FileStorageBackend implements StorageBackend {
     }
 
     const filePath: string = PathEx.join(this.basePath, key);
+    const temporaryFilePath: string = this.getTemporaryFilePath(filePath);
     try {
-      writeFileSync(filePath, data, {flag: 'w'});
+      writeFileSync(temporaryFilePath, data, {flag: 'wx'});
+      renameSync(temporaryFilePath, filePath);
     } catch (error) {
+      try {
+        unlinkSync(temporaryFilePath);
+      } catch {
+        // best-effort: the temporary file may not exist yet or may already be cleaned up
+      }
       throw new StorageBackendError(`error writing file: ${filePath}`, error);
     }
+  }
+
+  private getTemporaryFilePath(filePath: string): string {
+    const directoryPath: string = PathEx.dirname(filePath);
+    const fileName: string = PathEx.basename(filePath);
+    const uniqueSuffix: string = `${process.pid}-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    return PathEx.join(directoryPath, `.${fileName}.solo-write-${uniqueSuffix}.tmp`);
   }
 
   public async delete(key: string): Promise<void> {

--- a/test/unit/data/backend/impl/file-storage-backend.test.ts
+++ b/test/unit/data/backend/impl/file-storage-backend.test.ts
@@ -81,6 +81,19 @@ describe('File Storage Backend', (): void => {
     expect(fs.readFileSync(temporaryFile, 'utf8')).to.equal('test');
   });
 
+  it('replaces existing file contents without leaving temporary files behind', async (): Promise<void> => {
+    const key: string = `${testName}-atomic-write.txt`;
+    const targetFilePath: string = PathEx.join(temporaryDirectory, key);
+    fs.writeFileSync(targetFilePath, 'old-value');
+
+    const backend: FileStorageBackend = new FileStorageBackend(temporaryDirectory);
+    await backend.writeBytes(key, Buffer.from('new-value', 'utf8'));
+
+    expect(fs.readFileSync(targetFilePath, 'utf8')).to.equal('new-value');
+    expect(fs.readdirSync(temporaryDirectory).filter((entry: string): boolean => entry.includes('.solo-write-'))).to.be
+      .empty;
+  });
+
   it('test writeBytes with empty key', async (): Promise<void> => {
     const backend: FileStorageBackend = new FileStorageBackend(temporaryDirectory);
     await expect(backend.writeBytes('', Buffer.from('test', 'utf8'))).to.be.rejectedWith(
@@ -99,6 +112,8 @@ describe('File Storage Backend', (): void => {
     fs.mkdirSync(temporaryFile);
     const backend: FileStorageBackend = new FileStorageBackend(temporaryDirectory);
     await expect(backend.writeBytes(key, Buffer.from('test', 'utf8'))).to.be.rejectedWith('error writing file');
+    expect(fs.readdirSync(temporaryDirectory).filter((entry: string): boolean => entry.includes('.solo-write-'))).to.be
+      .empty;
   });
 
   it('test delete', async (): Promise<void> => {


### PR DESCRIPTION
## Description

This pull request changes the following:

* makes local file-backed config writes atomic by writing to a sibling temporary file and renaming it into place
* adds unit coverage that verifies existing files are replaced cleanly and temporary files are not left behind after success or failure
* documents in the PR context that issue #2165 was reviewed and that most reported claims are stale against the current codebase

### Related Issues

* Close #2165

### Pull request (PR) checklist

* [x] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [x] Any technical debt has been documented as a separate issue and linked to this PR
* [x] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the `commit message guidelines` below have been followed

### Testing

* [x] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [ ] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* None

The following was not tested:

* kill/interruption during an actual write on a live filesystem; this PR validates the atomic replace path with unit tests

### Issue #2165 review notes

During this fix, #2165 was re-checked against the current tree.

Claims that appear stale or already resolved in current `main`:

* the reported inverted cluster-ref lookup is not present in `src/commands/cluster/tasks.ts`
* the reported Prometheus install inversion is not present; current logic installs when absent and skips only when already installed
* the reported shell command injection path no longer matches current Helm execution, which uses structured arguments with `shell: false`
* the reported lock hang does not match current `IntervalLock.acquire()`, which throws when another holder owns the lease

Claim addressed by this PR:

* local file writes in `FileStorageBackend.writeBytes()` were still direct target writes and are now converted to temp-file-plus-rename atomic replacement
