### PR TITLE
fix: throw a typed Solo error when a cached values file fails to parse

### DIFF
--- a/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
+++ b/src/commands/one-shot/orchestrator/deploy/default-one-shot-deploy-orchestrator.ts
@@ -76,6 +76,7 @@ import {ListrLock} from '../../../../core/lock/listr-lock.js';
 import {UserBreak} from '../../../../core/errors/user-break.js';
 import {ConfirmationRequiredSoloError} from '../../../../core/errors/classes/validation/confirmation-required-solo-error.js';
 import {ValuesFileNotFoundSoloError} from '../../../../core/errors/classes/validation/values-file-not-found-solo-error.js';
+import {ValuesFileParser} from '../../../../core/util/values-file-parser.js';
 import {Templates} from '../../../../core/templates.js';
 import {PathEx} from '../../../../business/utils/path-ex.js';
 import {SemanticVersion} from '../../../../business/utils/semantic-version.js';
@@ -93,7 +94,6 @@ import {ConfigMap} from '../../../../integration/kube/resources/config-map/confi
 import chalk from 'chalk';
 import fs from 'node:fs';
 import path from 'node:path';
-import yaml from 'yaml';
 import {DeployArgvBuilders} from './deploy-argv-builders.js';
 import {OrchestratorPipeline} from '../orchestrator-pipeline.js';
 import {SINGLE_DESTROY_COMMAND} from '../../one-shot-command-paths.js';
@@ -211,7 +211,8 @@ export class DefaultOneShotDeployOrchestrator implements OneShotDeployOrchestrat
                 throw new ValuesFileNotFoundSoloError(config.valuesFile);
               }
               const valuesFileContent: string = fs.readFileSync(context_.config.valuesFile, 'utf8');
