### PR TITLE
fix: preserve pod readiness failure diagnostics

### DIFF
--- a/src/integration/kube/errors/kube-pod-readiness-failed-error.ts
+++ b/src/integration/kube/errors/kube-pod-readiness-failed-error.ts
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+
+import {KubeError} from './kube-error.js';
+import {KubePodCreationFailedError} from './kube-pod-creation-failed-error.js';
+import {KubePodNotFoundError} from './kube-pod-not-found-error.js';
+
+export class KubePodReadinessFailedError extends KubeError {
+  public readonly namespace: string;
+  public readonly labels: string[];
+
+  public constructor(namespace: string, labels: string[], cause?: Error | unknown) {
+    const causeError: Error | undefined = cause instanceof Error ? cause : undefined;
+    const causeMessage: string = cause instanceof Error ? cause.message : String(cause ?? '');
+    const meta: Record<string, unknown> = {
+      namespace,
+      labels,
+    };
+
+    if (cause instanceof KubePodCreationFailedError) {
+      meta['podCreationFailure'] = cause.result;
+    }
+
+    if (cause instanceof KubePodNotFoundError) {
+      meta['resource'] = cause.resource;
+    }
+
+    super(
+      `Pod readiness check failed in namespace ${namespace} for labels [${labels.join(', ')}]${
+        causeMessage ? `: ${causeMessage}` : ''
+      }`,
+      causeError,
+      meta,
+    );
+    this.namespace = namespace;
+    this.labels = labels;
+  }
+}

--- a/src/integration/kube/k8-client/resources/pod/k8-client-pods.ts
+++ b/src/integration/kube/k8-client/resources/pod/k8-client-pods.ts
@@ -25,6 +25,7 @@ import {KubeError} from '../../../errors/kube-error.js';
 import {KubeMissingArgumentError} from '../../../errors/kube-missing-argument-error.js';
 import {KubePodNotFoundError} from '../../../errors/kube-pod-not-found-error.js';
 import {KubePodCreationFailedError} from '../../../errors/kube-pod-creation-failed-error.js';
+import {KubePodReadinessFailedError} from '../../../errors/kube-pod-readiness-failed-error.js';
 import {KubePodTerminationTimeoutError} from '../../../errors/kube-pod-termination-timeout-error.js';
 import * as constants from '../../../../../core/constants.js';
 import {type SoloLogger} from '../../../../../core/logging/solo-logger.js';
@@ -238,7 +239,10 @@ export class K8ClientPods extends K8ClientBase implements Pods {
     } catch (error: Error | unknown) {
       const errorMessage: string = error instanceof Error ? error.message : String(error);
       this.logger.showUser(`Pod readiness check failed: ${errorMessage}`);
-      throw new KubePodNotFoundError(`pods:${labels.join(',')}`);
+      // Wrap readiness failures in a dedicated error so CI reviewers can see the
+      // namespace/label selector that was being waited on while still preserving
+      // the underlying fatal pod cause for image-pull/startup debugging.
+      throw new KubePodReadinessFailedError(namespace.name, labels, error);
     }
   }
 

--- a/test/unit/integration/kube/detect-fatal-container-error.test.ts
+++ b/test/unit/integration/kube/detect-fatal-container-error.test.ts
@@ -292,9 +292,9 @@ describe('detectFatalContainerError', (): void => {
         expect((error as KubePodReadinessFailedError).message).to.include('test-namespace');
         expect((error as KubePodReadinessFailedError).message).to.include('app=test');
         expect((error as KubePodReadinessFailedError).cause).to.be.instanceOf(KubePodCreationFailedError);
-        expect(
-          ((error as KubePodReadinessFailedError).cause as KubePodCreationFailedError).result,
-        ).to.include('containerd socket error');
+        expect(((error as KubePodReadinessFailedError).cause as KubePodCreationFailedError).result).to.include(
+          'containerd socket error',
+        );
       }
       expect(listNamespacedPodStub).to.have.callCount(5);
     });

