### PR TITLE
fix: wrap corrupt or missing PEM load failures in a typed key error

### DIFF
--- a/src/core/errors/classes/component/node-key-load-failed-solo-error.ts
+++ b/src/core/errors/classes/component/node-key-load-failed-solo-error.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {SoloError} from '../../solo-error.js';
+import {ErrorOwnership} from '../../error-ownership.js';
+import {ErrorCodeRegistry} from '../../error-code-registry.js';
+
+/**
+ * @description Thrown when solo cannot load a consensus node key or certificate from its PEM file; the underlying
+ * failure is wrapped in `cause` and the message names the offending file. solo reads the gossip and gRPC
+ * TLS PEM files back from disk before using them, so this means the file is missing, truncated, or not
+ * valid PEM content — regenerating the keys replaces the corrupt files.
+ */
+export class NodeKeyLoadFailedSoloError extends SoloError {
+  protected override readonly retryable: boolean = false;
+  protected override readonly ownership: ErrorOwnership = ErrorOwnership.User;
+
+  public constructor(keyName: string, nodeAlias: string, filePath: string, cause: Error) {
+    super(
+      {
+        message: `Failed to load ${keyName} key for node ${nodeAlias} from '${filePath}': ${cause.message}`,
+        code: ErrorCodeRegistry.NODE_KEY_LOAD_FAILED,
+        troubleshootingSteps:
+          `Verify the file exists and contains valid PEM content: ${filePath}\n` +
+          'Regenerate the node keys: solo keys consensus generate --deployment <name> --generate-gossip-keys --generate-tls-keys\n' +
+          'Check solo logs: tail -n 100 ~/.solo/logs/solo.log',
+      },
+      cause,
+    );
+  }
+}

