### PR TITLE
fix: spawn npm through a shell on Windows

### DIFF
--- a/src/integration/npm/npm-client.ts
+++ b/src/integration/npm/npm-client.ts
@@ -6,6 +6,7 @@ import {type SoloLogger} from '../../core/logging/solo-logger.js';
 import {patchInject} from '../../core/dependency-injection/container-helper.js';
 import {ShellRunner} from '../../core/shell-runner.js';
 import {SubprocessCommandProfile} from '../../core/subprocess-command-profile.js';
+import {OperatingSystem} from '../../business/utils/operating-system.js';
 
 @injectable()
 export class NpmClient {
@@ -18,6 +19,10 @@ export class NpmClient {
    */
   public async listGlobal(): Promise<string[]> {
     const shellRunner: ShellRunner = new ShellRunner(this.logger);
-    return shellRunner.run('npm', ['list', '--global', '--depth=0'], {commandProfile: SubprocessCommandProfile.NPM});
+    return shellRunner.run('npm', ['list', '--global', '--depth=0'], {
+      commandProfile: SubprocessCommandProfile.NPM,
+      // npm is npm.cmd on Windows, and Node refuses to spawn .cmd files without a shell (CVE-2024-27980)
+      useShell: OperatingSystem.isWin32(),
+    });
   }
 }

--- a/test/unit/integration/npm/npm-client.test.ts
+++ b/test/unit/integration/npm/npm-client.test.ts
@@ -8,6 +8,7 @@ import {expect} from 'chai';
 import {describe, it, beforeEach, afterEach} from 'mocha';
 import {NpmClient} from '../../../../src/integration/npm/npm-client.js';
 import {ShellRunner} from '../../../../src/core/shell-runner.js';
+import {OperatingSystem} from '../../../../src/business/utils/operating-system.js';
 
 describe('NpmClient', (): void => {
   let npmClient: NpmClient;
@@ -27,6 +28,32 @@ describe('NpmClient', (): void => {
       await npmClient.listGlobal();
 
       expect(shellRunnerRunStub).to.have.been.calledOnceWith('npm', ['list', '--global', '--depth=0']);
+    });
+
+    it('should spawn npm through a shell on Windows, where npm is a .cmd batch file', async (): Promise<void> => {
+      sinon.stub(OperatingSystem, 'isWin32').returns(true);
+      shellRunnerRunStub.resolves([]);
+
+      await npmClient.listGlobal();
+
+      expect(shellRunnerRunStub).to.have.been.calledOnceWith(
+        'npm',
+        ['list', '--global', '--depth=0'],
+        sinon.match.has('useShell', true),
+      );
+    });
+
+    it('should spawn npm without a shell on other platforms', async (): Promise<void> => {
+      sinon.stub(OperatingSystem, 'isWin32').returns(false);
+      shellRunnerRunStub.resolves([]);
+
+      await npmClient.listGlobal();
+
+      expect(shellRunnerRunStub).to.have.been.calledOnceWith(
+        'npm',
+        ['list', '--global', '--depth=0'],
+        sinon.match.has('useShell', false),
+      );
     });
 
     it('should return the lines from npm list output', async (): Promise<void> => {

--- a/test/unit/integration/npm/npm-client.test.ts
+++ b/test/unit/integration/npm/npm-client.test.ts
@@ -23,6 +23,7 @@ describe('NpmClient', (): void => {
 
   describe('listGlobal', (): void => {
     it('should call npm list with global and depth=0 flags', async (): Promise<void> => {
+      sinon.stub(OperatingSystem, 'isWin32').returns(false);
       shellRunnerRunStub.resolves([]);
 
       await npmClient.listGlobal();


### PR DESCRIPTION
## Description

Investigation of #5429 showed two distinct things behind that failed Windows run:

1. **What actually failed the job** was a transient network error on the runner: `read ECONNRESET` followed by `Resource not found: https://builds.hedera.com/node/software/v0.74/build-v0.74.0.sha384` while fetching the platform software (`SOLO-3035` in the job log). That artifact downloads fine in every other run, and the bisection branch under test (#5314) touches nothing related — it was a one-off CDN/network blip, not a code defect.

2. **What the issue's diagnostics latched onto** is a real, but non-fatal, Windows bug — and this PR fixes it. On Windows npm is `npm.cmd`, and Node refuses to spawn `.cmd` files without a shell (the CVE-2024-27980 hardening), so `NpmClient.listGlobal()` has thrown `spawn npm ENOENT` on **every** Windows invocation since #4804 converted exec calls to shell-less form. The `detectLocalSoloPackages` middleware swallows the error, so globally-linked-package detection has silently never worked on Windows, and every command writes `ERROR: Error executing: 'npm'` into solo.log (23 entries in the failed run) — exactly the noise that misled the automated CI diagnostics into naming npm as the root cause.

### The fix

`NpmClient.listGlobal()` now passes `useShell` on win32 only. The npm arguments are static literals, so no untrusted input reaches the shell. With the spawn working, linked-package detection functions on Windows and the misleading ERROR spam disappears from solo.log, which also keeps future auto-filed CI issues pointed at real failures.

### Testing

- New unit tests pin the platform behavior: shell spawn on win32, shell-less on other platforms; full unit suite passing, typecheck and lint clean.
- The `Windows Deploy and Destroy` check on this PR exercises the exact code path from the issue (`solo init` and one-shot on a Windows runner).

Fixes #5429
