### PR TITLE
fix: upgrade mirror node to solo's default version in the version upgrade test

### DIFF
--- a/examples/version-upgrade-test/Taskfile.yml
+++ b/examples/version-upgrade-test/Taskfile.yml
@@ -30,9 +30,6 @@ vars:
   PREV_BLOCK_VERSION:
     sh: sed -n "s/.*PREV_BLOCK_NODE_VERSION.*'\([^']*\)'.*/\1/p" "$(git rev-parse --show-toplevel)/version-test.ts"
 
-  # Current versions to upgrade to
-  CURRENT_MIRROR_VERSION: "v0.152.0"
-
   # Local build path for network upgrade
   ROOT_DIR:
     sh: git rev-parse --show-toplevel
@@ -137,10 +134,9 @@ tasks:
   upgrade-components:
     desc: Upgrade all components to current versions
     cmds:
-      # Upgrade mirror node
+      # Upgrade mirror node to solo's current default version so the target tracks version.ts instead of a stale pin
       - cmd: |
-          $SOLO_COMMAND mirror node upgrade --deployment {{ .DEPLOYMENT }} \
-          --mirror-node-version {{ .CURRENT_MIRROR_VERSION }}
+          $SOLO_COMMAND mirror node upgrade --deployment {{ .DEPLOYMENT }}
       - cmd: $SOLO_COMMAND ledger account create --deployment {{ .DEPLOYMENT }} --hbar-amount 50
 
       # Upgrade network to main with local build path


### PR DESCRIPTION
## Description

The `Test Example (Version Upgrade Test)` CI job failed with `[SOLO-3032]`: it tried to upgrade the mirror node to `v0.152.0` while the test had just deployed `0.156.0`, so the downgrade guard correctly rejected the command.

The root cause is a stale pin, not the guard. The test derives every "from" version from `version-test.ts` (`PREV_MIRROR_NODE_VERSION` is now `v0.156.0`), and every component upgrades to solo's current default — except the mirror node, which used the one remaining hard-coded target, `CURRENT_MIRROR_VERSION: "v0.152.0"`. That literal was current when it was introduced in #4001 and was never maintained; the moment the "from" version passed it, the upgrade became a downgrade.

### The fix

Instead of bumping the literal (which would rot again at the next version bump), drop `--mirror-node-version` so `mirror node upgrade` targets its flag default — `MIRROR_NODE_VERSION` from `version.ts` (`v0.159.0` today, overridable via the `MIRROR_NODE_VERSION` env var). This is the same shape the relay, explorer, and block node upgrade steps in this Taskfile already use, and it works in both test modes: a dev build upgrades to the checked-out `version.ts` default, and `USE_RELEASED_VERSION=true` upgrades to the released CLI's own default. The now-unused `CURRENT_MIRROR_VERSION` variable is removed.

The flag is in the upgrade command's optional list, so omitting it takes the default without any interactive prompt.

### Testing

- `task --taskfile examples/version-upgrade-test/Taskfile.yml --list-all` parses cleanly; no remaining references to `CURRENT_MIRROR_VERSION`.
- The real verification is the `Test Example (Version Upgrade Test)` CI job on this PR, which now upgrades `v0.156.0` → `v0.159.0`.

Fixes #5410
Fixes #5409