--- a/src/core/errors/error-code-registry.ts
+++ b/src/core/errors/error-code-registry.ts
@@ -132,6 +132,7 @@ export const ErrorCodeRegistry: Record<string, string> = {
   BLOCK_NODE_JFR_COLLECTION_FAILED: 'SOLO-3090',
   GOSSIP_KEY_SECRET_RESTORE_FAILED: 'SOLO-3091',
   SDK_CLIENT_NO_HEALTHY_NODES: 'SOLO-3092',
+  NODE_KEY_LOAD_FAILED: 'SOLO-3093',
 
   // 4xxx - Validation: User input, flags, IDs, formatting
   MISSING_ARGUMENT: 'SOLO-4001',

--- a/src/core/errors/solo-errors.ts
+++ b/src/core/errors/solo-errors.ts
@@ -169,6 +169,7 @@ import {GossipKeySecretRestoreFailedSoloError} from './classes/component/gossip-
 import {TlsKeySecretCreationFailedSoloError} from './classes/component/tls-key-secret-creation-failed-solo-error.js';
 import {TlsKeyGenerationFailedSoloError} from './classes/component/tls-key-generation-failed-solo-error.js';
 import {SigningKeyGenerationFailedSoloError} from './classes/component/signing-key-generation-failed-solo-error.js';
+import {NodeKeyLoadFailedSoloError} from './classes/component/node-key-load-failed-solo-error.js';
 import {GrpcTlsKeyGenerationFailedSoloError} from './classes/component/grpc-tls-key-generation-failed-solo-error.js';
 import {GrpcTlsCertMismatchSoloError} from './classes/component/grpc-tls-cert-mismatch-solo-error.js';
 import {GrpcWebTlsCertMismatchSoloError} from './classes/component/grpc-web-tls-cert-mismatch-solo-error.js';
@@ -446,6 +447,7 @@ export class SoloErrors {
     readonly tlsKeySecretCreationFailed: typeof TlsKeySecretCreationFailedSoloError;
     readonly tlsKeyGenerationFailed: typeof TlsKeyGenerationFailedSoloError;
     readonly signingKeyGenerationFailed: typeof SigningKeyGenerationFailedSoloError;
+    readonly nodeKeyLoadFailed: typeof NodeKeyLoadFailedSoloError;
     readonly grpcTlsKeyGenerationFailed: typeof GrpcTlsKeyGenerationFailedSoloError;
     readonly grpcTlsCertMismatch: typeof GrpcTlsCertMismatchSoloError;
     readonly grpcWebTlsCertMismatch: typeof GrpcWebTlsCertMismatchSoloError;
@@ -537,6 +539,7 @@ export class SoloErrors {
     tlsKeySecretCreationFailed: TlsKeySecretCreationFailedSoloError,
     tlsKeyGenerationFailed: TlsKeyGenerationFailedSoloError,
     signingKeyGenerationFailed: SigningKeyGenerationFailedSoloError,
+    nodeKeyLoadFailed: NodeKeyLoadFailedSoloError,
     grpcTlsKeyGenerationFailed: GrpcTlsKeyGenerationFailedSoloError,
     grpcTlsCertMismatch: GrpcTlsCertMismatchSoloError,
     grpcWebTlsCertMismatch: GrpcWebTlsCertMismatchSoloError,

--- a/src/core/key-manager.ts
+++ b/src/core/key-manager.ts
@@ -248,20 +248,39 @@ export class KeyManager {
 
     this.logger.debug(`Loading ${keyName}-keys for node: ${nodeAlias}`, {nodeKeyFiles});
 
-    const keyBytes: Buffer = fs.readFileSync(nodeKeyFiles.privateKeyFile);
-    const keyPem: string = keyBytes.toString();
-    const key: CryptoKey = await this.convertPemToPrivateKey(keyPem, algo);
-
-    const certBytes: Buffer = fs.readFileSync(nodeKeyFiles.certificateFile);
-    const certPems: any = x509.PemConverter.decode(certBytes.toString());
-
-    const certs: x509.X509Certificate[] = [];
-    for (const certPem of certPems) {
-      const cert: x509.X509Certificate = new x509.X509Certificate(certPem);
-      certs.push(cert);
+    let key: CryptoKey;
+    try {
+      const keyBytes: Buffer = fs.readFileSync(nodeKeyFiles.privateKeyFile);
+      const keyPem: string = keyBytes.toString();
+      key = await this.convertPemToPrivateKey(keyPem, algo);
+    } catch (error) {
+      throw new SoloErrors.component.nodeKeyLoadFailed(keyName, nodeAlias, nodeKeyFiles.privateKeyFile, error as Error);
     }
 
-    const certChain: any = await new x509.X509ChainBuilder({certificates: certs.slice(1)}).build(certs[0]);
+    let certs: x509.X509Certificate[];
+    let certChain: any;
+    try {
+      const certBytes: Buffer = fs.readFileSync(nodeKeyFiles.certificateFile);
+      const certPems: any = x509.PemConverter.decode(certBytes.toString());
+      if (certPems.length === 0) {
+        throw new Error('no PEM certificate blocks found in file');
+      }
+
+      certs = [];
+      for (const certPem of certPems) {
+        const cert: x509.X509Certificate = new x509.X509Certificate(certPem);
+        certs.push(cert);
+      }
+
+      certChain = await new x509.X509ChainBuilder({certificates: certs.slice(1)}).build(certs[0]);
+    } catch (error) {
+      throw new SoloErrors.component.nodeKeyLoadFailed(
+        keyName,
+        nodeAlias,
+        nodeKeyFiles.certificateFile,
+        error as Error,
+      );
+    }
 
     this.logger.debug(`Loaded ${keyName}-key for node: ${nodeAlias}`, {
       nodeKeyFiles,

--- a/test/unit/core/key-manager.test.ts
+++ b/test/unit/core/key-manager.test.ts
@@ -17,6 +17,7 @@ import {type NodeKeyObject} from '../../../src/types/node-key-object.js';
 import {type PrivateKeyAndCertificateObject} from '../../../src/types/private-key-and-certificate-object.js';
 import {type K8Factory} from '../../../src/integration/kube/k8-factory.js';
 import {NamespaceName} from '../../../src/types/namespace/namespace-name.js';
+import {NodeKeyLoadFailedSoloError} from '../../../src/core/errors/classes/component/node-key-load-failed-solo-error.js';
 
 describe('KeyManager', (): void => {
   const keyManager: KeyManager = container.resolve(InjectTokens.KeyManager);
@@ -109,4 +110,82 @@ describe('KeyManager', (): void => {
 
     fs.rmSync(temporaryDirectory, {recursive: true});
   }).timeout(Duration.ofSeconds(20).toMillis());
+
+  describe('loadNodeKey with corrupt or missing PEM files', (): void => {
+    it('should report a typed error naming the private key file when the PEM is corrupt', async (): Promise<void> => {
+      const temporaryDirectory: string = fs.mkdtempSync(PathEx.join(os.tmpdir(), 'keys-'));
+      const nodeAlias: NodeAlias = 'node1';
+
+      const signingKey: NodeKeyObject = await keyManager.generateSigningKey(nodeAlias);
+      await keyManager.storeSigningKey(nodeAlias, signingKey, temporaryDirectory);
+
+      const nodeKeyFiles: PrivateKeyAndCertificateObject = keyManager.prepareNodeKeyFilePaths(
+        nodeAlias,
+        temporaryDirectory,
+      );
+      fs.writeFileSync(nodeKeyFiles.privateKeyFile, '-----BEGIN PRIVATE KEY-----\ntruncated');
+
+      try {
+        await keyManager.loadSigningKey(nodeAlias, temporaryDirectory);
+        expect.fail('expected loadSigningKey to reject');
+      } catch (error) {
+        expect(error).to.be.instanceOf(NodeKeyLoadFailedSoloError);
+        const soloError: NodeKeyLoadFailedSoloError = error as NodeKeyLoadFailedSoloError;
+        expect(soloError.getFormattedCode()).to.equal('SOLO-3093');
+        expect(soloError.message).to.include(nodeKeyFiles.privateKeyFile);
+        expect(soloError.getTroubleshootingSteps()?.join('\n')).to.include('solo keys consensus generate');
+      }
+
+      fs.rmSync(temporaryDirectory, {recursive: true});
+    }).timeout(Duration.ofSeconds(20).toMillis());
+
+    it('should report a typed error naming the certificate file when the PEM is corrupt', async (): Promise<void> => {
+      const temporaryDirectory: string = fs.mkdtempSync(PathEx.join(os.tmpdir(), 'keys-'));
+      const nodeAlias: NodeAlias = 'node1';
+
+      const signingKey: NodeKeyObject = await keyManager.generateSigningKey(nodeAlias);
+      await keyManager.storeSigningKey(nodeAlias, signingKey, temporaryDirectory);
+
+      const nodeKeyFiles: PrivateKeyAndCertificateObject = keyManager.prepareNodeKeyFilePaths(
+        nodeAlias,
+        temporaryDirectory,
+      );
+      fs.writeFileSync(nodeKeyFiles.certificateFile, 'not a pem certificate');
+
+      try {
+        await keyManager.loadSigningKey(nodeAlias, temporaryDirectory);
+        expect.fail('expected loadSigningKey to reject');
+      } catch (error) {
+        expect(error).to.be.instanceOf(NodeKeyLoadFailedSoloError);
+        const soloError: NodeKeyLoadFailedSoloError = error as NodeKeyLoadFailedSoloError;
+        expect(soloError.getFormattedCode()).to.equal('SOLO-3093');
+        expect(soloError.message).to.include(nodeKeyFiles.certificateFile);
+        expect(soloError.getTroubleshootingSteps()?.join('\n')).to.include('solo keys consensus generate');
+      }
+
+      fs.rmSync(temporaryDirectory, {recursive: true});
+    }).timeout(Duration.ofSeconds(20).toMillis());
+
+    it('should report a typed error naming the private key file when it is missing', async (): Promise<void> => {
+      const temporaryDirectory: string = fs.mkdtempSync(PathEx.join(os.tmpdir(), 'keys-'));
+      const nodeAlias: NodeAlias = 'node1';
+
+      const nodeKeyFiles: PrivateKeyAndCertificateObject = keyManager.prepareNodeKeyFilePaths(
+        nodeAlias,
+        temporaryDirectory,
+      );
+
+      try {
+        await keyManager.loadSigningKey(nodeAlias, temporaryDirectory);
+        expect.fail('expected loadSigningKey to reject');
+      } catch (error) {
+        expect(error).to.be.instanceOf(NodeKeyLoadFailedSoloError);
+        const soloError: NodeKeyLoadFailedSoloError = error as NodeKeyLoadFailedSoloError;
+        expect(soloError.getFormattedCode()).to.equal('SOLO-3093');
+        expect(soloError.message).to.include(nodeKeyFiles.privateKeyFile);
+      }
+
+      fs.rmSync(temporaryDirectory, {recursive: true});
+    });
+  });
 });


### PR DESCRIPTION
Fixes #5461

## Description

`KeyManager.loadNodeKey()` read the gossip and gRPC TLS PEM files with raw `fs.readFileSync` and parsed them with the WebCrypto/x509 APIs outside any try/catch, so a truncated, corrupt, or missing PEM surfaced as a raw `ENOENT` or ASN.1/crypto error with no Solo error code and no remediation.

## Changes

- New `NodeKeyLoadFailedSoloError` (`SOLO-3093`, ownership `user`, non-retryable) that names the key type, node alias, and the offending file, wraps the underlying failure as `cause`, and tells the user to regenerate keys with `solo keys consensus generate`.
- `loadNodeKey()` wraps the private-key read/parse and the certificate read/decode/chain-build in two try/catch blocks, each reporting the file that failed. An empty or fully-truncated certificate file (which `PemConverter.decode` silently turns into an empty list) now reports a clear "no PEM certificate blocks found in file" cause instead of an undefined-property crash.
- Unit tests covering a corrupt private key PEM, a corrupt certificate PEM, and a missing key file — each asserting the `SOLO-3093` code, the file name in the message, and the regeneration step in the troubleshooting output.

## Verification

Drove the built artifact through the real DI container and `ErrorHandler.handle()` (the `solo.ts` catch path) for four scenarios — truncated private key, corrupt certificate, missing key file, corrupt gRPC TLS key — plus an intact-PEM control. All failures render the `SOLO-3093` error box with the file path, the regeneration command, and the docs link; the control load still succeeds.

Example output:

```
╭─ ERROR ────────────────────────────────────────────────────────────────────╮
│ [SOLO-3093] Failed to load signing key for node node1 from                 │
│ '.../keys-FSCPkN/s-private-node1.pem': Failed to execute 'importKey'       │
│ on 'SubtleCrypto': 2nd argument is not instance of ArrayBuffer, ...        │
│   → Verify the file exists and contains valid PEM content: ...             │
│   → Regenerate the node keys: solo keys consensus generate ...             │
│   → Check solo logs: tail -n 100 ~/.solo/logs/solo.log                     │
│ Learn more: https://solo.hiero.org/docs/troubleshooting/errors/component/SOLO-3093/ │
╰────────────────────────────────────────────────────────────────────────────╯
```

Note: `loadNodeKey`/`loadSigningKey`/`loadTLSKey` currently have no production call sites (only unit tests exercise them), so no CLI command reaches this path today — the hardening protects the `KeyManager` API surface for when a caller is reintroduced.