-              const profileItems: Record<string, object> = yaml.parse(valuesFileContent) as Record<string, object>;
+              const profileItems: Record<string, object> =
+                (ValuesFileParser.parse(context_.config.valuesFile, valuesFileContent) as Record<string, object>) ?? {};
 
               if (profileItems.network) {
                 config.networkConfiguration = profileItems.network as object;

--- a/src/core/errors/classes/validation/values-file-parse-failed-solo-error.ts
+++ b/src/core/errors/classes/validation/values-file-parse-failed-solo-error.ts
@@ -1,0 +1,30 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {SoloError} from '../../solo-error.js';
+import {ErrorOwnership} from '../../error-ownership.js';
+import {ErrorCodeRegistry} from '../../error-code-registry.js';
+
+/**
+ * @description Thrown when a Helm values file cannot be parsed as YAML; the underlying failure is wrapped in `cause`.
+ * solo reads values files supplied via `--values-file` and values files it caches under the solo home directory before
+ * handing them to Helm, so this means the file content is not valid YAML — for example a stale or partially written
+ * cached values file left behind by an interrupted run.
+ */
+export class ValuesFileParseFailedSoloError extends SoloError {
+  protected override readonly retryable: boolean = false;
+  protected override readonly ownership: ErrorOwnership = ErrorOwnership.User;
+
+  public constructor(valuesFilePath: string, cause: Error) {
+    super(
+      {
+        message: `Failed to parse values file ${valuesFilePath}: ${cause.message}`,
+        code: ErrorCodeRegistry.VALUES_FILE_PARSE_FAILED,
+        troubleshootingSteps:
+          `Open ${valuesFilePath} and correct the YAML syntax reported above\n` +
+          `Regenerate a cached values file by deleting it and re-running the command: rm ${valuesFilePath}\n` +
+          'Cached values files live under the solo home directory (default ~/.solo) and are rewritten on the next run',
+      },
+      cause,
+    );
+  }
+}

--- a/src/core/errors/error-code-registry.ts
+++ b/src/core/errors/error-code-registry.ts
@@ -212,6 +212,7 @@ export const ErrorCodeRegistry: Record<string, string> = {
   FLAG_INPUT_FAILED: 'SOLO-4076',
   CONFIRMATION_REQUIRED: 'SOLO-4077',
   VALUES_FILE_NOT_FOUND: 'SOLO-4078',
+  VALUES_FILE_PARSE_FAILED: 'SOLO-4079',
 
   // 5xxx - System / Environment: kubectl, DNS, permissions, timeouts
   RESOURCE_NOT_FOUND: 'SOLO-5001',

--- a/src/core/errors/solo-errors.ts
+++ b/src/core/errors/solo-errors.ts
@@ -238,6 +238,7 @@ import {BackupNoLogFilesSoloError} from './classes/validation/backup-no-log-file
 import {FlagInputFailedSoloError} from './classes/validation/flag-input-failed-solo-error.js';
 import {ConfirmationRequiredSoloError} from './classes/validation/confirmation-required-solo-error.js';
 import {ValuesFileNotFoundSoloError} from './classes/validation/values-file-not-found-solo-error.js';
+import {ValuesFileParseFailedSoloError} from './classes/validation/values-file-parse-failed-solo-error.js';
 import {HelmRepoSetupFailedSoloError} from './classes/system/helm-repo-setup-failed-solo-error.js';
 import {HelmRepoCheckFailedSoloError} from './classes/system/helm-repo-check-failed-solo-error.js';
 import {HelmChartListFailedSoloError} from './classes/system/helm-chart-list-failed-solo-error.js';
@@ -639,6 +640,7 @@ export class SoloErrors {
     readonly flagInputFailed: typeof FlagInputFailedSoloError;
     readonly confirmationRequired: typeof ConfirmationRequiredSoloError;
     readonly valuesFileNotFound: typeof ValuesFileNotFoundSoloError;
+    readonly valuesFileParseFailed: typeof ValuesFileParseFailedSoloError;
   } = Object.freeze({
     blockNodeLocalImageNotFound: BlockNodeLocalImageNotFoundSoloError,
     blockNodeInvalidComponentId: BlockNodeInvalidComponentIdSoloError,
@@ -714,6 +716,7 @@ export class SoloErrors {
     flagInputFailed: FlagInputFailedSoloError,
     confirmationRequired: ConfirmationRequiredSoloError,
     valuesFileNotFound: ValuesFileNotFoundSoloError,
+    valuesFileParseFailed: ValuesFileParseFailedSoloError,
   });
 
   // 5xxx — System / Environment: kubectl, DNS, permissions, timeouts

--- a/src/core/helm-values-helper.ts
+++ b/src/core/helm-values-helper.ts
@@ -13,6 +13,7 @@ import {
   type PerNodeIdentity,
 } from '../types/helm-values.js';
 import yaml from 'yaml';
+import {ValuesFileParser} from './util/values-file-parser.js';
 
 type ExtractedExtraEnvironmentAnalysis = {
   environmentVariablesByNode: Record<NodeAlias, EnvironmentVariable[]>;
@@ -135,15 +136,12 @@ export class HelmValuesHelper {
     try {
       content = fs.readFileSync(filePath, 'utf8');
     } catch {
+      // best-effort: values files are optional inputs, so an absent or unreadable path simply contributes nothing.
+      // Content that is present but unparseable is a different matter and is reported by ValuesFileParser below.
       return undefined;
     }
 
-    let parsedValues: unknown;
-    try {
-      parsedValues = yaml.parse(content);
-    } catch {
-      return undefined;
-    }
+    const parsedValues: unknown = ValuesFileParser.parse(filePath, content);
 
     if (!parsedValues || typeof parsedValues !== 'object') {
       return undefined;

--- a/src/core/util/helm-scheduling-values.ts
+++ b/src/core/util/helm-scheduling-values.ts
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import * as fs from 'node:fs';
-import yaml from 'yaml';
+import {ValuesFileParser} from './values-file-parser.js';
 import {HelmChartValues, type HelmChartValue} from '../../integration/helm/model/values.js';
 import {type HelmSchedulingValueFallback} from './helm-scheduling-value-fallback.js';
 import {type HelmSchedulingValueMapping} from './helm-scheduling-value-mapping.js';
@@ -78,7 +78,9 @@ export class HelmSchedulingValues {
 
   private static readHelmValuesObjects(chartValues: HelmChartValues): HelmValuesObject[] {
     return HelmSchedulingValues.getValuesFilePaths(chartValues)
-      .map((valuesFilePath: string): unknown => yaml.parse(fs.readFileSync(valuesFilePath, 'utf8')))
+      .map((valuesFilePath: string): unknown =>
+        ValuesFileParser.parse(valuesFilePath, fs.readFileSync(valuesFilePath, 'utf8')),
+      )
       .filter((values: unknown): values is HelmValuesObject => HelmSchedulingValues.isHelmValuesObject(values));
   }
 

--- a/src/core/util/values-file-parser.ts
+++ b/src/core/util/values-file-parser.ts
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import yaml from 'yaml';
+import {ValuesFileParseFailedSoloError} from '../errors/classes/validation/values-file-parse-failed-solo-error.js';
+
+/**
+ * Single entry point for turning Helm values file content into an object graph.
+ *
+ * Every values file solo reads — user supplied via `--values-file` or cached under the solo home directory — must be
+ * parsed through here so that an unparseable file fails the command with a coded error naming the offending path
+ * instead of being silently ignored or handed to Helm as-is.
+ */
+export class ValuesFileParser {
+  /**
+   * Parses the content of a values file as YAML.
+   *
+   * @param valuesFilePath - path the content was read from; reported in the error so the user knows which file to fix
+   * @param content - raw file content
+   * @returns the parsed document, which is `null` for an empty file
+   * @throws ValuesFileParseFailedSoloError when the content is not valid YAML
+   */
+  public static parse(valuesFilePath: string, content: string): unknown {
+    try {
+      return yaml.parse(content);
+    } catch (error) {
+      throw new ValuesFileParseFailedSoloError(valuesFilePath, error as Error);
+    }
+  }
+}

--- a/test/unit/core/util/helm-scheduling-values.test.ts
+++ b/test/unit/core/util/helm-scheduling-values.test.ts
@@ -7,6 +7,7 @@ import {afterEach, beforeEach, describe, it} from 'mocha';
 import {PathEx} from '../../../../src/business/utils/path-ex.js';
 import {HelmSchedulingValues} from '../../../../src/core/util/helm-scheduling-values.js';
 import {HelmChartValues} from '../../../../src/integration/helm/model/values.js';
+import {ValuesFileParseFailedSoloError} from '../../../../src/core/errors/classes/validation/values-file-parse-failed-solo-error.js';
 
 describe('Helm scheduling values', (): void => {
   let temporaryDirectory: string;
@@ -91,5 +92,22 @@ tolerations:
     expect(valueArguments).to.include(String.raw`controller.nodeSelector.solo\.hashgraph\.io/role=consensus-node`);
     expect(valueArguments).to.include('controller.tolerations[0].key=solo.hashgraph.io/owner');
     expect(valueArguments).to.include('controller.tolerations[0].value=adhoc-performance-test');
+  });
+
+  it('should fail with a coded error naming the values file when it cannot be parsed', (): void => {
+    const valuesFilePath: string = PathEx.join(temporaryDirectory, 'stale-values.yaml');
+    fs.writeFileSync(valuesFilePath, 'nodeSelector:\n  solo.hashgraph.io/owner: "unterminated\n');
+    const sourceChartValues: HelmChartValues = new HelmChartValues().file(valuesFilePath);
+
+    let thrownError: ValuesFileParseFailedSoloError | undefined;
+    try {
+      HelmSchedulingValues.buildSchedulingChartValues(sourceChartValues, 'controller');
+    } catch (error) {
+      thrownError = error as ValuesFileParseFailedSoloError;
+    }
+
+    expect(thrownError).to.be.instanceof(ValuesFileParseFailedSoloError);
+    expect(thrownError.message).to.contain(valuesFilePath);
+    expect(thrownError.getFormattedCode()).to.equal('SOLO-4079');
   });
 });

--- a/test/unit/core/util/values-file-parser.test.ts
+++ b/test/unit/core/util/values-file-parser.test.ts
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {expect} from 'chai';
+import {describe, it} from 'mocha';
+import {ValuesFileParser} from '../../../../src/core/util/values-file-parser.js';
+import {ValuesFileParseFailedSoloError} from '../../../../src/core/errors/classes/validation/values-file-parse-failed-solo-error.js';
+import {SoloError} from '../../../../src/core/errors/solo-error.js';
+
+describe('Values file parser', (): void => {
+  const valuesFilePath: string = '/home/user/.solo/values-files/stale-values.yaml';
+
+  it('should parse a valid values file into an object', (): void => {
+    const parsed: unknown = ValuesFileParser.parse(
+      valuesFilePath,
+      'hedera:\n  nodes:\n    - name: node1\n      nodeId: 0\n',
+    );
+
+    expect(parsed).to.deep.equal({hedera: {nodes: [{name: 'node1', nodeId: 0}]}});
+  });
+
+  it('should return null for an empty values file', (): void => {
+    expect(ValuesFileParser.parse(valuesFilePath, '')).to.be.null;
+  });
+
+  it('should throw a typed Solo error naming the file when the values file is unparseable', (): void => {
+    let thrownError: ValuesFileParseFailedSoloError | undefined;
+
+    try {
+      ValuesFileParser.parse(valuesFilePath, 'hedera:\n  nodes:\n  - name: node1\n   nodeId: 0\n');
+    } catch (error) {
+      thrownError = error as ValuesFileParseFailedSoloError;
+    }
+
+    expect(thrownError).to.be.instanceof(ValuesFileParseFailedSoloError);
+    expect(thrownError).to.be.instanceof(SoloError);
+    expect(thrownError.message).to.contain(valuesFilePath);
+    expect(thrownError.getFormattedCode()).to.equal('SOLO-4079');
+    expect(thrownError.cause).to.be.instanceof(Error);
+  });
+
+  it('should tell the user how to regenerate the offending values file', (): void => {
+    let thrownError: ValuesFileParseFailedSoloError | undefined;
+
+    try {
+      ValuesFileParser.parse(valuesFilePath, '{not: valid');
+    } catch (error) {
+      thrownError = error as ValuesFileParseFailedSoloError;
+    }
+
+    const troubleshootingSteps: ReadonlyArray<string> = thrownError.getTroubleshootingSteps() ?? [];
+    expect(troubleshootingSteps.join('\n')).to.contain(`rm ${valuesFilePath}`);
+  });
+});


### PR DESCRIPTION
## Description

Values files were read from disk and handed to `yaml.parse()` with no guard, in three separate places. The consequences differed but all of them hid the real problem from the user:

* `DefaultOneShotDeployOrchestrator` read the `--values-file` content and called `yaml.parse()` directly. A stale or partially written file surfaced as a raw `YAMLParseError` from the `yaml` package with no indication of which file was at fault, and no Solo error code.
* `HelmSchedulingValues.readHelmValuesObjects()` parsed every `--values` file collected from the chart values in a `.map()`, again unguarded — the same raw `YAMLParseError`, thrown while assembling arguments that were about to go to Helm.
* `HelmValuesHelper.parseValuesFile()` wrapped the parse in `try { … } catch { return undefined; }`. This was the worst case: a corrupt values file was silently treated as empty, so its `extraEnv` entries and per-node identity/`blockNodesJson` values were quietly dropped and the deploy proceeded with partial values.

Changes:

* Added `ValuesFileParser` (`src/core/util/values-file-parser.ts`) — a single static `parse(valuesFilePath, content)` entry point that wraps `yaml.parse()` and converts a YAML failure into a typed Solo error. Each caller keeps its own file-read semantics; only the parse is centralised.
* Added `ValuesFileParseFailedSoloError` (`SOLO-4079`, validation range, `ErrorOwnership.User`, non-retryable). The message names the offending path and includes the underlying YAML error; the troubleshooting steps tell the user to fix the YAML or delete the file so it is regenerated on the next run (`rm <path>`), and note that cached values files live under the solo home directory.
* Registered the code in `error-code-registry.ts` and exposed it as `SoloErrors.validation.valuesFileParseFailed`, following the pattern established by `ValuesFileNotFoundSoloError` (#5401).
* Routed all three parse sites through `ValuesFileParser.parse()`. The swallowing `catch` in `HelmValuesHelper.parseValuesFile()` is gone; the remaining `catch` around `readFileSync` (an absent values file is a legitimate no-op) now carries the explanatory comment the style guide requires.
* Guarded the orchestrator against an empty values file: `yaml.parse('')` returns `null`, which previously produced a `TypeError` on the first `profileItems.network` read. It now falls back to `{}`.
* Removed the now-unused `yaml` import from `default-one-shot-deploy-orchestrator.ts`.

Not changed: `DefaultOneShotDeployOrchestrator.concatConfigFiles()` (the third line the issue cites) concatenates `settings.txt` and `application.properties`. Those are not YAML documents, so YAML parse validation does not apply to them.

### Related Issues

* Closes #5499

### Pull request (PR) checklist

- [x] This PR added tests (unit, integration, and/or end-to-end)
- [ ] This PR updated documentation
- [x] This PR added no TODOs or commented out code
- [ ] This PR has no breaking changes
- [ ] Any technical debt has been documented as a separate issue and linked to this PR
- [x] Any `package.json` changes have been explained to and approved by a repository manager
- [x] All related issues have been linked to this PR
- [x] All changes in this PR are included in the description
- [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

Note on "no breaking changes": there is no API change, but there is an intentional behaviour change. A values file that is present but unparseable now fails the command instead of being silently ignored (`HelmValuesHelper`) or throwing an untyped `YAMLParseError` (the other two sites). That is the point of the issue.

`package.json` was not modified — `yaml` is already a direct dependency and no new dependency was added.

### Testing

- [x] This PR added unit tests
- [ ] This PR added integration/end-to-end tests
- [ ] These changes required manual testing that is documented below
- [x] Anything not tested is documented

The following was run from the repository root (the `task` CLI was not available on the machine, so the underlying tools were invoked directly):

* `npx tsc --noEmit` — clean, no output, exit 0.
* `npx eslint` over all nine changed/added files — clean, no output, exit 0.
* `npx prettier --check` over the same nine files — "All matched files use Prettier code style!".
* `npx mocha 'test/unit/**/*.ts' --exclude 'test/unit/core/helm/**/*.ts'` — **1393 passing, 0 failing** (19s). No failures at all, so there is nothing to compare against an `origin/main` baseline and no pre-existing failure to report.
* Focused run of the two touched test files (`test/unit/core/util/values-file-parser.test.ts`, `test/unit/core/util/helm-scheduling-values.test.ts`) — 7 passing.

New unit tests:

* `test/unit/core/util/values-file-parser.test.ts` — a valid values file parses to the expected object; an empty file parses to `null`; malformed YAML throws `ValuesFileParseFailedSoloError` whose message contains the file path, whose `getFormattedCode()` is `SOLO-4079`, and which carries the original YAML error as `cause`; the troubleshooting steps contain `rm <path>`.
* `test/unit/core/util/helm-scheduling-values.test.ts` — a new case writes an unparseable values file to a temp directory, passes it through `HelmChartValues().file(...)`, and asserts `HelmSchedulingValues.buildSchedulingChartValues()` throws the coded error naming that file rather than returning values for Helm. This is the acceptance criterion end to end for that path.

The following was not tested:

* The one-shot deploy orchestrator call site is not covered by a new test. The parse happens inside an inline Listr task in `buildPipeline()`, and the existing `default-one-shot-deploy-orchestrator.test.ts` only exercises private helpers (`isKindContext`, `buildDeploymentStateSnapshot`, `hasExistingOneShotState`, …), never the config-building task; driving that task would require mocking the config manager, k8 factory, and the whole Listr context. The single line it now calls is directly unit-tested via `ValuesFileParser`.
* No e2e suites were run — they require a live Kind cluster.
* No manual CLI run against a real deployment.