--- a/test/unit/integration/kube/detect-fatal-container-error.test.ts
+++ b/test/unit/integration/kube/detect-fatal-container-error.test.ts
@@ -4,6 +4,7 @@ import {expect} from 'chai';
 import {before, describe, it} from 'mocha';
 import sinon, {type SinonStub} from 'sinon';
 import {KubePodCreationFailedError} from '../../../../src/integration/kube/errors/kube-pod-creation-failed-error.js';
+import {KubePodReadinessFailedError} from '../../../../src/integration/kube/errors/kube-pod-readiness-failed-error.js';
 import {type Pod} from '../../../../src/integration/kube/resources/pod/pod.js';
 import {type ContainerStatus} from '../../../../src/integration/kube/resources/pod/container-status.js';
 import {K8ClientPods} from '../../../../src/integration/kube/k8-client/resources/pod/k8-client-pods.js';
@@ -270,6 +271,30 @@ describe('detectFatalContainerError', (): void => {
       } catch (error: Error | unknown) {
         expect(error).to.be.instanceOf(KubePodCreationFailedError);
         expect((error as KubePodCreationFailedError).result).to.include('containerd socket error');
+      }
+      expect(listNamespacedPodStub).to.have.callCount(5);
+    });
+
+    it('waitForReadyStatus wraps readiness context while preserving pod creation failures', async (): Promise<void> => {
+      const pod: RawPodFixture = buildRawPodWithContainerStatus(
+        buildWaitingRawContainerStatus('ImageInspectError', containerdSocketMessage),
+      );
+      pod.status.phase = 'Pending';
+
+      const listNamespacedPodStub: SinonStub = sinon.stub().resolves({items: [pod]});
+      const pods: K8ClientPods = new K8ClientPods({listNamespacedPod: listNamespacedPodStub} as never, {} as never, '');
+
+      try {
+        await pods.waitForReadyStatus(NamespaceName.of('test-namespace'), ['app=test'], 5, 0);
+        expect.fail('Expected waitForReadyStatus to reject');
+      } catch (error: Error | unknown) {
+        expect(error).to.be.instanceOf(KubePodReadinessFailedError);
+        expect((error as KubePodReadinessFailedError).message).to.include('test-namespace');
+        expect((error as KubePodReadinessFailedError).message).to.include('app=test');
+        expect((error as KubePodReadinessFailedError).cause).to.be.instanceOf(KubePodCreationFailedError);
+        expect(
+          ((error as KubePodReadinessFailedError).cause as KubePodCreationFailedError).result,
+        ).to.include('containerd socket error');
       }
       expect(listNamespacedPodStub).to.have.callCount(5);
     });


### PR DESCRIPTION
## Description

This pull request changes the following:

* adds a dedicated `KubePodReadinessFailedError` for pod readiness waits
* preserves the underlying fatal pod failure as the error cause instead of collapsing readiness failures into a generic not-found error
* adds focused unit coverage for the readiness failure propagation path

### Related Issues

* Related to intermittent one-shot Podman CI readiness failures #5540 

### Pull request (PR) checklist

* [x] This PR added tests (unit, integration, and/or end-to-end)
* [ ] This PR updated documentation
* [x] This PR added no TODOs or commented out code
* [x] This PR has no breaking changes
* [ ] Any technical debt has been documented as a separate issue and linked to this PR
* [ ] Any `package.json` changes have been explained to and approved by a repository manager
* [x] All related issues have been linked to this PR
* [x] All changes in this PR are included in the description
* [x] When this PR merges the commits will be squashed and the title will be used as the commit message, the 'commit message guidelines' below have been followed

### Testing

* [x] This PR added unit tests
* [ ] This PR added integration/end-to-end tests
* [ ] These changes required manual testing that is documented below
* [x] Anything not tested is documented

The following manual testing was done:

* None

The following was not tested:

* Full E2E / GitHub Actions rerun was not run locally
