### PR TITLE
ci: fix false cancellation in performance workflow

### DIFF
--- a/.github/workflows/flow-performance-test.yaml
+++ b/.github/workflows/flow-performance-test.yaml
@@ -202,22 +202,21 @@ jobs:
           }
           trap cleanup SIGTERM SIGINT
 
-          # API poller: polls the run's updated_at field every 30 s and sends
-          # SIGTERM to the main shell when GitHub marks the run as cancelled.
+          # API poller: polls the run status every 30 s and sends SIGTERM to
+          # the main shell only when GitHub marks the workflow run cancelled.
           # Self-hosted runners do not deliver SIGTERM to step scripts directly,
           # so this is the only reliable way to detect workflow cancellation.
           # GITHUB_TOKEN is passed explicitly via step env (self-hosted runners
           # do not auto-expose it as a shell variable).
-          _run_updated_at() {
+          _run_state() {
             local _api="${GITHUB_API_URL:-https://api.github.com}"
             curl -sf \
               -H "Authorization: token ${GITHUB_TOKEN}" \
               -H "Accept: application/vnd.github.v3+json" \
               "${_api}/repos/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
-              | jq -r '.updated_at // empty' 2>/dev/null || echo ""
+              | jq -r '[.status // "", .conclusion // ""] | @tsv' 2>/dev/null || echo ""
           }
-          RUN_UPDATED_AT_INITIAL="$(_run_updated_at)"
-          echo "Run updated_at baseline: ${RUN_UPDATED_AT_INITIAL}"
+          echo "Run state baseline: $(_run_state)"
 
           if command -v setsid >/dev/null 2>&1; then
             setsid task test-e2e-performance &
@@ -231,10 +230,9 @@ jobs:
           api_cancel_poller() {
             while true; do
               sleep 30
-              current="$(_run_updated_at)"
-              if [[ -n "${RUN_UPDATED_AT_INITIAL}" && -n "${current}" \
-                    && "${current}" != "${RUN_UPDATED_AT_INITIAL}" ]]; then
-                echo "=== API poller: updated_at changed, signalling main shell ==="
+              current="$(_run_state)"
+              if [[ "${current}" == $'completed\tcancelled' ]]; then
+                echo "=== API poller: run concluded as cancelled, signalling main shell ==="
                 kill -TERM $$ 2>/dev/null || true
                 return
               fi


### PR DESCRIPTION
## Description

This pull request changes the following:

* fixes the `flow-performance-test` cancellation poller so it only terminates the background performance task when the workflow run is actually cancelled
* replaces the false-positive `updated_at` comparison with a `status` and `conclusion` check against the Actions run API
* prevents sibling jobs in `Nightly Extended Tests` from causing the performance job to self-terminate with exit status `143`

### Related Issues

* Closes #5472
* Related to #5472

### Pull request (PR) checklist

* [ ] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [x] Any technical debt has been documented as a separate issue and linked to this PR
* [ ] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [ ] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [x] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* verified the July 29, 2026 failure against GitHub Actions run `30430094892` and job `90619025869`
* validated `.github/workflows/flow-performance-test.yaml` parses successfully with `ruby -e "require 'yaml'; YAML.load_file(...)"`

The following was not tested:

* a full rerun of `flow-performance-test` in GitHub Actions after the workflow change
